### PR TITLE
feat: Story 3.4 - Door Feedback Options

### DIFF
--- a/docs/stories/3.4.story.md
+++ b/docs/stories/3.4.story.md
@@ -1,0 +1,100 @@
+<!--
+title: "3.4: Door Feedback Options"
+status: "In Progress"
+-->
+
+# Story 3.4: Door Feedback Options
+
+**As a** user,
+**I want** to provide feedback on why a door isn't suitable,
+**so that** the system can learn my preferences over time.
+
+## Acceptance Criteria
+
+1. **Feedback Menu**: When a door is selected in the three doors view and the user presses 'n' (not now), options are displayed: "Blocked", "Not now", "Needs breakdown", "Other comment". The feedback is recorded with the task ID and timestamp.
+
+2. **Needs Breakdown**: When the user selects "Needs breakdown", the task is flagged for future breakdown and the doors refresh with a new set.
+
+3. **Other Comment**: When the user selects "Other comment", a text input appears for freeform feedback. The comment is stored with the task.
+
+## NOT In Scope
+
+* No automatic task breakdown logic
+* No feedback analytics or pattern display
+* No feedback history viewing UI
+* No feedback-driven door selection algorithm (Epic 4)
+
+## Definition of Done
+
+* All acceptance criteria implemented
+* `make build` succeeds with zero errors
+* `make test` passes with zero failures
+* `gofumpt -d .` produces no output (code is formatted)
+* `golangci-lint run ./...` passes with zero warnings
+* Unit tests cover feedback view and session tracker recording
+
+### Dev Notes
+
+This story adds a feedback dialog similar to `mood_view.go`. Follow existing patterns for multi-option views with optional text input.
+
+**Critical coding standards to follow:**
+* Errors must be wrapped with context using `%w` verb
+* No panics in user-facing code — `Update()` and `View()` must never panic
+* Do not use `fmt.Println` for TUI output — all rendering through `View()` only
+* Follow gofumpt formatting standards
+
+### Parent Epic
+
+* Parent Epic: Epic 3: Enhanced Task Capture & Interaction
+
+### Architecture & Design
+
+**Feedback Data Model:**
+```go
+type DoorFeedbackEntry struct {
+    Timestamp    time.Time `json:"timestamp"`
+    TaskID       string    `json:"task_id"`
+    FeedbackType string    `json:"feedback_type"` // blocked, not-now, needs-breakdown, other
+    Comment      string    `json:"comment,omitempty"`
+}
+```
+
+**New View:** `ViewFeedback` for feedback menu (follows mood_view.go pattern)
+
+**Key Binding:** 'n' key in doors view (when door is selected) opens feedback menu
+
+**Session Tracking:** Add `RecordDoorFeedback()` to `SessionTracker`
+
+### Key Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `internal/tui/feedback_view.go` | Created - feedback dialog |
+| `internal/tui/feedback_view_test.go` | Created - feedback tests |
+| `internal/tasks/session_tracker.go` | Modified - add feedback recording |
+| `internal/tasks/session_tracker_test.go` | Modified - add feedback tests |
+| `internal/tui/messages.go` | Modified - add feedback messages |
+| `internal/tui/main_model.go` | Modified - add ViewFeedback, wire feedback |
+| `internal/tui/doors_view.go` | Modified - add 'n' key hint |
+| `internal/tui/styles.go` | Modified - add feedback header style |
+
+### Testing
+
+* Unit tests for feedback view rendering
+* Unit tests for each feedback option key
+* Unit tests for "Other" custom input flow
+* Unit tests for Esc cancellation
+* Unit tests for session tracker RecordDoorFeedback
+
+## Tasks / Subtasks
+
+- [ ] Add `DoorFeedbackEntry` and `RecordDoorFeedback()` to `session_tracker.go`
+- [ ] Add feedback tests to `session_tracker_test.go`
+- [ ] Add `DoorFeedbackMsg` and `ShowFeedbackMsg` to `messages.go`
+- [ ] Add `ViewFeedback` to `main_model.go`
+- [ ] Create `feedback_view.go` with options menu and custom input
+- [ ] Create `feedback_view_test.go`
+- [ ] Add feedback header style to `styles.go`
+- [ ] Add 'n' key handling in `main_model.go` doors update
+- [ ] Update doors_view help text with 'n' key
+- [ ] Run `make test`, `make fmt`, `make lint` to verify

