### PR TITLE
feat: Story 3.6 - Session Improvement Prompt

### DIFF
--- a/cmd/threedoors/main_test.go
+++ b/cmd/threedoors/main_test.go
@@ -21,33 +21,55 @@ func newTestModel(t *testing.T) *tui.MainModel {
 func TestQuitKey(t *testing.T) {
 	m := newTestModel(t)
 
+	// 'q' sends RequestQuitMsg, which (with no completions and <5min) becomes tea.Quit
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
-	_, cmd := m.Update(msg)
+	updated, cmd := m.Update(msg)
 
 	if cmd == nil {
-		t.Error("'q' key should trigger tea.Quit command")
+		t.Error("'q' key should trigger a command")
 		return
 	}
 
+	// First step: RequestQuitMsg
 	result := cmd()
-	if _, ok := result.(tea.QuitMsg); !ok {
-		t.Error("'q' key should return a tea.QuitMsg")
+	updated, cmd = updated.Update(result)
+
+	if cmd == nil {
+		t.Error("RequestQuitMsg should trigger tea.Quit command")
+		return
 	}
+
+	quitResult := cmd()
+	if _, ok := quitResult.(tea.QuitMsg); !ok {
+		t.Error("'q' key should ultimately return a tea.QuitMsg")
+	}
+	_ = updated
 }
 
 func TestCtrlCKey(t *testing.T) {
 	m := newTestModel(t)
 
+	// 'ctrl+c' sends RequestQuitMsg, which (with no completions and <5min) becomes tea.Quit
 	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
-	_, cmd := m.Update(msg)
+	updated, cmd := m.Update(msg)
 
 	if cmd == nil {
-		t.Error("'ctrl+c' should trigger tea.Quit command")
+		t.Error("'ctrl+c' should trigger a command")
 		return
 	}
 
+	// First step: RequestQuitMsg
 	result := cmd()
-	if _, ok := result.(tea.QuitMsg); !ok {
-		t.Error("'ctrl+c' should return a tea.QuitMsg")
+	updated, cmd = updated.Update(result)
+
+	if cmd == nil {
+		t.Error("RequestQuitMsg should trigger tea.Quit command")
+		return
 	}
+
+	quitResult := cmd()
+	if _, ok := quitResult.(tea.QuitMsg); !ok {
+		t.Error("'ctrl+c' should ultimately return a tea.QuitMsg")
+	}
+	_ = updated
 }

--- a/docs/stories/3.6.story.md
+++ b/docs/stories/3.6.story.md
@@ -1,0 +1,97 @@
+<!--
+title: "3.6: Session Improvement Prompt"
+status: "In Progress"
+-->
+
+# Story 3.6: Session Improvement Prompt
+
+**As a** user,
+**I want** to be prompted for one improvement idea per session,
+**so that** I continuously refine my task management approach.
+
+## Acceptance Criteria
+
+1. **Exit Prompt Trigger**: When the user has been in a session for at least 5 minutes OR completed 1+ tasks, and exits the application (q, ctrl+c, :quit, :exit), a prompt appears: "What's one thing you could improve about this list/task/goal right now?"
+
+2. **Input & Save**: The user can type a response and press Enter to save. The response is appended to `~/.threedoors/improvements.txt` with timestamp and session ID.
+
+3. **Skip Option**: Pressing Esc skips the prompt and exits immediately.
+
+## NOT In Scope
+
+* No improvement history viewing UI
+* No analytics on improvement suggestions
+* No prompt customization
+* No multiple prompts per session
+
+## Definition of Done
+
+* All acceptance criteria implemented
+* `make build` succeeds with zero errors
+* `make test` passes with zero failures
+* `gofumpt -d .` produces no output (code is formatted)
+* `golangci-lint run ./...` passes with zero warnings
+* Unit tests cover improvement view and improvement writer
+
+### Dev Notes
+
+This story adds an exit intercept view similar to `feedback_view.go`. When quit conditions are met, instead of returning `tea.Quit`, the app transitions to `ViewImprovement` which shows a text input prompt. On submit or skip, it then returns `tea.Quit`.
+
+**Critical coding standards to follow:**
+* Errors must be wrapped with context using `%w` verb
+* No panics in user-facing code — `Update()` and `View()` must never panic
+* Do not use `fmt.Println` for TUI output — all rendering through `View()` only
+* Follow gofumpt formatting standards
+
+### Parent Epic
+
+* Parent Epic: Epic 3: Enhanced Task Capture & Interaction
+
+### Architecture & Design
+
+**Quit Intercept Pattern:**
+- Both quit paths (doors view `q`/`ctrl+c`, search view `:quit`/`:exit`) send a `RequestQuitMsg` instead of `tea.Quit`
+- `MainModel.Update()` handles `RequestQuitMsg`: checks session criteria, transitions to `ViewImprovement` or returns `tea.Quit`
+- `ImprovementView` handles text input, sends `ImprovementSubmittedMsg` or `ImprovementSkippedMsg`
+- Both messages trigger file write (if text provided) then `tea.Quit`
+
+**Improvement Writer:**
+- Appends to `~/.threedoors/improvements.txt`
+- Format: `[2026-03-02 15:04:05] (session-id) improvement text`
+- Uses `os.OpenFile` with `O_APPEND|O_CREATE|O_WRONLY`
+
+### Key Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `internal/tui/improvement_view.go` | Created - improvement prompt dialog |
+| `internal/tui/improvement_view_test.go` | Created - improvement view tests |
+| `internal/tasks/improvement_writer.go` | Created - file writer for improvements |
+| `internal/tasks/improvement_writer_test.go` | Created - writer tests |
+| `internal/tui/messages.go` | Modified - add improvement messages |
+| `internal/tui/main_model.go` | Modified - add ViewImprovement, quit intercept |
+| `internal/tui/search_view.go` | Modified - use RequestQuitMsg instead of tea.Quit |
+| `internal/tui/styles.go` | Modified - add improvement header style |
+
+### Testing
+
+* Unit tests for improvement view rendering
+* Unit tests for Enter submit flow
+* Unit tests for Esc skip flow
+* Unit tests for improvement writer file output
+* Unit tests for quit intercept logic in main model
+
+## Tasks / Subtasks
+
+- [ ] Create `improvement_writer.go` with `WriteImprovement()` function
+- [ ] Create `improvement_writer_test.go`
+- [ ] Add `RequestQuitMsg`, `ImprovementSubmittedMsg`, `ImprovementSkippedMsg` to `messages.go`
+- [ ] Add `ViewImprovement` to `main_model.go` ViewMode enum
+- [ ] Create `improvement_view.go` with text input prompt
+- [ ] Create `improvement_view_test.go`
+- [ ] Add improvement header style to `styles.go`
+- [ ] Modify doors view quit to send `RequestQuitMsg`
+- [ ] Modify search view quit to send `RequestQuitMsg`
+- [ ] Add quit intercept logic in `MainModel.Update()`
+- [ ] Wire improvement view update/render in main model
+- [ ] Run `make test`, `make fmt`, `make lint` to verify

--- a/internal/tasks/improvement_writer.go
+++ b/internal/tasks/improvement_writer.go
@@ -1,0 +1,30 @@
+package tasks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// WriteImprovement appends an improvement suggestion to improvements.txt.
+// Format: [YYYY-MM-DD HH:MM:SS] (session-id) text
+// Creates the file if it doesn't exist.
+func WriteImprovement(baseDir, sessionID, text string) error {
+	path := filepath.Join(baseDir, "improvements.txt")
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening improvements file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on append file
+
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	line := fmt.Sprintf("[%s] (%s) %s\n", timestamp, sessionID, text)
+
+	if _, err := f.WriteString(line); err != nil {
+		return fmt.Errorf("writing improvement: %w", err)
+	}
+
+	return nil
+}

--- a/internal/tasks/improvement_writer_test.go
+++ b/internal/tasks/improvement_writer_test.go
@@ -1,0 +1,101 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteImprovement(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteImprovement(dir, "test-session-123", "Break tasks into smaller pieces")
+	if err != nil {
+		t.Fatalf("WriteImprovement failed: %v", err)
+	}
+
+	path := filepath.Join(dir, "improvements.txt")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading improvements file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "(test-session-123)") {
+		t.Errorf("expected session ID in output, got: %s", content)
+	}
+	if !strings.Contains(content, "Break tasks into smaller pieces") {
+		t.Errorf("expected improvement text in output, got: %s", content)
+	}
+	if !strings.HasSuffix(content, "\n") {
+		t.Error("expected trailing newline")
+	}
+}
+
+func TestWriteImprovement_AppendsMultiple(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteImprovement(dir, "session-1", "First improvement")
+	if err != nil {
+		t.Fatalf("first write failed: %v", err)
+	}
+
+	err = WriteImprovement(dir, "session-2", "Second improvement")
+	if err != nil {
+		t.Fatalf("second write failed: %v", err)
+	}
+
+	path := filepath.Join(dir, "improvements.txt")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading improvements file: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines, got %d: %s", len(lines), string(data))
+	}
+}
+
+func TestWriteImprovement_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "improvements.txt")
+
+	// File should not exist yet
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("file should not exist before write")
+	}
+
+	err := WriteImprovement(dir, "session-1", "test")
+	if err != nil {
+		t.Fatalf("WriteImprovement failed: %v", err)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("file should exist after write")
+	}
+}
+
+func TestWriteImprovement_TimestampFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteImprovement(dir, "session-1", "test improvement")
+	if err != nil {
+		t.Fatalf("WriteImprovement failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "improvements.txt"))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+
+	content := string(data)
+	// Should start with [YYYY-MM-DD HH:MM:SS]
+	if !strings.HasPrefix(content, "[") {
+		t.Errorf("expected timestamp prefix, got: %s", content)
+	}
+	if !strings.Contains(content, "] (session-1) test improvement") {
+		t.Errorf("expected formatted line, got: %s", content)
+	}
+}

--- a/internal/tasks/session_tracker.go
+++ b/internal/tasks/session_tracker.go
@@ -135,6 +135,30 @@ func (st *SessionTracker) RecordDoorFeedback(taskID, feedbackType, comment strin
 	st.metrics.DoorFeedbackCount++
 }
 
+// MetricsSnapshot provides a read-only view of current session state without finalizing.
+type MetricsSnapshot struct {
+	TasksCompleted int
+	startTime      time.Time
+}
+
+// DurationSeconds returns the elapsed session duration in seconds.
+func (ms *MetricsSnapshot) DurationSeconds() float64 {
+	return time.Since(ms.startTime).Seconds()
+}
+
+// GetMetricsSnapshot returns a snapshot of current session metrics without finalizing.
+func (st *SessionTracker) GetMetricsSnapshot() *MetricsSnapshot {
+	return &MetricsSnapshot{
+		TasksCompleted: st.metrics.TasksCompleted,
+		startTime:      st.metrics.StartTime,
+	}
+}
+
+// GetSessionID returns the current session's unique identifier.
+func (st *SessionTracker) GetSessionID() string {
+	return st.metrics.SessionID
+}
+
 // Finalize calculates session duration and returns metrics for persistence.
 func (st *SessionTracker) Finalize() *SessionMetrics {
 	st.metrics.EndTime = time.Now().UTC()

--- a/internal/tui/improvement_view.go
+++ b/internal/tui/improvement_view.go
@@ -1,0 +1,70 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ImprovementView displays the session improvement prompt on exit.
+type ImprovementView struct {
+	input string
+	width int
+}
+
+// NewImprovementView creates a new improvement prompt view.
+func NewImprovementView() *ImprovementView {
+	return &ImprovementView{}
+}
+
+// SetWidth sets the terminal width.
+func (iv *ImprovementView) SetWidth(w int) {
+	iv.width = w
+}
+
+// Update handles key input for the improvement prompt.
+func (iv *ImprovementView) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			text := strings.TrimSpace(iv.input)
+			if text != "" {
+				return func() tea.Msg { return ImprovementSubmittedMsg{Text: text} }
+			}
+			// Empty input on Enter — skip
+			return func() tea.Msg { return ImprovementSkippedMsg{} }
+		case "esc", "ctrl+c":
+			return func() tea.Msg { return ImprovementSkippedMsg{} }
+		case "backspace":
+			if len(iv.input) > 0 {
+				iv.input = iv.input[:len(iv.input)-1]
+			}
+		default:
+			if len(msg.String()) == 1 && len(iv.input) < 500 {
+				iv.input += msg.String()
+			}
+		}
+	}
+	return nil
+}
+
+// View renders the improvement prompt dialog.
+func (iv *ImprovementView) View() string {
+	s := strings.Builder{}
+	s.WriteString(improvementHeaderStyle.Render("Session Reflection"))
+	s.WriteString("\n\n")
+
+	s.WriteString("What's one thing you could improve about\n")
+	s.WriteString("this list/task/goal right now?\n\n")
+
+	s.WriteString("> " + iv.input + "_\n\n")
+
+	s.WriteString(helpStyle.Render("Enter to save | Esc to skip"))
+
+	w := iv.width - 6
+	if w < 40 {
+		w = 40
+	}
+	return detailBorder.Width(w).Render(s.String())
+}

