### PR TITLE
feat: Story 3.3 - Values & Goals Setup and Display

### DIFF
--- a/docs/stories/3.3.story.md
+++ b/docs/stories/3.3.story.md
@@ -1,0 +1,117 @@
+<!--
+title: "3.3: Values & Goals Setup and Display"
+status: "In Progress"
+-->
+
+# Story 3.3: Values & Goals Setup and Display
+
+**As a** user,
+**I want** to define and see my values and goals during task sessions,
+**so that** I stay aligned with what matters most.
+
+## Acceptance Criteria
+
+1. **Initial Setup Flow**: When the user has no values/goals configured and types `:goals` in the command palette, a setup flow guides them through entering 1-5 values or goals. Values are persisted to `~/.threedoors/config.yaml`.
+
+2. **Persistent Display**: When the user has values/goals configured, values/goals appear as a subtle footer (not intrusive). They remain visible across door selection, detail view, and search views.
+
+3. **Edit Functionality**: When the user types `:goals edit` in the command palette, the existing values are displayed for editing (add, remove, reorder).
+
+## NOT In Scope
+
+* No automatic goal-task linking or categorization
+* No goal progress tracking or metrics
+* No goal completion workflows
+* No import/export of values/goals
+
+## Definition of Done
+
+* All acceptance criteria implemented
+* `make build` succeeds with zero errors
+* `make test` passes with zero failures
+* `gofumpt -d .` produces no output (code is formatted)
+* `golangci-lint run ./...` passes with zero warnings
+* Unit tests cover config persistence and view logic
+
+### Dev Notes
+
+This story adds a new persistent display element and a new config file. Follow existing patterns from `provider_config.go` for YAML persistence and `add_task_view.go` for multi-step input flows.
+
+**Critical coding standards to follow:**
+* Errors must be wrapped with context using `%w` verb
+* No panics in user-facing code — `Update()` and `View()` must never panic
+* Do not use `fmt.Println` for TUI output — all rendering through `View()` only
+* Follow gofumpt formatting standards
+
+### Parent Epic
+
+* Parent Epic: Epic 3: Enhanced Task Capture & Interaction
+
+### Architecture & Design
+
+**Storage:**
+* Config file: `~/.threedoors/config.yaml`
+* Uses `GetConfigDirPath()` from `file_manager.go`
+* Atomic write pattern (temp file + rename) for persistence
+
+**Data Model:**
+```go
+type ValuesConfig struct {
+    Values []string `yaml:"values"`
+}
+```
+
+**New View Mode:** `ViewValuesGoals` for setup/edit flow
+
+**Command Palette Integration:**
+* `:goals` → Opens setup flow (if no values) or shows current values
+* `:goals edit` → Opens edit flow for existing values
+
+**Persistent Display:**
+* Render as subtle footer on doors, detail, and search views
+* Use muted styling (grey/dim) to avoid being intrusive
+* Show values separated by centered dot or similar delimiter
+
+### Key Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `internal/tasks/values_config.go` | Created - config persistence |
+| `internal/tasks/values_config_test.go` | Created - config tests |
+| `internal/tui/values_view.go` | Created - setup/edit view |
+| `internal/tui/values_view_test.go` | Created - view tests |
+| `internal/tui/main_model.go` | Modified - add ViewValuesGoals, wire config |
+| `internal/tui/search_view.go` | Modified - add :goals command handling |
+| `internal/tui/doors_view.go` | Modified - render values footer |
+| `internal/tui/detail_view.go` | Modified - render values footer |
+| `internal/tui/styles.go` | Modified - add values footer styling |
+
+### Testing
+
+* Unit tests for `ValuesConfig` load/save/validation
+* Unit tests for values view setup flow
+* Unit tests for values view edit flow
+* Unit tests for command parsing (`:goals`, `:goals edit`)
+* Integration test for persistent display rendering
+
+## Tasks / Subtasks
+
+- [ ] Create `ValuesConfig` struct and persistence in `internal/tasks/values_config.go`
+- [ ] Create unit tests for values config in `internal/tasks/values_config_test.go`
+- [ ] Add `ViewValuesGoals` view mode to `main_model.go`
+- [ ] Create values setup/edit view in `internal/tui/values_view.go`
+- [ ] Add `:goals` and `:goals edit` command handling in `search_view.go`
+- [ ] Add values footer styling to `styles.go`
+- [ ] Render values footer in `doors_view.go`
+- [ ] Render values footer in `detail_view.go`
+- [ ] Render values footer in search view
+- [ ] Create view tests in `internal/tui/values_view_test.go`
+- [ ] Run `make test`, `make fmt`, `make lint` to verify
+
+## Dev Agent Record
+
+*(To be filled during implementation)*
+
+## QA Results
+
+*(To be filled during QA review)*

