### PR TITLE
feat: create GitHub Release with binaries on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   quality-gate:
@@ -71,3 +71,27 @@ jobs:
           name: threedoors-binaries-${{ github.sha }}
           path: threedoors-*
           retention-days: 14
+
+      - name: Generate release tag
+        id: tag
+        run: echo "tag=alpha-$(date -u +%Y%m%d)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: Alpha ${{ steps.tag.outputs.tag }}
+          body: |
+            Automated alpha release from merge to main.
+
+            **Commit:** ${{ github.sha }}
+
+            **Binaries:**
+            - `threedoors-darwin-arm64` — macOS Apple Silicon
+            - `threedoors-darwin-amd64` — macOS Intel
+            - `threedoors-linux-amd64` — Linux x86_64
+          prerelease: true
+          files: |
+            threedoors-darwin-arm64
+            threedoors-darwin-amd64
+            threedoors-linux-amd64


### PR DESCRIPTION
## Summary
- Extends the existing `alpha-release` CI job to create a **prerelease GitHub Release** with compiled Go binaries attached on every merge to main
- Binaries: `darwin/arm64`, `darwin/amd64`, `linux/amd64`
- Tags use auto-generated `alpha-YYYYMMDD-SHORTSHA` format
- Bumps workflow permissions from `contents: read` to `contents: write` to allow release creation
- Existing artifact upload is preserved for backward compatibility

## Changes
- `.github/workflows/ci.yml`: Added "Generate release tag" and "Create GitHub Release" steps using `softprops/action-gh-release@v2`; updated permissions

## Notes
- Future opportunity: add `linux/arm64` and `windows/amd64` targets
- Future opportunity: embed version info via `-ldflags` at build time

## Test plan
- [ ] PR CI quality-gate passes (lint, vet, test, build)
- [ ] On merge, alpha-release job creates a GitHub Release with 3 binary assets