--- a/internal/tui/improvement_view_test.go
+++ b/internal/tui/improvement_view_test.go
@@ -1,0 +1,191 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestImprovementView_Render(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+	view := iv.View()
+
+	if !strings.Contains(view, "Session Reflection") {
+		t.Error("expected 'Session Reflection' header")
+	}
+	if !strings.Contains(view, "What's one thing you could improve") {
+		t.Error("expected prompt text")
+	}
+	if !strings.Contains(view, "Enter to save") {
+		t.Error("expected help text")
+	}
+}
+
+func TestImprovementView_TextInput(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	// Type characters
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+
+	view := iv.View()
+	if !strings.Contains(view, "hi") {
+		t.Errorf("expected typed text in view, got: %s", view)
+	}
+}
+
+func TestImprovementView_Backspace(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+
+	if iv.input != "a" {
+		t.Errorf("expected 'a' after backspace, got: %s", iv.input)
+	}
+}
+
+func TestImprovementView_BackspaceEmpty(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	// Backspace on empty should not panic
+	cmd := iv.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if cmd != nil {
+		t.Error("backspace on empty should not produce a command")
+	}
+	if iv.input != "" {
+		t.Errorf("expected empty input, got: %s", iv.input)
+	}
+}
+
+func TestImprovementView_SubmitWithText(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+
+	cmd := iv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter with text should produce a command")
+	}
+
+	msg := cmd()
+	submitted, ok := msg.(ImprovementSubmittedMsg)
+	if !ok {
+		t.Fatalf("expected ImprovementSubmittedMsg, got %T", msg)
+	}
+	if submitted.Text != "test" {
+		t.Errorf("expected 'test', got: %s", submitted.Text)
+	}
+}
+
+func TestImprovementView_SubmitEmpty(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	cmd := iv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on empty should produce a skip command")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(ImprovementSkippedMsg); !ok {
+		t.Fatalf("expected ImprovementSkippedMsg, got %T", msg)
+	}
+}
+
+func TestImprovementView_EscSkips(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	cmd := iv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("Esc should produce a skip command")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(ImprovementSkippedMsg); !ok {
+		t.Fatalf("expected ImprovementSkippedMsg, got %T", msg)
+	}
+}
+
+func TestImprovementView_CtrlCSkips(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	cmd := iv.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("Ctrl+C should produce a skip command")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(ImprovementSkippedMsg); !ok {
+		t.Fatalf("expected ImprovementSkippedMsg, got %T", msg)
+	}
+}
+
+func TestImprovementView_CharLimit(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	// Fill to max
+	for i := 0; i < 500; i++ {
+		iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	}
+
+	if len(iv.input) != 500 {
+		t.Errorf("expected 500 chars, got %d", len(iv.input))
+	}
+
+	// Should not grow past 500
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+	if len(iv.input) != 500 {
+		t.Errorf("expected 500 chars after limit, got %d", len(iv.input))
+	}
+}
+
+func TestImprovementView_TrimsWhitespace(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(80)
+
+	// Type spaces then text
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	iv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	cmd := iv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter should produce a command")
+	}
+
+	msg := cmd()
+	submitted, ok := msg.(ImprovementSubmittedMsg)
+	if !ok {
+		t.Fatalf("expected ImprovementSubmittedMsg, got %T", msg)
+	}
+	if submitted.Text != "x" {
+		t.Errorf("expected trimmed 'x', got: '%s'", submitted.Text)
+	}
+}
+
+func TestImprovementView_MinWidth(t *testing.T) {
+	iv := NewImprovementView()
+	iv.SetWidth(10) // Very narrow
+	view := iv.View()
+
+	// Should not panic with narrow width
+	if view == "" {
+		t.Error("expected non-empty view even at narrow width")
+	}
+}

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -22,6 +22,7 @@ const (
 	ViewAddTask
 	ViewValuesGoals
 	ViewFeedback
+	ViewImprovement
 )
 
 // MainModel is the root Bubbletea model that orchestrates view transitions.