--- a/internal/tasks/values_config.go
+++ b/internal/tasks/values_config.go
@@ -1,0 +1,134 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	valuesConfigFile = "config.yaml"
+	maxValues        = 5
+	maxValueLength   = 200
+)
+
+// ValuesConfig holds user-defined values and goals.
+type ValuesConfig struct {
+	Values []string `yaml:"values"`
+}
+
+// LoadValuesConfig reads values configuration from a YAML file.
+// Returns an empty config if the file does not exist.
+func LoadValuesConfig(path string) (*ValuesConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &ValuesConfig{}, nil
+		}
+		return nil, fmt.Errorf("failed to read values config: %w", err)
+	}
+
+	if len(data) == 0 {
+		return &ValuesConfig{}, nil
+	}
+
+	cfg := &ValuesConfig{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse values config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// SaveValuesConfig persists values configuration to a YAML file using atomic write.
+func SaveValuesConfig(path string, cfg *ValuesConfig) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal values config: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to sync temp file: %w", err)
+	}
+	_ = f.Close()
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+	return nil
+}
+
+// GetValuesConfigPath returns the path to config.yaml.
+func GetValuesConfigPath() (string, error) {
+	configPath, err := GetConfigDirPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configPath, valuesConfigFile), nil
+}
+
+// HasValues returns true if the config has at least one value.
+func (vc *ValuesConfig) HasValues() bool {
+	return len(vc.Values) > 0
+}
+
+// AddValue appends a value if under the limit.
+func (vc *ValuesConfig) AddValue(value string) error {
+	if len(vc.Values) >= maxValues {
+		return fmt.Errorf("cannot add more than %d values", maxValues)
+	}
+	if len(value) > maxValueLength {
+		return fmt.Errorf("value exceeds maximum length of %d characters", maxValueLength)
+	}
+	if value == "" {
+		return errors.New("value cannot be empty")
+	}
+	vc.Values = append(vc.Values, value)
+	return nil
+}
+
+// RemoveValue removes a value by index.
+func (vc *ValuesConfig) RemoveValue(index int) error {
+	if index < 0 || index >= len(vc.Values) {
+		return fmt.Errorf("index %d out of range", index)
+	}
+	vc.Values = append(vc.Values[:index], vc.Values[index+1:]...)
+	return nil
+}
+
+// MoveUp moves a value up by one position.
+func (vc *ValuesConfig) MoveUp(index int) error {
+	if index <= 0 || index >= len(vc.Values) {
+		return fmt.Errorf("cannot move index %d up", index)
+	}
+	vc.Values[index], vc.Values[index-1] = vc.Values[index-1], vc.Values[index]
+	return nil
+}
+
+// MoveDown moves a value down by one position.
+func (vc *ValuesConfig) MoveDown(index int) error {
+	if index < 0 || index >= len(vc.Values)-1 {
+		return fmt.Errorf("cannot move index %d down", index)
+	}
+	vc.Values[index], vc.Values[index+1] = vc.Values[index+1], vc.Values[index]
+	return nil
+}

