### PR TITLE
feat: add test coverage reporting to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,11 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
 
-      - name: Run tests
-        run: go test ./... -v -count=1
+      - name: Run tests with coverage
+        run: go test ./... -v -count=1 -coverprofile=coverage.out -covermode=atomic
+
+      - name: Display coverage summary
+        run: go tool cover -func=coverage.out
 
       - name: Validate build
         run: go build -o /dev/null ./cmd/threedoors


### PR DESCRIPTION
## Summary

- Add `-coverprofile` and `-covermode=atomic` flags to the `go test` step in CI
- Add a coverage summary step (`go tool cover -func`) so coverage % is visible in CI logs

Follow-up to PR #8 (Story 1.7) which set up the CI pipeline but ran tests without coverage.

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Coverage summary appears in the "Display coverage summary" step output