@@ -36,6 +37,7 @@ type MainModel struct {
 	addTaskView         *AddTaskView
 	valuesView          *ValuesView
 	feedbackView        *FeedbackView
+	improvementView     *ImprovementView
 	pool                *tasks.TaskPool
 	tracker             *tasks.SessionTracker
 	provider            tasks.TaskProvider
@@ -114,6 +116,9 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.feedbackView != nil {
 			m.feedbackView.SetWidth(msg.Width)
+		}
+		if m.improvementView != nil {
+			m.improvementView.SetWidth(msg.Width)
 		}
 		return m, nil
 
@@ -306,6 +311,33 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.doorsView.RefreshDoors()
 		return m, ClearFlashCmd()
 
+	case RequestQuitMsg:
+		// Show improvement prompt if session qualifies (5+ min OR 1+ completions)
+		if m.tracker != nil {
+			metrics := m.tracker.GetMetricsSnapshot()
+			if metrics.TasksCompleted >= 1 || metrics.DurationSeconds() >= 300 {
+				m.improvementView = NewImprovementView()
+				m.improvementView.SetWidth(m.width)
+				m.viewMode = ViewImprovement
+				return m, nil
+			}
+		}
+		return m, tea.Quit
+
+	case ImprovementSubmittedMsg:
+		if m.tracker != nil && msg.Text != "" {
+			configDir, err := tasks.GetConfigDirPath()
+			if err == nil {
+				if writeErr := tasks.WriteImprovement(configDir, m.tracker.GetSessionID(), msg.Text); writeErr != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to save improvement: %v\n", writeErr)
+				}
+			}
+		}
+		return m, tea.Quit
+
+	case ImprovementSkippedMsg:
+		return m, tea.Quit
+
 	case FlashMsg:
 		m.flash = msg.Text
 		return m, ClearFlashCmd()