--- a/internal/tasks/values_config_test.go
+++ b/internal/tasks/values_config_test.go
@@ -1,0 +1,185 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadValuesConfig_FileNotFound(t *testing.T) {
+	cfg, err := LoadValuesConfig("/nonexistent/path/config.yaml")
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got: %v", err)
+	}
+	if cfg.HasValues() {
+		t.Error("expected empty values for missing file")
+	}
+}
+
+func TestLoadValuesConfig_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadValuesConfig(path)
+	if err != nil {
+		t.Fatalf("expected no error for empty file, got: %v", err)
+	}
+	if cfg.HasValues() {
+		t.Error("expected empty values for empty file")
+	}
+}
+
+func TestLoadValuesConfig_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "values:\n  - Health\n  - Family\n  - Growth\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadValuesConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Values) != 3 {
+		t.Fatalf("expected 3 values, got %d", len(cfg.Values))
+	}
+	if cfg.Values[0] != "Health" {
+		t.Errorf("expected first value 'Health', got '%s'", cfg.Values[0])
+	}
+}
+
+func TestLoadValuesConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("{{invalid yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadValuesConfig(path)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestSaveValuesConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg := &ValuesConfig{Values: []string{"Health", "Family"}}
+	if err := SaveValuesConfig(path, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	loaded, err := LoadValuesConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error loading: %v", err)
+	}
+	if len(loaded.Values) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(loaded.Values))
+	}
+	if loaded.Values[0] != "Health" || loaded.Values[1] != "Family" {
+		t.Errorf("values mismatch: %v", loaded.Values)
+	}
+}
+
+func TestValuesConfig_HasValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		values   []string
+		expected bool
+	}{
+		{"empty", nil, false},
+		{"with values", []string{"Health"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ValuesConfig{Values: tt.values}
+			if cfg.HasValues() != tt.expected {
+				t.Errorf("HasValues() = %v, want %v", cfg.HasValues(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestValuesConfig_AddValue(t *testing.T) {
+	cfg := &ValuesConfig{}
+
+	if err := cfg.AddValue("Health"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Values) != 1 {
+		t.Fatalf("expected 1 value, got %d", len(cfg.Values))
+	}
+
+	// Test empty value
+	if err := cfg.AddValue(""); err == nil {
+		t.Error("expected error for empty value")
+	}
+
+	// Fill to max
+	for i := len(cfg.Values); i < maxValues; i++ {
+		if err := cfg.AddValue("Value"); err != nil {
+			t.Fatalf("unexpected error adding value %d: %v", i, err)
+		}
+	}
+
+	// Test max exceeded
+	if err := cfg.AddValue("One too many"); err == nil {
+		t.Error("expected error when exceeding max values")
+	}
+}
+
+func TestValuesConfig_RemoveValue(t *testing.T) {
+	cfg := &ValuesConfig{Values: []string{"A", "B", "C"}}
+
+	if err := cfg.RemoveValue(1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Values) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(cfg.Values))
+	}
+	if cfg.Values[0] != "A" || cfg.Values[1] != "C" {
+		t.Errorf("unexpected values: %v", cfg.Values)
+	}
+
+	// Out of range
+	if err := cfg.RemoveValue(5); err == nil {
+		t.Error("expected error for out of range index")
+	}
+}
+
+func TestValuesConfig_MoveUp(t *testing.T) {
+	cfg := &ValuesConfig{Values: []string{"A", "B", "C"}}
+
+	if err := cfg.MoveUp(1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Values[0] != "B" || cfg.Values[1] != "A" {
+		t.Errorf("unexpected order: %v", cfg.Values)
+	}
+
+	// Cannot move first element up
+	if err := cfg.MoveUp(0); err == nil {
+		t.Error("expected error for moving first element up")
+	}
+}
+
+func TestValuesConfig_MoveDown(t *testing.T) {
+	cfg := &ValuesConfig{Values: []string{"A", "B", "C"}}
+
+	if err := cfg.MoveDown(0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Values[0] != "B" || cfg.Values[1] != "A" {
+		t.Errorf("unexpected order: %v", cfg.Values)
+	}
+
+	// Cannot move last element down
+	if err := cfg.MoveDown(2); err == nil {
+		t.Error("expected error for moving last element down")
+	}
+}

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -19,6 +19,7 @@ const (
 	ViewSearch
 	ViewHealth
 	ViewAddTask
+	ViewValuesGoals
 )
 
 // MainModel is the root Bubbletea model that orchestrates view transitions.
@@ -31,10 +32,12 @@ type MainModel struct {
 	searchView          *SearchView
 	healthView          *HealthView
 	addTaskView         *AddTaskView
+	valuesView          *ValuesView
 	pool                *tasks.TaskPool
 	tracker             *tasks.SessionTracker
 	provider            tasks.TaskProvider
 	healthChecker       *tasks.HealthChecker
+	valuesConfig        *tasks.ValuesConfig
 	flash               string
 	width               int
 	height              int
@@ -44,6 +47,17 @@ type MainModel struct {
 
 // NewMainModel creates the root application model.
 func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider tasks.TaskProvider, hc *tasks.HealthChecker) *MainModel {
+	// Load values config
+	var valuesConfig *tasks.ValuesConfig
+	if path, err := tasks.GetValuesConfigPath(); err == nil {
+		if cfg, err := tasks.LoadValuesConfig(path); err == nil {
+			valuesConfig = cfg
+		}
+	}
+	if valuesConfig == nil {
+		valuesConfig = &tasks.ValuesConfig{}
+	}
+
 	return &MainModel{
 		viewMode:      ViewDoors,
 		doorsView:     NewDoorsView(pool, tracker),
@@ -51,6 +65,7 @@ func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider 
 		tracker:       tracker,
 		provider:      provider,
 		healthChecker: hc,
+		valuesConfig:  valuesConfig,
 	}
 }
 
@@ -80,6 +95,9 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.addTaskView != nil {
 			m.addTaskView.SetWidth(msg.Width)
+		}
+		if m.valuesView != nil {
+			m.valuesView.SetWidth(msg.Width)
 		}
 		return m, nil
 
@@ -217,6 +235,33 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.viewMode = ViewMood
 		return m, nil
 
+	case ShowValuesSetupMsg:
+		m.valuesView = NewValuesSetupView(m.valuesConfig)
+		m.valuesView.SetWidth(m.width)
+		m.previousView = m.viewMode
+		m.viewMode = ViewValuesGoals
+		return m, nil
+
+	case ShowValuesEditMsg:
+		m.valuesView = NewValuesEditView(m.valuesConfig)
+		m.valuesView.SetWidth(m.width)
+		m.previousView = m.viewMode
+		m.viewMode = ViewValuesGoals
+		return m, nil
+
+	case ValuesSavedMsg:
+		m.valuesConfig = msg.Config
+		if path, err := tasks.GetValuesConfigPath(); err == nil {
+			if saveErr := tasks.SaveValuesConfig(path, msg.Config); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to save values config: %v\n", saveErr)
+			}
+		}
+		m.valuesView = nil
+		m.flash = "Values saved"
+		m.viewMode = ViewDoors
+		m.doorsView.RefreshDoors()
+		return m, ClearFlashCmd()
+
 	case FlashMsg:
 		m.flash = msg.Text
 		return m, ClearFlashCmd()
@@ -236,6 +281,8 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateHealth(msg)
 	case ViewAddTask:
 		return m.updateAddTask(msg)
+	case ViewValuesGoals:
+		return m.updateValues(msg)
 	}
 
 	return m, nil
@@ -329,6 +376,14 @@ func (m *MainModel) updateAddTask(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *MainModel) updateValues(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.valuesView == nil {
+		return m, nil
+	}
+	cmd := m.valuesView.Update(msg)
+	return m, cmd
+}
+
 func (m *MainModel) saveTasks() error {
 	allTasks := m.pool.GetAllTasks()
 	return m.provider.SaveTasks(allTasks)
@@ -337,11 +392,14 @@ func (m *MainModel) saveTasks() error {
 // View implements tea.Model.
 func (m *MainModel) View() string {
 	var view string
+	showValuesFooter := false
+
 	switch m.viewMode {
 	case ViewDetail:
 		if m.detailView != nil {
 			view = m.detailView.View()
 		}
+		showValuesFooter = true
 	case ViewMood:
 		if m.moodView != nil {
 			view = m.moodView.View()
@@ -350,6 +408,7 @@ func (m *MainModel) View() string {
 		if m.searchView != nil {
 			view = m.searchView.View()
 		}
+		showValuesFooter = true
 	case ViewHealth:
 		if m.healthView != nil {
 			view = m.healthView.View()
@@ -358,12 +417,21 @@ func (m *MainModel) View() string {
 		if m.addTaskView != nil {
 			view = m.addTaskView.View()
 		}
+	case ViewValuesGoals:
+		if m.valuesView != nil {
+			view = m.valuesView.View()
+		}
 	default:
 		view = m.doorsView.View()
+		showValuesFooter = true
 	}
 
 	if m.flash != "" {
 		view += "\n" + flashStyle.Render(m.flash)
+	}
+
+	if showValuesFooter {
+		view += RenderValuesFooter(m.valuesConfig)
 	}
 
 	return view

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -64,6 +64,17 @@ type AddTaskWithContextPromptMsg struct {
 	PrefilledText string
 }
 
+// ValuesSavedMsg is sent when values/goals have been saved.
+type ValuesSavedMsg struct {
+	Config *tasks.ValuesConfig
+}
+
+// ShowValuesSetupMsg is sent to open the values setup flow.
+type ShowValuesSetupMsg struct{}
+
+// ShowValuesEditMsg is sent to open the values edit flow.
+type ShowValuesEditMsg struct{}
+
 // ReturnToSearchMsg is sent to restore search view from detail view.
 type ReturnToSearchMsg struct {
 	Query         string

--- a/internal/tui/search_view.go
+++ b/internal/tui/search_view.go
@@ -148,9 +148,15 @@ func (sv *SearchView) executeCommand() tea.Cmd {
 	case "health":
 		return sv.runHealthCheck()
 
+	case "goals":
+		if args == "edit" {
+			return func() tea.Msg { return ShowValuesEditMsg{} }
+		}
+		return func() tea.Msg { return ShowValuesSetupMsg{} }
+
 	case "help":
 		return func() tea.Msg {
-			return FlashMsg{Text: "Commands: :add <text>, :add-ctx, :add --why, :mood [mood], :stats, :health, :help, :quit | Keys: / search, a/w/d select, s re-roll, Enter open, m mood, q quit"}
+			return FlashMsg{Text: "Commands: :add <text>, :add-ctx, :add --why, :goals [edit], :mood [mood], :stats, :health, :help, :quit | Keys: / search, a/w/d select, s re-roll, Enter open, m mood, q quit"}
 		}
 
 	case "quit", "exit":

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -121,6 +121,19 @@ var (
 
 	healthSuggestionStyle = lipgloss.NewStyle().
 				Foreground(colorInProgress)
+
+	// Values/goals styles
+	valuesFooterStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("243")).
+				Italic(true)
+
+	valuesHeaderStyle = lipgloss.NewStyle().
+				Foreground(colorAccent).
+				Bold(true)
+
+	valuesFooterSeparator = "  ·  "
+
+	valuesSelectedPrefix = "▸ "
 )
 
 // StatusColor returns the lipgloss color for a given status string.

--- a/internal/tui/values_view.go
+++ b/internal/tui/values_view.go
@@ -1,0 +1,262 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ValuesViewMode tracks whether we are in setup or edit mode.
+type ValuesViewMode int
+
+const (
+	ValuesSetupMode ValuesViewMode = iota
+	ValuesEditMode
+)
+
+// ValuesView handles the values/goals setup and editing flow.
+type ValuesView struct {
+	mode          ValuesViewMode
+	config        *tasks.ValuesConfig
+	textInput     textinput.Model
+	selectedIndex int
+	width         int
+}
+
+// NewValuesSetupView creates a values view in setup mode.
+func NewValuesSetupView(cfg *tasks.ValuesConfig) *ValuesView {
+	ti := textinput.New()
+	ti.Placeholder = "Enter a value or goal (1-5 total)..."
+	ti.Focus()
+	ti.CharLimit = 200
+	ti.Width = 40
+
+	return &ValuesView{
+		mode:      ValuesSetupMode,
+		config:    cfg,
+		textInput: ti,
+	}
+}
+
+// NewValuesEditView creates a values view in edit mode.
+func NewValuesEditView(cfg *tasks.ValuesConfig) *ValuesView {
+	ti := textinput.New()
+	ti.Placeholder = "Enter new value..."
+	ti.CharLimit = 200
+	ti.Width = 40
+
+	return &ValuesView{
+		mode:      ValuesEditMode,
+		config:    cfg,
+		textInput: ti,
+	}
+}
+
+// SetWidth sets the terminal width for rendering.
+func (vv *ValuesView) SetWidth(w int) {
+	vv.width = w
+	if w > 4 {
+		vv.textInput.Width = w - 4
+	}
+}
+
+// Update handles messages for the values view.
+func (vv *ValuesView) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if vv.mode == ValuesSetupMode {
+			return vv.updateSetup(msg)
+		}
+		return vv.updateEdit(msg)
+	}
+
+	var cmd tea.Cmd
+	vv.textInput, cmd = vv.textInput.Update(msg)
+	return cmd
+}
+
+func (vv *ValuesView) updateSetup(msg tea.KeyMsg) tea.Cmd {
+	switch msg.Type {
+	case tea.KeyEscape:
+		if vv.config.HasValues() {
+			return vv.saveAndReturn()
+		}
+		return func() tea.Msg { return ReturnToDoorsMsg{} }
+
+	case tea.KeyEnter:
+		text := strings.TrimSpace(vv.textInput.Value())
+		if text == "" {
+			if vv.config.HasValues() {
+				return vv.saveAndReturn()
+			}
+			return nil
+		}
+		if err := vv.config.AddValue(text); err != nil {
+			return func() tea.Msg { return FlashMsg{Text: err.Error()} }
+		}
+		vv.textInput.SetValue("")
+		if len(vv.config.Values) >= 5 {
+			return vv.saveAndReturn()
+		}
+		return nil
+	}
+
+	var cmd tea.Cmd
+	vv.textInput, cmd = vv.textInput.Update(msg)
+	return cmd
+}
+
+func (vv *ValuesView) updateEdit(msg tea.KeyMsg) tea.Cmd {
+	if vv.textInput.Focused() {
+		return vv.updateEditInput(msg)
+	}
+
+	switch msg.String() {
+	case "esc", "q":
+		return vv.saveAndReturn()
+	case "up", "k":
+		if vv.selectedIndex > 0 {
+			vv.selectedIndex--
+		}
+	case "down", "j":
+		if vv.selectedIndex < len(vv.config.Values)-1 {
+			vv.selectedIndex++
+		}
+	case "d", "backspace":
+		if len(vv.config.Values) > 0 {
+			_ = vv.config.RemoveValue(vv.selectedIndex)
+			if vv.selectedIndex >= len(vv.config.Values) && vv.selectedIndex > 0 {
+				vv.selectedIndex--
+			}
+		}
+	case "K":
+		if len(vv.config.Values) > 0 {
+			_ = vv.config.MoveUp(vv.selectedIndex)
+			if vv.selectedIndex > 0 {
+				vv.selectedIndex--
+			}
+		}
+	case "J":
+		if len(vv.config.Values) > 0 {
+			_ = vv.config.MoveDown(vv.selectedIndex)
+			if vv.selectedIndex < len(vv.config.Values)-1 {
+				vv.selectedIndex++
+			}
+		}
+	case "a":
+		if len(vv.config.Values) < 5 {
+			vv.textInput.Focus()
+			vv.textInput.SetValue("")
+		}
+	}
+	return nil
+}
+
+func (vv *ValuesView) updateEditInput(msg tea.KeyMsg) tea.Cmd {
+	switch msg.Type {
+	case tea.KeyEscape:
+		vv.textInput.Blur()
+		return nil
+	case tea.KeyEnter:
+		text := strings.TrimSpace(vv.textInput.Value())
+		if text != "" {
+			if err := vv.config.AddValue(text); err != nil {
+				return func() tea.Msg { return FlashMsg{Text: err.Error()} }
+			}
+		}
+		vv.textInput.Blur()
+		vv.textInput.SetValue("")
+		return nil
+	}
+
+	var cmd tea.Cmd
+	vv.textInput, cmd = vv.textInput.Update(msg)
+	return cmd
+}
+
+func (vv *ValuesView) saveAndReturn() tea.Cmd {
+	cfg := vv.config
+	return func() tea.Msg {
+		return ValuesSavedMsg{Config: cfg}
+	}
+}
+
+// View renders the values view.
+func (vv *ValuesView) View() string {
+	s := strings.Builder{}
+
+	if vv.mode == ValuesSetupMode {
+		s.WriteString(headerStyle.Render("ThreeDoors - Values & Goals Setup"))
+		s.WriteString("\n\n")
+		s.WriteString(helpStyle.Render("Define what matters most to you (1-5 values/goals)."))
+		s.WriteString("\n")
+		s.WriteString(helpStyle.Render("These will appear during your task sessions as a reminder."))
+		s.WriteString("\n\n")
+
+		if len(vv.config.Values) > 0 {
+			s.WriteString(valuesHeaderStyle.Render("Your values:"))
+			s.WriteString("\n")
+			for i, v := range vv.config.Values {
+				fmt.Fprintf(&s, "  %d. %s\n", i+1, v)
+			}
+			s.WriteString("\n")
+		}
+
+		s.WriteString(vv.textInput.View())
+		s.WriteString("\n\n")
+
+		count := len(vv.config.Values)
+		remaining := 5 - count
+		if count == 0 {
+			s.WriteString(helpStyle.Render("Enter your first value/goal and press Enter"))
+		} else if remaining > 0 {
+			s.WriteString(helpStyle.Render(fmt.Sprintf("Enter to add (%d/%d) | Enter empty to finish | Esc to finish", count, 5)))
+		}
+	} else {
+		s.WriteString(headerStyle.Render("ThreeDoors - Edit Values & Goals"))
+		s.WriteString("\n\n")
+
+		if len(vv.config.Values) == 0 {
+			s.WriteString(helpStyle.Render("No values defined. Press 'a' to add one."))
+			s.WriteString("\n\n")
+		} else {
+			for i, v := range vv.config.Values {
+				prefix := "  "
+				if i == vv.selectedIndex {
+					prefix = valuesSelectedPrefix
+				}
+				line := fmt.Sprintf("%s%d. %s", prefix, i+1, v)
+				if i == vv.selectedIndex {
+					s.WriteString(searchSelectedStyle.Render(line))
+				} else {
+					s.WriteString(line)
+				}
+				s.WriteString("\n")
+			}
+			s.WriteString("\n")
+		}
+
+		if vv.textInput.Focused() {
+			s.WriteString(vv.textInput.View())
+			s.WriteString("\n\n")
+			s.WriteString(helpStyle.Render("Enter to add | Esc to cancel"))
+		} else {
+			s.WriteString(helpStyle.Render("↑/↓ navigate | d delete | K/J reorder | a add | Esc/q done"))
+		}
+	}
+
+	return s.String()
+}
+
+// RenderValuesFooter renders a subtle footer showing the user's values/goals.
+func RenderValuesFooter(cfg *tasks.ValuesConfig) string {
+	if cfg == nil || !cfg.HasValues() {
+		return ""
+	}
+
+	joined := strings.Join(cfg.Values, valuesFooterSeparator)
+	return "\n" + valuesFooterStyle.Render(joined)
+}

--- a/internal/tui/values_view_test.go
+++ b/internal/tui/values_view_test.go
@@ -1,0 +1,213 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestNewValuesSetupView(t *testing.T) {
+	cfg := &tasks.ValuesConfig{}
+	vv := NewValuesSetupView(cfg)
+	if vv.mode != ValuesSetupMode {
+		t.Errorf("expected setup mode, got %d", vv.mode)
+	}
+}
+
+func TestNewValuesEditView(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"Health"}}
+	vv := NewValuesEditView(cfg)
+	if vv.mode != ValuesEditMode {
+		t.Errorf("expected edit mode, got %d", vv.mode)
+	}
+}
+
+func TestValuesSetupView_AddValue(t *testing.T) {
+	cfg := &tasks.ValuesConfig{}
+	vv := NewValuesSetupView(cfg)
+	vv.textInput.SetValue("Health and fitness")
+
+	cmd := vv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("expected nil cmd after adding value (not at max yet)")
+	}
+	if len(cfg.Values) != 1 {
+		t.Fatalf("expected 1 value, got %d", len(cfg.Values))
+	}
+	if cfg.Values[0] != "Health and fitness" {
+		t.Errorf("expected 'Health and fitness', got '%s'", cfg.Values[0])
+	}
+}
+
+func TestValuesSetupView_EmptyEnterWithValues(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"Health"}}
+	vv := NewValuesSetupView(cfg)
+	vv.textInput.SetValue("")
+
+	cmd := vv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected save cmd when pressing enter with empty input and existing values")
+	}
+	msg := cmd()
+	if _, ok := msg.(ValuesSavedMsg); !ok {
+		t.Errorf("expected ValuesSavedMsg, got %T", msg)
+	}
+}
+
+func TestValuesSetupView_EmptyEnterNoValues(t *testing.T) {
+	cfg := &tasks.ValuesConfig{}
+	vv := NewValuesSetupView(cfg)
+	vv.textInput.SetValue("")
+
+	cmd := vv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("expected nil cmd when pressing enter with no values")
+	}
+}
+
+func TestValuesSetupView_EscWithValues(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"Health"}}
+	vv := NewValuesSetupView(cfg)
+
+	cmd := vv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected cmd on Esc with values")
+	}
+	msg := cmd()
+	if _, ok := msg.(ValuesSavedMsg); !ok {
+		t.Errorf("expected ValuesSavedMsg, got %T", msg)
+	}
+}
+
+func TestValuesSetupView_EscWithoutValues(t *testing.T) {
+	cfg := &tasks.ValuesConfig{}
+	vv := NewValuesSetupView(cfg)
+
+	cmd := vv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected cmd on Esc without values")
+	}
+	msg := cmd()
+	if _, ok := msg.(ReturnToDoorsMsg); !ok {
+		t.Errorf("expected ReturnToDoorsMsg, got %T", msg)
+	}
+}
+
+func TestValuesEditView_DeleteValue(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"A", "B", "C"}}
+	vv := NewValuesEditView(cfg)
+	vv.selectedIndex = 1
+
+	vv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if len(cfg.Values) != 2 {
+		t.Fatalf("expected 2 values after delete, got %d", len(cfg.Values))
+	}
+	if cfg.Values[0] != "A" || cfg.Values[1] != "C" {
+		t.Errorf("unexpected values: %v", cfg.Values)
+	}
+}
+
+func TestValuesEditView_Navigate(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"A", "B", "C"}}
+	vv := NewValuesEditView(cfg)
+	vv.selectedIndex = 0
+
+	vv.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if vv.selectedIndex != 1 {
+		t.Errorf("expected selectedIndex 1, got %d", vv.selectedIndex)
+	}
+
+	vv.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if vv.selectedIndex != 0 {
+		t.Errorf("expected selectedIndex 0, got %d", vv.selectedIndex)
+	}
+}
+
+func TestValuesEditView_Reorder(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"A", "B", "C"}}
+	vv := NewValuesEditView(cfg)
+	vv.selectedIndex = 0
+
+	// Move down with J
+	vv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'J'}})
+	if cfg.Values[0] != "B" || cfg.Values[1] != "A" {
+		t.Errorf("unexpected order after J: %v", cfg.Values)
+	}
+	if vv.selectedIndex != 1 {
+		t.Errorf("expected selectedIndex 1 after J, got %d", vv.selectedIndex)
+	}
+
+	// Move up with K
+	vv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
+	if cfg.Values[0] != "A" || cfg.Values[1] != "B" {
+		t.Errorf("unexpected order after K: %v", cfg.Values)
+	}
+}
+
+func TestValuesEditView_SaveOnEsc(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"A"}}
+	vv := NewValuesEditView(cfg)
+
+	cmd := vv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected cmd on Esc")
+	}
+	msg := cmd()
+	if _, ok := msg.(ValuesSavedMsg); !ok {
+		t.Errorf("expected ValuesSavedMsg, got %T", msg)
+	}
+}
+
+func TestRenderValuesFooter(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *tasks.ValuesConfig
+		contains string
+		empty    bool
+	}{
+		{"nil config", nil, "", true},
+		{"empty values", &tasks.ValuesConfig{}, "", true},
+		{"single value", &tasks.ValuesConfig{Values: []string{"Health"}}, "Health", false},
+		{"multiple values", &tasks.ValuesConfig{Values: []string{"Health", "Family"}}, "·", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RenderValuesFooter(tt.cfg)
+			if tt.empty && result != "" {
+				t.Errorf("expected empty footer, got '%s'", result)
+			}
+			if !tt.empty && !strings.Contains(result, tt.contains) {
+				t.Errorf("expected footer to contain '%s', got '%s'", tt.contains, result)
+			}
+		})
+	}
+}
+
+func TestValuesSetupView_View(t *testing.T) {
+	cfg := &tasks.ValuesConfig{}
+	vv := NewValuesSetupView(cfg)
+	view := vv.View()
+
+	if !strings.Contains(view, "Values & Goals Setup") {
+		t.Error("expected setup header in view")
+	}
+	if !strings.Contains(view, "Define what matters most") {
+		t.Error("expected setup instructions in view")
+	}
+}
+
+func TestValuesEditView_View(t *testing.T) {
+	cfg := &tasks.ValuesConfig{Values: []string{"Health", "Family"}}
+	vv := NewValuesEditView(cfg)
+	view := vv.View()
+
+	if !strings.Contains(view, "Edit Values & Goals") {
+		t.Error("expected edit header in view")
+	}
+	if !strings.Contains(view, "Health") {
+		t.Error("expected values in view")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements Story 3.3 (Values & Goals Setup and Display) from Epic 3
- Adds `ValuesConfig` struct with YAML persistence to `~/.threedoors/config.yaml` using atomic write pattern
- Adds `:goals` command palette command for guided setup flow (1-5 values/goals)
- Adds `:goals edit` command for editing existing values (add, remove, reorder with vi-style keys)
- Displays configured values as a subtle italic footer across doors, detail, and search views
- Full unit test coverage for config persistence and view logic

## What Changed

### New Files
- `internal/tasks/values_config.go` - Config struct with load/save/validate/manipulate methods
- `internal/tasks/values_config_test.go` - Tests for config persistence and operations
- `internal/tui/values_view.go` - Setup and edit view with two modes
- `internal/tui/values_view_test.go` - Tests for setup flow, edit flow, and footer rendering
- `docs/stories/3.3.story.md` - Story specification

### Modified Files
- `internal/tui/main_model.go` - Added `ViewValuesGoals` mode, values config loading, message handling
- `internal/tui/messages.go` - Added `ValuesSavedMsg`, `ShowValuesSetupMsg`, `ShowValuesEditMsg`
- `internal/tui/search_view.go` - Added `:goals` and `:goals edit` command handling
- `internal/tui/styles.go` - Added values footer/header styles

## Acceptance Criteria Coverage
- [x] `:goals` opens setup flow when no values configured
- [x] Setup flow guides through 1-5 values with persistence
- [x] Values appear as subtle footer across doors, detail, and search views
- [x] `:goals edit` opens edit flow with add/remove/reorder

## Test Plan
- [x] `go test ./...` - all tests pass
- [x] `gofumpt -d .` - no formatting issues
- [x] `golangci-lint run ./...` - zero warnings
- [x] `go build ./...` - builds clean

## Dependencies
- Builds on Story 3.2 (Extended Task Capture with Context)
- Maps to FR6 in PRD