--- a/internal/tasks/session_tracker.go
+++ b/internal/tasks/session_tracker.go
@@ -6,6 +6,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// DoorFeedbackEntry captures feedback on why a door/task was declined.
+type DoorFeedbackEntry struct {
+	Timestamp    time.Time `json:"timestamp"`
+	TaskID       string    `json:"task_id"`
+	FeedbackType string    `json:"feedback_type"` // blocked, not-now, needs-breakdown, other
+	Comment      string    `json:"comment,omitempty"`
+}
+
 // MoodEntry captures a timestamped mood record.
 type MoodEntry struct {
 	Timestamp  time.Time `json:"timestamp"`
@@ -37,6 +45,8 @@ type SessionMetrics struct {
 	DoorSelections      []DoorSelectionRecord `json:"door_selections,omitempty"`
 	TaskBypasses        [][]string            `json:"task_bypasses,omitempty"`
 	MoodEntries         []MoodEntry           `json:"mood_entries_detail,omitempty"`
+	DoorFeedback        []DoorFeedbackEntry   `json:"door_feedback,omitempty"`
+	DoorFeedbackCount   int                   `json:"door_feedback_count"`
 }
 
 // SessionTracker provides in-memory tracking of user behavior during an app session.
@@ -112,6 +122,17 @@ func (st *SessionTracker) RecordMood(mood string, customText string) {
 		CustomText: customText,
 	})
 	st.metrics.MoodEntryCount++
+}
+
+// RecordDoorFeedback records feedback on a task shown in a door.
+func (st *SessionTracker) RecordDoorFeedback(taskID, feedbackType, comment string) {
+	st.metrics.DoorFeedback = append(st.metrics.DoorFeedback, DoorFeedbackEntry{
+		Timestamp:    time.Now().UTC(),
+		TaskID:       taskID,
+		FeedbackType: feedbackType,
+		Comment:      comment,
+	})
+	st.metrics.DoorFeedbackCount++
 }
 
 // Finalize calculates session duration and returns metrics for persistence.

--- a/internal/tasks/session_tracker_test.go
+++ b/internal/tasks/session_tracker_test.go
@@ -197,6 +197,40 @@ func TestSessionTracker_RecordRefresh_EmptySlice(t *testing.T) {
 	}
 }
 