@@ -329,9 +361,19 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateValues(msg)
 	case ViewFeedback:
 		return m.updateFeedback(msg)
+	case ViewImprovement:
+		return m.updateImprovement(msg)
 	}
 
 	return m, nil
+}
+
+func (m *MainModel) updateImprovement(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.improvementView == nil {
+		return m, nil
+	}
+	cmd := m.improvementView.Update(msg)
+	return m, cmd
 }
 
 func (m *MainModel) updateDoors(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -339,7 +381,7 @@ func (m *MainModel) updateDoors(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":
-			return m, tea.Quit
+			return m, func() tea.Msg { return RequestQuitMsg{} }
 		case "a", "left":
 			m.doorsView.selectedDoorIndex = 0
 		case "w", "up":
@@ -483,6 +525,10 @@ func (m *MainModel) View() string {
 	case ViewFeedback:
 		if m.feedbackView != nil {
 			view = m.feedbackView.View()
+		}
+	case ViewImprovement:
+		if m.improvementView != nil {
+			view = m.improvementView.View()
 		}
 	default:
 		view = m.doorsView.View()

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -87,6 +87,18 @@ type DoorFeedbackMsg struct {
 	Comment      string
 }
 
+// RequestQuitMsg is sent when the user requests to quit.
+// MainModel intercepts this to show the improvement prompt if criteria are met.
+type RequestQuitMsg struct{}
+
+// ImprovementSubmittedMsg is sent when the user submits an improvement suggestion.
+type ImprovementSubmittedMsg struct {
+	Text string
+}
+
+// ImprovementSkippedMsg is sent when the user skips the improvement prompt.
+type ImprovementSkippedMsg struct{}
+
 // ReturnToSearchMsg is sent to restore search view from detail view.
 type ReturnToSearchMsg struct {
 	Query         string

--- a/internal/tui/search_view.go
+++ b/internal/tui/search_view.go
@@ -162,7 +162,7 @@ func (sv *SearchView) executeCommand() tea.Cmd {
 		}
 
 	case "quit", "exit":
-		return tea.Quit
+		return func() tea.Msg { return RequestQuitMsg{} }
 
 	case "":
 		return nil

--- a/internal/tui/search_view_test.go
+++ b/internal/tui/search_view_test.go
@@ -436,7 +436,7 @@ func TestSearchView_QuitCommand_SendsQuit(t *testing.T) {
 	if cmd == nil {
 		t.Fatal(":quit should return a command")
 	}
-	// tea.Quit returns a special batch message
+	// :quit sends RequestQuitMsg which triggers quit flow
 }
 
 func TestSearchView_ExitCommand_SendsQuit(t *testing.T) {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -135,6 +135,10 @@ var (
 				Bold(true).
 				Foreground(lipgloss.Color("214"))
 
+	improvementHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("86"))
+
 	valuesFooterSeparator = "  ·  "
 
 	valuesSelectedPrefix = "▸ "


### PR DESCRIPTION
## Summary

- Adds an exit prompt that asks users for one improvement suggestion per session
- Triggers when session is 5+ minutes OR user has completed 1+ tasks
- Saves responses to `~/.threedoors/improvements.txt` with timestamp and session ID
- Users can skip with Esc or submit with Enter

## Changes

### New Files
- `internal/tui/improvement_view.go` — TUI view with text input for improvement prompt
- `internal/tui/improvement_view_test.go` — Tests for render, input, submit, skip, char limit
- `internal/tasks/improvement_writer.go` — Append-only file writer for improvements.txt
- `internal/tasks/improvement_writer_test.go` — Tests for file creation, append, format
- `docs/stories/3.6.story.md` — Story spec

### Modified Files
- `internal/tui/main_model.go` — Added `ViewImprovement`, `RequestQuitMsg` intercept, improvement view wiring
- `internal/tui/messages.go` — Added `RequestQuitMsg`, `ImprovementSubmittedMsg`, `ImprovementSkippedMsg`
- `internal/tui/styles.go` — Added `improvementHeaderStyle`
- `internal/tui/search_view.go` — Changed `:quit`/`:exit` to send `RequestQuitMsg`
- `internal/tasks/session_tracker.go` — Added `GetMetricsSnapshot()`, `GetSessionID()`, `MetricsSnapshot` type
- `cmd/threedoors/main_test.go` — Updated quit tests for two-step flow
- `internal/tui/search_view_test.go` — Updated comment

## Architecture

Quit paths (`q`, `ctrl+c`, `:quit`, `:exit`) now send `RequestQuitMsg` instead of `tea.Quit`. The `MainModel` intercepts this, checks session criteria via `GetMetricsSnapshot()`, and either shows the improvement view or quits immediately. This follows the same modal view pattern used by feedback_view and mood_view.

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes (all packages)
- [x] `gofumpt -d .` produces no output
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Improvement view renders correctly
- [x] Enter submits, Esc skips, backspace works, char limit enforced
- [x] ImprovementWriter creates file, appends multiple entries, formats correctly
- [x] Existing quit tests updated and passing

## Dependencies

- Depends on: Story 3.5 (PR #28, merged)
- FR covered: FR9 (Session improvement prompt)