### PR TITLE
fix: apply gofumpt formatting to detail_view_test.go

### DIFF
--- a/internal/tui/detail_view_test.go
+++ b/internal/tui/detail_view_test.go
@@ -183,7 +183,7 @@ func TestDetailView_FKey_FlashesNotImplemented(t *testing.T) {
 
 func TestDetailView_AllStatusKeys(t *testing.T) {
 	tests := []struct {
-		key         string
+		key           string
 		expectMsgType string
 	}{
 		{"c", "TaskCompletedMsg"},


### PR DESCRIPTION
## Summary
- Fix struct field alignment in `internal/tui/detail_view_test.go` to pass CI gofumpt check
- Single whitespace change: `key` field padding in `TestDetailView_AllStatusKeys` test struct

## Test plan
- [x] `gofumpt -d` shows no remaining diff
- [x] `go test ./internal/tui/` passes