+func TestSessionTracker_RecordDoorFeedback(t *testing.T) {
+	st := NewSessionTracker()
+	st.RecordDoorFeedback("task-123", "blocked", "")
+	st.RecordDoorFeedback("task-456", "other", "too vague")
+
+	if st.metrics.DoorFeedbackCount != 2 {
+		t.Errorf("Expected 2 door feedback entries, got %d", st.metrics.DoorFeedbackCount)
+	}
+	if len(st.metrics.DoorFeedback) != 2 {
+		t.Fatalf("Expected 2 door feedback records, got %d", len(st.metrics.DoorFeedback))
+	}
+	if st.metrics.DoorFeedback[0].TaskID != "task-123" {
+		t.Errorf("Expected task ID 'task-123', got %q", st.metrics.DoorFeedback[0].TaskID)
+	}
+	if st.metrics.DoorFeedback[0].FeedbackType != "blocked" {
+		t.Errorf("Expected feedback type 'blocked', got %q", st.metrics.DoorFeedback[0].FeedbackType)
+	}
+	if st.metrics.DoorFeedback[1].Comment != "too vague" {
+		t.Errorf("Expected comment 'too vague', got %q", st.metrics.DoorFeedback[1].Comment)
+	}
+	if st.metrics.DoorFeedback[1].FeedbackType != "other" {
+		t.Errorf("Expected feedback type 'other', got %q", st.metrics.DoorFeedback[1].FeedbackType)
+	}
+}
+
+func TestSessionTracker_RecordDoorFeedback_Timestamp(t *testing.T) {
+	st := NewSessionTracker()
+	st.RecordDoorFeedback("task-789", "not-now", "")
+
+	if st.metrics.DoorFeedback[0].Timestamp.IsZero() {
+		t.Error("Expected non-zero timestamp on door feedback entry")
+	}
+}
+
 func TestSessionTracker_RecordRefresh_NilSlice(t *testing.T) {
 	st := NewSessionTracker()
 

--- a/internal/tui/doors_view.go
+++ b/internal/tui/doors_view.go
@@ -124,7 +124,7 @@ func (dv *DoorsView) View() string {
 	}
 
 	s.WriteString("\n\n")
-	s.WriteString(helpStyle.Render("a/left, w/up, d/right to select | s/down to re-roll | Enter to open | / search | M mood | q quit"))
+	s.WriteString(helpStyle.Render("a/left, w/up, d/right to select | s/down to re-roll | Enter to open | N feedback | / search | M mood | q quit"))
 	s.WriteString("\n")
 	s.WriteString(greetingStyle.Render("Progress over perfection. Just pick one and start."))
 

--- a/internal/tui/feedback_view.go
+++ b/internal/tui/feedback_view.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+var feedbackOptions = []string{
+	"Blocked",
+	"Not now",
+	"Needs breakdown",
+	"Other comment",
+}
+
+// FeedbackView displays the door feedback dialog.
+type FeedbackView struct {
+	task        *tasks.Task
+	customInput string
+	isCustom    bool
+	width       int
+}
+
+// NewFeedbackView creates a new feedback view for the given task.
+func NewFeedbackView(task *tasks.Task) *FeedbackView {
+	return &FeedbackView{task: task}
+}
+
+// SetWidth sets the terminal width.
+func (fv *FeedbackView) SetWidth(w int) {
+	fv.width = w
+}
+
+// Update handles key input for feedback selection.
+func (fv *FeedbackView) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if fv.isCustom {
+			return fv.handleCustomInput(msg)
+		}
+		return fv.handleFeedbackSelection(msg)
+	}
+	return nil
+}
+
+func (fv *FeedbackView) handleFeedbackSelection(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc":
+		return func() tea.Msg { return ReturnToDoorsMsg{} }
+	case "1":
+		return feedbackCmd(fv.task, "blocked", "")
+	case "2":
+		return feedbackCmd(fv.task, "not-now", "")
+	case "3":
+		return feedbackCmd(fv.task, "needs-breakdown", "")
+	case "4":
+		fv.isCustom = true
+		fv.customInput = ""
+	}
+	return nil
+}
+
+func (fv *FeedbackView) handleCustomInput(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "enter":
+		if fv.customInput != "" {
+			return feedbackCmd(fv.task, "other", fv.customInput)
+		}
+	case "esc":
+		fv.isCustom = false
+		fv.customInput = ""
+	case "backspace":
+		if len(fv.customInput) > 0 {
+			fv.customInput = fv.customInput[:len(fv.customInput)-1]
+		}
+	default:
+		if len(msg.String()) == 1 && len(fv.customInput) < 200 {
+			fv.customInput += msg.String()
+		}
+	}
+	return nil
+}
+
+func feedbackCmd(task *tasks.Task, feedbackType, comment string) tea.Cmd {
+	return func() tea.Msg {
+		return DoorFeedbackMsg{Task: task, FeedbackType: feedbackType, Comment: comment}
+	}
+}
+
+// View renders the feedback dialog.
+func (fv *FeedbackView) View() string {
+	s := strings.Builder{}
+	s.WriteString(feedbackHeaderStyle.Render("Door Feedback"))
+	s.WriteString("\n\n")
+
+	s.WriteString(helpStyle.Render(fmt.Sprintf("Task: %s", fv.task.Text)))
+	s.WriteString("\n\n")
+
+	s.WriteString("Why isn't this task suitable right now?\n\n")
+
+	for i, option := range feedbackOptions {
+		fmt.Fprintf(&s, "  %d. %s\n", i+1, option)
+	}
+
+	s.WriteString("\n")
+
+	if fv.isCustom {
+		s.WriteString("Enter your comment: " + fv.customInput + "_\n")
+	} else {
+		s.WriteString(helpStyle.Render("Press 1-4 to select | Esc to cancel"))
+	}
+
+	w := fv.width - 6
+	if w < 40 {
+		w = 40
+	}
+	return detailBorder.Width(w).Render(s.String())
+}

--- a/internal/tui/feedback_view_test.go
+++ b/internal/tui/feedback_view_test.go
@@ -1,0 +1,200 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func newTestTask() *tasks.Task {
+	return tasks.NewTask("Test task for feedback")
+}
+
+// --- View Rendering ---
+
+func TestFeedbackView_RendersAllOptions(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	fv.SetWidth(80)
+	view := fv.View()
+
+	expectedOptions := []string{"Blocked", "Not now", "Needs breakdown", "Other comment"}
+	for _, opt := range expectedOptions {
+		if !strings.Contains(view, opt) {
+			t.Errorf("FeedbackView should contain %q", opt)
+		}
+	}
+}
+
+func TestFeedbackView_RendersHeader(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	fv.SetWidth(80)
+	view := fv.View()
+	if !strings.Contains(view, "Door Feedback") {
+		t.Error("FeedbackView should contain 'Door Feedback' header")
+	}
+}
+
+func TestFeedbackView_RendersTaskText(t *testing.T) {
+	task := tasks.NewTask("Buy groceries")
+	fv := NewFeedbackView(task)
+	fv.SetWidth(80)
+	view := fv.View()
+	if !strings.Contains(view, "Buy groceries") {
+		t.Error("FeedbackView should show the task text")
+	}
+}
+
+func TestFeedbackView_RendersHelpText(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	fv.SetWidth(80)
+	view := fv.View()
+	if !strings.Contains(view, "1-4") {
+		t.Error("FeedbackView should contain '1-4' in help text")
+	}
+}
+
+// --- Feedback Selection via Number Keys ---
+
+func TestFeedbackView_NumberKeySelects(t *testing.T) {
+	tests := []struct {
+		key            string
+		expectedType   string
+		expectedHasCmd bool
+	}{
+		{"1", "blocked", true},
+		{"2", "not-now", true},
+		{"3", "needs-breakdown", true},
+	}
+
+	for _, tt := range tests {
+		t.Run("key_"+tt.key, func(t *testing.T) {
+			task := newTestTask()
+			fv := NewFeedbackView(task)
+			cmd := fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tt.key)})
+			if cmd == nil {
+				t.Fatalf("key %q should return a command", tt.key)
+			}
+			msg := cmd()
+			dfm, ok := msg.(DoorFeedbackMsg)
+			if !ok {
+				t.Fatalf("expected DoorFeedbackMsg, got %T", msg)
+			}
+			if dfm.FeedbackType != tt.expectedType {
+				t.Errorf("expected feedback type %q, got %q", tt.expectedType, dfm.FeedbackType)
+			}
+			if dfm.Comment != "" {
+				t.Errorf("expected empty comment for predefined option, got %q", dfm.Comment)
+			}
+			if dfm.Task.ID != task.ID {
+				t.Errorf("expected task ID %q, got %q", task.ID, dfm.Task.ID)
+			}
+		})
+	}
+}
+
+// --- Esc Cancels ---
+
+func TestFeedbackView_EscCancels(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	cmd := fv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("Esc should return a command")
+	}
+	msg := cmd()
+	if _, ok := msg.(ReturnToDoorsMsg); !ok {
+		t.Errorf("expected ReturnToDoorsMsg, got %T", msg)
+	}
+}
+
+// --- Other / Custom Input ---
+
+func TestFeedbackView_OtherKey_EntersCustomMode(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	cmd := fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")})
+	if cmd != nil {
+		t.Error("key '4' (Other) should enter custom mode, not return a command")
+	}
+	if !fv.isCustom {
+		t.Error("isCustom should be true after pressing '4'")
+	}
+}
+
+func TestFeedbackView_CustomInput_EnterSubmits(t *testing.T) {
+	task := newTestTask()
+	fv := NewFeedbackView(task)
+	// Enter custom mode
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")})
+
+	// Type comment
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")})
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+
+	// Submit
+	cmd := fv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter should return a command after typing custom comment")
+	}
+	msg := cmd()
+	dfm, ok := msg.(DoorFeedbackMsg)
+	if !ok {
+		t.Fatalf("expected DoorFeedbackMsg, got %T", msg)
+	}
+	if dfm.FeedbackType != "other" {
+		t.Errorf("expected feedback type 'other', got %q", dfm.FeedbackType)
+	}
+	if dfm.Comment != "too" {
+		t.Errorf("expected comment 'too', got %q", dfm.Comment)
+	}
+}
+
+func TestFeedbackView_CustomInput_EmptyEnterIgnored(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")})
+
+	cmd := fv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("Enter with empty custom input should not return a command")
+	}
+}
+
+func TestFeedbackView_CustomInput_EscCancels(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")})
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+
+	cmd := fv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd != nil {
+		t.Error("Esc in custom mode should return to feedback selection, not return a command")
+	}
+	if fv.isCustom {
+		t.Error("isCustom should be false after Esc")
+	}
+	if fv.customInput != "" {
+		t.Error("customInput should be cleared after Esc")
+	}
+}
+
+func TestFeedbackView_CustomInput_BackspaceWorks(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")})
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")})
+	fv.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+
+	if fv.customInput != "a" {
+		t.Errorf("expected 'a' after backspace, got %q", fv.customInput)
+	}
+}
+
+func TestFeedbackView_CustomMode_ShowsInputPrompt(t *testing.T) {
+	fv := NewFeedbackView(newTestTask())
+	fv.SetWidth(80)
+	fv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")})
+	view := fv.View()
+	if !strings.Contains(view, "Enter your comment") {
+		t.Error("View should show input prompt in custom mode")
+	}
+}

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -20,6 +20,7 @@ const (
 	ViewHealth
 	ViewAddTask
 	ViewValuesGoals
+	ViewFeedback
 )
 
 // MainModel is the root Bubbletea model that orchestrates view transitions.
@@ -33,6 +34,7 @@ type MainModel struct {
 	healthView          *HealthView
 	addTaskView         *AddTaskView
 	valuesView          *ValuesView
+	feedbackView        *FeedbackView
 	pool                *tasks.TaskPool
 	tracker             *tasks.SessionTracker
 	provider            tasks.TaskProvider
@@ -98,6 +100,9 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.valuesView != nil {
 			m.valuesView.SetWidth(msg.Width)
+		}
+		if m.feedbackView != nil {
+			m.feedbackView.SetWidth(msg.Width)
 		}
 		return m, nil
 
@@ -235,6 +240,29 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.viewMode = ViewMood
 		return m, nil
 
+	case ShowFeedbackMsg:
+		m.feedbackView = NewFeedbackView(msg.Task)
+		m.feedbackView.SetWidth(m.width)
+		m.previousView = m.viewMode
+		m.viewMode = ViewFeedback
+		return m, nil
+
+	case DoorFeedbackMsg:
+		if m.tracker != nil {
+			m.tracker.RecordDoorFeedback(msg.Task.ID, msg.FeedbackType, msg.Comment)
+		}
+		if msg.FeedbackType == "needs-breakdown" {
+			msg.Task.AddNote("Flagged: needs breakdown")
+			if err := m.saveTasks(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to save tasks: %v\n", err)
+			}
+		}
+		m.feedbackView = nil
+		m.viewMode = ViewDoors
+		m.doorsView.RefreshDoors()
+		m.flash = "Feedback recorded"
+		return m, ClearFlashCmd()
+
 	case ShowValuesSetupMsg:
 		m.valuesView = NewValuesSetupView(m.valuesConfig)
 		m.valuesView.SetWidth(m.width)
@@ -283,6 +311,8 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateAddTask(msg)
 	case ViewValuesGoals:
 		return m.updateValues(msg)
+	case ViewFeedback:
+		return m.updateFeedback(msg)
 	}
 
 	return m, nil
@@ -314,6 +344,11 @@ func (m *MainModel) updateDoors(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.detailView = NewDetailView(task, m.tracker)
 				m.detailView.SetWidth(m.width)
 				m.viewMode = ViewDetail
+			}
+		case "n", "N":
+			if m.doorsView.selectedDoorIndex >= 0 && m.doorsView.selectedDoorIndex < len(m.doorsView.currentDoors) {
+				task := m.doorsView.currentDoors[m.doorsView.selectedDoorIndex]
+				return m, func() tea.Msg { return ShowFeedbackMsg{Task: task} }
 			}
 		case "m", "M":
 			return m, func() tea.Msg { return ShowMoodMsg{} }
@@ -376,6 +411,14 @@ func (m *MainModel) updateAddTask(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *MainModel) updateFeedback(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.feedbackView == nil {
+		return m, nil
+	}
+	cmd := m.feedbackView.Update(msg)
+	return m, cmd
+}
+
 func (m *MainModel) updateValues(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.valuesView == nil {
 		return m, nil
@@ -420,6 +463,10 @@ func (m *MainModel) View() string {
 	case ViewValuesGoals:
 		if m.valuesView != nil {
 			view = m.valuesView.View()
+		}
+	case ViewFeedback:
+		if m.feedbackView != nil {
+			view = m.feedbackView.View()
 		}
 	default:
 		view = m.doorsView.View()

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -75,6 +75,18 @@ type ShowValuesSetupMsg struct{}
 // ShowValuesEditMsg is sent to open the values edit flow.
 type ShowValuesEditMsg struct{}
 
+// ShowFeedbackMsg is sent to open the door feedback dialog.
+type ShowFeedbackMsg struct {
+	Task *tasks.Task
+}
+
+// DoorFeedbackMsg is sent when door feedback has been submitted.
+type DoorFeedbackMsg struct {
+	Task         *tasks.Task
+	FeedbackType string
+	Comment      string
+}
+
 // ReturnToSearchMsg is sent to restore search view from detail view.
 type ReturnToSearchMsg struct {
 	Query         string

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -131,6 +131,10 @@ var (
 				Foreground(colorAccent).
 				Bold(true)
 
+	feedbackHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("214"))
+
 	valuesFooterSeparator = "  ·  "
 
 	valuesSelectedPrefix = "▸ "


### PR DESCRIPTION
## Summary

- Add door feedback menu activated by pressing 'n' when a door is selected in the three doors view
- Four feedback options: Blocked, Not now, Needs breakdown, Other comment (with freeform text input)
- Feedback recorded with task ID and timestamp via `SessionTracker.RecordDoorFeedback()` for future learning (Epic 4)
- "Needs breakdown" flags the task with a note for future decomposition
- Follows existing `mood_view.go` pattern for multi-option dialog with optional custom input

Covers FR18 (door feedback options) and FR19 (blocker capture).

**Chain:** Story 3.2 (#24) → Story 3.3 (#25) → **Story 3.4 (this PR)**

### Files Changed
- `internal/tui/feedback_view.go` — new feedback dialog view
- `internal/tui/feedback_view_test.go` — comprehensive tests (rendering, key selection, custom input, cancellation)
- `internal/tasks/session_tracker.go` — `DoorFeedbackEntry` struct and `RecordDoorFeedback()` method
- `internal/tasks/session_tracker_test.go` — feedback recording tests
- `internal/tui/messages.go` — `ShowFeedbackMsg` and `DoorFeedbackMsg`
- `internal/tui/main_model.go` — `ViewFeedback` mode, 'n' key binding, feedback message handling
- `internal/tui/doors_view.go` — updated help text with 'N feedback' hint
- `internal/tui/styles.go` — `feedbackHeaderStyle`
- `docs/stories/3.4.story.md` — story spec

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (all existing + new feedback tests)
- [x] `gofumpt -d .` produces no output
- [x] `golangci-lint run ./...` passes with 0 issues
- [ ] Manual: select a door, press 'n', verify feedback menu appears
- [ ] Manual: select each option (1-4), verify feedback recorded
- [ ] Manual: select "Other comment", type text, verify stored