### PR TITLE
feat: Story 3.7 - Enhanced Navigation & Messaging

### DIFF
--- a/_bmad-output/implementation-artifacts/3.7.story.md
+++ b/_bmad-output/implementation-artifacts/3.7.story.md
@@ -1,0 +1,106 @@
+# Story 3.7: Enhanced Navigation & Messaging
+
+Status: ready-for-dev
+
+## Story
+
+As a user,
+I want richer choose-your-own-adventure navigation and enhanced "progress over perfection" messaging,
+So that the app feels like a supportive partner rather than a demanding taskmaster.
+
+## Acceptance Criteria
+
+1. **Contextual Encouraging Messages:** When the user performs actions (complete task, open door, refresh, add task), contextual encouraging messages are shown that vary (not always the same).
+2. **Progress Over Perfection Philosophy:** All messages embody "progress over perfection" philosophy and celebrate any action as progress.
+3. **Adaptive Next-Step Options:** At decision points (e.g., after completing a task), 3-5 contextual next steps are shown (not just "return to doors").
+4. **State-Aware Options:** Options adapt based on state (e.g., "add another task", "review blocked tasks", "check stats", "take a break").
+
+## Technical Design
+
+### New File: `internal/tui/next_steps_view.go`
+
+A modal view (like `FeedbackView`) that shows contextual next-step options after key actions. Uses numbered key selection (1-N) and Esc to dismiss.
+
+**Trigger contexts:**
+- After task completion (`TaskCompletedMsg`)
+- After adding a task (`TaskAddedMsg`)
+
+**State-aware option generation:**
+- Queries `pool.GetTasksByStatus()` for blocked tasks count
+- Queries `pool.Count()` for total task count
+- Queries `completionCounter` for daily stats
+- Queries `tracker.GetMetricsSnapshot()` for session info
+
+### New Message Pools in `styles.go`
+
+Add action-specific encouraging message pools:
+- `taskCompletedMessages` — celebration messages (expand existing `celebrationMessages`)
+- `taskAddedMessages` — messages for when a task is added
+- `doorRefreshMessages` — messages for when doors are re-rolled
+
+### Changes to `main_model.go`
+
+- Add `ViewNextSteps` to `ViewMode` enum
+- Add `nextStepsView *NextStepsView` field
+- Wire `ShowNextStepsMsg` and `NextStepSelectedMsg` handlers
+- Modify `TaskCompletedMsg` and `TaskAddedMsg` to show next-steps view
+- Add `updateNextSteps` delegate method
+
+### Changes to `messages.go`
+
+- Add `ShowNextStepsMsg` with `Context string` field (what triggered it)
+- Add `NextStepSelectedMsg` with `Action string` field
+- Add `NextStepDismissedMsg`
+
+### Changes to `doors_view.go`
+
+- Update the static "Progress over perfection" footer to rotate through encouraging messages
+- Add refresh-triggered flash messages
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Add Message Pools** (AC: 1, 2)
+  - [ ] 1.1: Add `taskAddedMessages` pool to `styles.go` (8-10 encouraging messages)
+  - [ ] 1.2: Add `doorRefreshMessages` pool to `styles.go` (6-8 messages)
+  - [ ] 1.3: Add next-steps header/option styles to `styles.go`
+  - [ ] 1.4: Replace static footer in `doors_view.go` with rotating messages
+
+- [ ] **Task 2: Add New Message Types** (AC: 3, 4)
+  - [ ] 2.1: Add `ShowNextStepsMsg` type to `messages.go`
+  - [ ] 2.2: Add `NextStepSelectedMsg` type to `messages.go`
+  - [ ] 2.3: Add `NextStepDismissedMsg` type to `messages.go`
+
+- [ ] **Task 3: Create NextStepsView** (AC: 3, 4)
+  - [ ] 3.1: Create `internal/tui/next_steps_view.go` with `NextStepsView` struct
+  - [ ] 3.2: Implement `NewNextStepsView()` constructor that takes context and pool state
+  - [ ] 3.3: Implement `generateOptions()` for state-aware option list
+  - [ ] 3.4: Implement `Update()` with numbered key selection and Esc dismiss
+  - [ ] 3.5: Implement `View()` rendering with encouraging header and options
+  - [ ] 3.6: Implement `SetWidth()` for responsive layout
+
+- [ ] **Task 4: Wire into MainModel** (AC: 1, 2, 3, 4)
+  - [ ] 4.1: Add `ViewNextSteps` to `ViewMode` enum
+  - [ ] 4.2: Add `nextStepsView` field to `MainModel`
+  - [ ] 4.3: Handle `ShowNextStepsMsg` — create view and transition
+  - [ ] 4.4: Handle `NextStepSelectedMsg` — dispatch to appropriate action
+  - [ ] 4.5: Handle `NextStepDismissedMsg` — return to doors
+  - [ ] 4.6: Modify `TaskCompletedMsg` to show next-steps after completion
+  - [ ] 4.7: Modify `TaskAddedMsg` to show next-steps after adding
+  - [ ] 4.8: Add `updateNextSteps` delegate method
+  - [ ] 4.9: Add `ViewNextSteps` to `View()` switch
+  - [ ] 4.10: Wire `WindowSizeMsg` for next-steps view
+  - [ ] 4.11: Add contextual flash messages for door refresh
+
+- [ ] **Task 5: Write Tests** (AC: 1, 2, 3, 4)
+  - [ ] 5.1: Create `next_steps_view_test.go` — test option generation for different contexts
+  - [ ] 5.2: Test state-aware options (blocked tasks present/absent, etc.)
+  - [ ] 5.3: Test key handling (numbered selection, Esc dismiss)
+  - [ ] 5.4: Test message pool randomization in main_model
+  - [ ] 5.5: Update `main_model_test.go` for new view mode and message handling
+
+## Dev Notes
+
+- Follow `FeedbackView` pattern for the new `NextStepsView`
+- Keep messages warm and encouraging, never judgmental
+- Options should feel like a "choose your own adventure" — every choice is valid
+- The view should be lightweight — no heavy state, just contextual rendering

--- a/internal/tui/doors_view.go
+++ b/internal/tui/doors_view.go
@@ -18,6 +18,7 @@ type DoorsView struct {
 	width             int
 	tracker           *tasks.SessionTracker
 	greeting          string
+	footerMessage     string
 }
 
 // NewDoorsView creates a new DoorsView.
@@ -27,6 +28,7 @@ func NewDoorsView(pool *tasks.TaskPool, tracker *tasks.SessionTracker) *DoorsVie
 		selectedDoorIndex: -1,
 		tracker:           tracker,
 		greeting:          pickGreeting(-1),
+		footerMessage:     pickFooterMessage(-1),
 	}
 	dv.RefreshDoors()
 	return dv
@@ -47,6 +49,24 @@ func pickGreeting(lastIdx int) string {
 // Greeting returns the current startup greeting message.
 func (dv *DoorsView) Greeting() string {
 	return dv.greeting
+}
+
+// pickFooterMessage selects a random footer message from the greeting pool,
+// avoiding lastIdx to prevent consecutive repeats.
+func pickFooterMessage(lastIdx int) string {
+	if len(greetingMessages) <= 1 {
+		return greetingMessages[0]
+	}
+	idx := rand.IntN(len(greetingMessages))
+	for idx == lastIdx {
+		idx = rand.IntN(len(greetingMessages))
+	}
+	return greetingMessages[idx]
+}
+
+// RotateFooterMessage picks a new footer message (called on refresh/return).
+func (dv *DoorsView) RotateFooterMessage() {
+	dv.footerMessage = pickFooterMessage(-1)
 }
 
 // RefreshDoors selects new random doors from the pool.
@@ -126,7 +146,7 @@ func (dv *DoorsView) View() string {
 	s.WriteString("\n\n")
 	s.WriteString(helpStyle.Render("a/left, w/up, d/right to select | s/down to re-roll | Enter to open | N feedback | / search | M mood | q quit"))
 	s.WriteString("\n")
-	s.WriteString(greetingStyle.Render("Progress over perfection. Just pick one and start."))
+	s.WriteString(greetingStyle.Render(dv.footerMessage))
 
 	return s.String()
 }

--- a/internal/tui/doors_view_test.go
+++ b/internal/tui/doors_view_test.go
@@ -125,12 +125,20 @@ func TestDoorsView_View_CompletionCounter_ZeroNotShown(t *testing.T) {
 	}
 }
 
-func TestDoorsView_View_ProgressMessage(t *testing.T) {
+func TestDoorsView_View_FooterMessage(t *testing.T) {
 	dv := newTestDoorsView("t1", "t2", "t3")
 	dv.SetWidth(80)
 	view := dv.View()
-	if !strings.Contains(view, "Progress over perfection") {
-		t.Error("View should contain 'Progress over perfection' message")
+	// Footer should contain one of the greeting messages (rotating pool)
+	found := false
+	for _, msg := range greetingMessages {
+		if strings.Contains(view, msg) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("View should contain a footer message from the greeting pool")
 	}
 }
 

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -23,6 +23,7 @@ const (
 	ViewValuesGoals
 	ViewFeedback
 	ViewImprovement
+	ViewNextSteps
 )
 
 // MainModel is the root Bubbletea model that orchestrates view transitions.
@@ -38,6 +39,7 @@ type MainModel struct {
 	valuesView          *ValuesView
 	feedbackView        *FeedbackView
 	improvementView     *ImprovementView
+	nextStepsView       *NextStepsView
 	pool                *tasks.TaskPool
 	tracker             *tasks.SessionTracker
 	provider            tasks.TaskProvider
@@ -119,6 +121,9 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.improvementView != nil {
 			m.improvementView.SetWidth(msg.Width)
+		}
+		if m.nextStepsView != nil {
+			m.nextStepsView.SetWidth(msg.Width)
 		}
 		return m, nil
 
@@ -204,17 +209,19 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err := m.saveTasks(); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to save tasks: %v\n", err)
 		}
-		m.flash = "Task added"
+		m.flash = taskAddedMessages[rand.IntN(len(taskAddedMessages))]
 		m.addTaskView = nil
-		// Return to previous view if it was search, otherwise doors
+		// Return to previous view if it was search, otherwise show next steps
 		if m.previousView == ViewSearch {
 			m.searchView = NewSearchView(m.pool, m.tracker, m.healthChecker, m.completionCounter)
 			m.searchView.SetWidth(m.width)
 			m.viewMode = ViewSearch
 			m.previousView = ViewDoors
 		} else {
-			m.viewMode = ViewDoors
 			m.doorsView.RefreshDoors()
+			m.nextStepsView = NewNextStepsView("added", m.pool, m.completionCounter)
+			m.nextStepsView.SetWidth(m.width)
+			m.viewMode = ViewNextSteps
 		}
 		return m, ClearFlashCmd()
 
@@ -232,9 +239,12 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			celebration += " | " + dailyMsg
 		}
 		m.flash = celebration
-		m.viewMode = ViewDoors
 		m.detailView = nil
 		m.doorsView.RefreshDoors()
+		// Show next-steps view instead of returning directly to doors
+		m.nextStepsView = NewNextStepsView("completed", m.pool, m.completionCounter)
+		m.nextStepsView.SetWidth(m.width)
+		m.viewMode = ViewNextSteps
 		return m, ClearFlashCmd()
 
 	case TaskUpdatedMsg:
@@ -338,6 +348,48 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ImprovementSkippedMsg:
 		return m, tea.Quit
 
+	case ShowNextStepsMsg:
+		m.nextStepsView = NewNextStepsView(msg.Context, m.pool, m.completionCounter)
+		m.nextStepsView.SetWidth(m.width)
+		m.viewMode = ViewNextSteps
+		return m, nil
+
+	case NextStepSelectedMsg:
+		m.nextStepsView = nil
+		switch msg.Action {
+		case "doors":
+			m.viewMode = ViewDoors
+			m.doorsView.RefreshDoors()
+			m.doorsView.RotateFooterMessage()
+		case "add":
+			return m, func() tea.Msg { return AddTaskPromptMsg{} }
+		case "mood":
+			return m, func() tea.Msg { return ShowMoodMsg{} }
+		case "search":
+			m.searchView = NewSearchView(m.pool, m.tracker, m.healthChecker, m.completionCounter)
+			m.searchView.SetWidth(m.width)
+			m.viewMode = ViewSearch
+			m.previousView = ViewDoors
+		case "stats":
+			m.searchView = NewSearchView(m.pool, m.tracker, m.healthChecker, m.completionCounter)
+			m.searchView.SetWidth(m.width)
+			m.searchView.textInput.SetValue(":stats")
+			m.searchView.checkCommandMode()
+			m.viewMode = ViewSearch
+			m.previousView = ViewDoors
+		default:
+			m.viewMode = ViewDoors
+			m.doorsView.RefreshDoors()
+		}
+		return m, nil
+
+	case NextStepDismissedMsg:
+		m.nextStepsView = nil
+		m.viewMode = ViewDoors
+		m.doorsView.RefreshDoors()
+		m.doorsView.RotateFooterMessage()
+		return m, nil
+
 	case FlashMsg:
 		m.flash = msg.Text
 		return m, ClearFlashCmd()
@@ -363,6 +415,8 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateFeedback(msg)
 	case ViewImprovement:
 		return m.updateImprovement(msg)
+	case ViewNextSteps:
+		return m.updateNextSteps(msg)
 	}
 
 	return m, nil
@@ -393,6 +447,9 @@ func (m *MainModel) updateDoors(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.tracker.RecordRefresh(m.doorsView.GetCurrentDoorTexts())
 			}
 			m.doorsView.RefreshDoors()
+			m.doorsView.RotateFooterMessage()
+			m.flash = doorRefreshMessages[rand.IntN(len(doorRefreshMessages))]
+			return m, ClearFlashCmd()
 		case "enter":
 			if m.doorsView.selectedDoorIndex >= 0 && m.doorsView.selectedDoorIndex < len(m.doorsView.currentDoors) {
 				task := m.doorsView.currentDoors[m.doorsView.selectedDoorIndex]
@@ -477,6 +534,14 @@ func (m *MainModel) updateFeedback(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *MainModel) updateNextSteps(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.nextStepsView == nil {
+		return m, nil
+	}
+	cmd := m.nextStepsView.Update(msg)
+	return m, cmd
+}
+
 func (m *MainModel) updateValues(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.valuesView == nil {
 		return m, nil
@@ -530,6 +595,11 @@ func (m *MainModel) View() string {
 		if m.improvementView != nil {
 			view = m.improvementView.View()
 		}
+	case ViewNextSteps:
+		if m.nextStepsView != nil {
+			view = m.nextStepsView.View()
+		}
+		showValuesFooter = true
 	default:
 		view = m.doorsView.View()
 		showValuesFooter = true

--- a/internal/tui/main_model_test.go
+++ b/internal/tui/main_model_test.go
@@ -317,8 +317,19 @@ func TestDoorsView_CompletionCounter_ShowsAfterCompletion(t *testing.T) {
 	m.Update(keyMsg("w"))
 	m.Update(keyMsg("enter"))
 
-	// Complete the task
+	// Complete the task — now goes to ViewNextSteps
 	_, cmd := m.Update(keyMsg("c"))
+	if cmd != nil {
+		msg := cmd()
+		m.Update(msg)
+	}
+
+	if m.viewMode != ViewNextSteps {
+		t.Errorf("expected ViewNextSteps after completion, got %d", m.viewMode)
+	}
+
+	// Dismiss next steps to return to doors
+	_, cmd = m.Update(keyMsg("esc"))
 	if cmd != nil {
 		msg := cmd()
 		m.Update(msg)
@@ -612,7 +623,7 @@ func TestAddTaskPromptMsg_TransitionsToAddTaskView(t *testing.T) {
 	}
 }
 
-// T8: TaskAddedMsg adds to pool, sets flash
+// T8: TaskAddedMsg adds to pool, sets flash from message pool
 func TestTaskAddedMsg_AddsToPool(t *testing.T) {
 	m := makeModel("task1", "task2", "task3")
 	initialCount := m.pool.Count()
@@ -623,8 +634,16 @@ func TestTaskAddedMsg_AddsToPool(t *testing.T) {
 	if m.pool.Count() != initialCount+1 {
 		t.Errorf("expected pool count %d, got %d", initialCount+1, m.pool.Count())
 	}
-	if m.flash != "Task added" {
-		t.Errorf("expected flash 'Task added', got %q", m.flash)
+	// Flash should be one of the task-added messages from the pool
+	found := false
+	for _, msg := range taskAddedMessages {
+		if m.flash == msg {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("flash message %q not found in taskAddedMessages pool", m.flash)
 	}
 }
 
@@ -677,8 +696,8 @@ func TestTaskAddedMsg_FromSearch_ReturnsToSearch(t *testing.T) {
 	}
 }
 
-// TaskAddedMsg from doors context returns to doors
-func TestTaskAddedMsg_FromDoors_ReturnsToDoors(t *testing.T) {
+// TaskAddedMsg from doors context shows next-steps view
+func TestTaskAddedMsg_FromDoors_ShowsNextSteps(t *testing.T) {
 	m := makeModel("task1", "task2", "task3")
 	m.previousView = ViewDoors
 	m.viewMode = ViewAddTask
@@ -686,8 +705,11 @@ func TestTaskAddedMsg_FromDoors_ReturnsToDoors(t *testing.T) {
 	newTask := tasks.NewTask("new task from doors")
 	m.Update(TaskAddedMsg{Task: newTask})
 
-	if m.viewMode != ViewDoors {
-		t.Errorf("expected ViewDoors after TaskAddedMsg from doors context, got %d", m.viewMode)
+	if m.viewMode != ViewNextSteps {
+		t.Errorf("expected ViewNextSteps after TaskAddedMsg from doors context, got %d", m.viewMode)
+	}
+	if m.nextStepsView == nil {
+		t.Error("nextStepsView should not be nil")
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -99,6 +99,19 @@ type ImprovementSubmittedMsg struct {
 // ImprovementSkippedMsg is sent when the user skips the improvement prompt.
 type ImprovementSkippedMsg struct{}
 
+// ShowNextStepsMsg is sent to open the contextual next-steps view.
+type ShowNextStepsMsg struct {
+	Context string // what triggered it: "completed", "added"
+}
+
+// NextStepSelectedMsg is sent when the user picks a next-step option.
+type NextStepSelectedMsg struct {
+	Action string // action identifier: "doors", "add", "mood", "search", "stats"
+}
+
+// NextStepDismissedMsg is sent when the user dismisses the next-steps view.
+type NextStepDismissedMsg struct{}
+
 // ReturnToSearchMsg is sent to restore search view from detail view.
 type ReturnToSearchMsg struct {
 	Query         string

--- a/internal/tui/next_steps_view.go
+++ b/internal/tui/next_steps_view.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// NextStepOption represents a single selectable option in the next-steps view.
+type NextStepOption struct {
+	Label  string
+	Action string // action identifier dispatched via NextStepSelectedMsg
+}
+
+// NextStepsView displays contextual next-step options after key actions.
+type NextStepsView struct {
+	context string // "completed" or "added"
+	header  string
+	options []NextStepOption
+	width   int
+}
+
+// NewNextStepsView creates a new NextStepsView with context-aware options.
+func NewNextStepsView(context string, pool *tasks.TaskPool, cc *tasks.CompletionCounter) *NextStepsView {
+	nv := &NextStepsView{context: context}
+	nv.generateOptions(context, pool, cc)
+	return nv
+}
+
+func (nv *NextStepsView) generateOptions(context string, pool *tasks.TaskPool, cc *tasks.CompletionCounter) {
+	switch context {
+	case "completed":
+		nv.header = pickCompletionHeader(cc)
+		nv.options = generateCompletionOptions(pool)
+	case "added":
+		nv.header = "Task captured! What's next?"
+		nv.options = generateAddedOptions(pool)
+	default:
+		nv.header = "What would you like to do next?"
+		nv.options = defaultOptions()
+	}
+}
+
+func pickCompletionHeader(cc *tasks.CompletionCounter) string {
+	if cc != nil {
+		today := cc.GetTodayCount()
+		if today >= 5 {
+			return "You're on fire! 5+ tasks today. What's next?"
+		}
+		if today >= 3 {
+			return "Great momentum! Keep it rolling?"
+		}
+	}
+	return "Nice work! What would you like to do next?"
+}
+
+func generateCompletionOptions(pool *tasks.TaskPool) []NextStepOption {
+	options := []NextStepOption{
+		{Label: "Open another door", Action: "doors"},
+	}
+
+	if pool.Count() > 0 {
+		blocked := pool.GetTasksByStatus(tasks.StatusBlocked)
+		if len(blocked) > 0 {
+			options = append(options, NextStepOption{
+				Label:  fmt.Sprintf("Review blocked tasks (%d)", len(blocked)),
+				Action: "search",
+			})
+		}
+	}
+
+	options = append(options, NextStepOption{Label: "Add a new task", Action: "add"})
+	options = append(options, NextStepOption{Label: "Check stats", Action: "stats"})
+	options = append(options, NextStepOption{Label: "Log your mood", Action: "mood"})
+
+	return options
+}
+
+func generateAddedOptions(pool *tasks.TaskPool) []NextStepOption {
+	options := []NextStepOption{
+		{Label: "Back to doors", Action: "doors"},
+		{Label: "Add another task", Action: "add"},
+	}
+
+	if pool.Count() > 0 {
+		options = append(options, NextStepOption{Label: "Search tasks", Action: "search"})
+	}
+
+	return options
+}
+
+func defaultOptions() []NextStepOption {
+	return []NextStepOption{
+		{Label: "Back to doors", Action: "doors"},
+		{Label: "Add a new task", Action: "add"},
+		{Label: "Log your mood", Action: "mood"},
+	}
+}
+
+// SetWidth sets the terminal width.
+func (nv *NextStepsView) SetWidth(w int) {
+	nv.width = w
+}
+
+// Update handles key input for next-step selection.
+func (nv *NextStepsView) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return func() tea.Msg { return NextStepDismissedMsg{} }
+		default:
+			// Handle number key selection (1-based)
+			if len(msg.String()) == 1 {
+				key := msg.String()[0]
+				if key >= '1' && key <= '9' {
+					idx := int(key - '1')
+					if idx < len(nv.options) {
+						action := nv.options[idx].Action
+						return func() tea.Msg { return NextStepSelectedMsg{Action: action} }
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// View renders the next-steps view.
+func (nv *NextStepsView) View() string {
+	s := strings.Builder{}
+	s.WriteString(nextStepsHeaderStyle.Render(nv.header))
+	s.WriteString("\n\n")
+
+	for i, opt := range nv.options {
+		line := fmt.Sprintf("  %d. %s", i+1, opt.Label)
+		s.WriteString(nextStepsOptionStyle.Render(line))
+		s.WriteString("\n")
+	}
+
+	s.WriteString("\n")
+	s.WriteString(helpStyle.Render(fmt.Sprintf("Press 1-%d to select | Esc to return to doors", len(nv.options))))
+
+	w := nv.width - 6
+	if w < 40 {
+		w = 40
+	}
+	return detailBorder.Width(w).Render(s.String())
+}

--- a/internal/tui/next_steps_view_test.go
+++ b/internal/tui/next_steps_view_test.go
@@ -1,0 +1,276 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// --- Option Generation ---
+
+func TestNextStepsView_CompletionContext_HasDoorOption(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "doors" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("completion context should have 'doors' option")
+	}
+}
+
+func TestNextStepsView_CompletionContext_HasAddOption(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "add" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("completion context should have 'add' option")
+	}
+}
+
+func TestNextStepsView_CompletionContext_HasMoodOption(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "mood" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("completion context should have 'mood' option")
+	}
+}
+
+func TestNextStepsView_CompletionContext_HasStatsOption(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "stats" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("completion context should have 'stats' option")
+	}
+}
+
+func TestNextStepsView_CompletionContext_BlockedTasks_ShowsReviewOption(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	// Set one task as blocked
+	for _, task := range pool.GetAllTasks() {
+		_ = task.UpdateStatus(tasks.StatusBlocked)
+		break
+	}
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "search" && strings.Contains(opt.Label, "blocked") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("completion context with blocked tasks should have 'review blocked' option")
+	}
+}
+
+func TestNextStepsView_CompletionContext_NoBlockedTasks_NoReviewOption(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	for _, opt := range nv.options {
+		if strings.Contains(opt.Label, "blocked") {
+			t.Error("completion context without blocked tasks should not have 'review blocked' option")
+		}
+	}
+}
+
+func TestNextStepsView_AddedContext_HasBackToDoors(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("added", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "doors" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("added context should have 'doors' option")
+	}
+}
+
+func TestNextStepsView_AddedContext_HasAddAnother(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("added", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "add" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("added context should have 'add' option")
+	}
+}
+
+func TestNextStepsView_AddedContext_HasSearchOption(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("added", pool, tasks.NewCompletionCounter())
+	found := false
+	for _, opt := range nv.options {
+		if opt.Action == "search" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("added context should have 'search' option when pool has tasks")
+	}
+}
+
+func TestNextStepsView_MinimumOptions(t *testing.T) {
+	pool := makePool("task1")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	if len(nv.options) < 3 {
+		t.Errorf("next steps should have at least 3 options, got %d", len(nv.options))
+	}
+}
+
+// --- Key Handling ---
+
+func TestNextStepsView_NumberKeySelects(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	nv.SetWidth(80)
+
+	cmd := nv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")})
+	if cmd == nil {
+		t.Fatal("pressing '1' should return a command")
+	}
+	msg := cmd()
+	nsm, ok := msg.(NextStepSelectedMsg)
+	if !ok {
+		t.Fatalf("expected NextStepSelectedMsg, got %T", msg)
+	}
+	if nsm.Action != nv.options[0].Action {
+		t.Errorf("expected action %q, got %q", nv.options[0].Action, nsm.Action)
+	}
+}
+
+func TestNextStepsView_InvalidNumberKey_NoOp(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+
+	// Press a number beyond the options count
+	key := fmt.Sprintf("%d", len(nv.options)+1)
+	cmd := nv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+	if cmd != nil {
+		t.Error("pressing an out-of-range number should be a no-op")
+	}
+}
+
+func TestNextStepsView_EscDismisses(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+
+	cmd := nv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("Esc should return a command")
+	}
+	msg := cmd()
+	if _, ok := msg.(NextStepDismissedMsg); !ok {
+		t.Errorf("expected NextStepDismissedMsg, got %T", msg)
+	}
+}
+
+// --- View Rendering ---
+
+func TestNextStepsView_RendersHeader(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	nv.SetWidth(80)
+	view := nv.View()
+	if !strings.Contains(view, "next") && !strings.Contains(view, "Nice") && !strings.Contains(view, "fire") && !strings.Contains(view, "momentum") {
+		t.Errorf("View should contain a header message, got: %s", view)
+	}
+}
+
+func TestNextStepsView_RendersOptions(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	nv.SetWidth(80)
+	view := nv.View()
+	for i, opt := range nv.options {
+		expected := fmt.Sprintf("%d. %s", i+1, opt.Label)
+		if !strings.Contains(view, expected) {
+			t.Errorf("View should contain option %q", expected)
+		}
+	}
+}
+
+func TestNextStepsView_RendersHelpText(t *testing.T) {
+	pool := makePool("task1", "task2", "task3")
+	nv := NewNextStepsView("completed", pool, tasks.NewCompletionCounter())
+	nv.SetWidth(80)
+	view := nv.View()
+	if !strings.Contains(view, "Esc") {
+		t.Error("View should contain Esc in help text")
+	}
+}
+
+// --- Completion Header Variants ---
+
+func TestPickCompletionHeader_HighCount(t *testing.T) {
+	cc := tasks.NewCompletionCounter()
+	for i := 0; i < 5; i++ {
+		cc.IncrementToday()
+	}
+	header := pickCompletionHeader(cc)
+	if !strings.Contains(header, "fire") {
+		t.Errorf("expected 'fire' header for 5+ completions, got %q", header)
+	}
+}
+
+func TestPickCompletionHeader_MediumCount(t *testing.T) {
+	cc := tasks.NewCompletionCounter()
+	for i := 0; i < 3; i++ {
+		cc.IncrementToday()
+	}
+	header := pickCompletionHeader(cc)
+	if !strings.Contains(header, "momentum") {
+		t.Errorf("expected 'momentum' header for 3+ completions, got %q", header)
+	}
+}
+
+func TestPickCompletionHeader_LowCount(t *testing.T) {
+	cc := tasks.NewCompletionCounter()
+	header := pickCompletionHeader(cc)
+	if !strings.Contains(header, "Nice") {
+		t.Errorf("expected 'Nice' header for low count, got %q", header)
+	}
+}
+
+func TestPickCompletionHeader_NilCounter(t *testing.T) {
+	header := pickCompletionHeader(nil)
+	if !strings.Contains(header, "Nice") {
+		t.Errorf("expected 'Nice' header for nil counter, got %q", header)
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -106,6 +106,36 @@ var (
 		"Well done! The best task is a done task.",
 	}
 
+	// Task-added messages pool — encouraging messages after adding a task
+	taskAddedMessages = []string{
+		"Task captured! Every task written down is a weight lifted.",
+		"Added! Getting it out of your head is step one.",
+		"New task logged. You're staying on top of things.",
+		"Got it! One more thing you won't forget.",
+		"Task added. Naming it is half the battle.",
+		"Captured! Your future self will thank you.",
+		"Added to the mix. Progress starts with awareness.",
+		"Logged! You're building momentum just by tracking.",
+	}
+
+	// Door-refresh messages pool — encouraging messages when re-rolling doors
+	doorRefreshMessages = []string{
+		"Fresh options! Sometimes a new perspective helps.",
+		"New doors, new possibilities.",
+		"Shuffled! Trust your gut on the next pick.",
+		"Re-rolled. Every choice is a good one.",
+		"New set! The right task will catch your eye.",
+		"Fresh draw. No wrong answers here.",
+	}
+
+	// Next-steps view styles
+	nextStepsHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("86"))
+
+	nextStepsOptionStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("252"))
+
 	// Health check styles
 	healthOKStyle = lipgloss.NewStyle().
 			Foreground(colorComplete).


### PR DESCRIPTION
## Summary

- **New NextStepsView** — contextual choose-your-own-adventure modal shown after task completion and task addition, offering 3-5 state-aware options (open another door, add task, review blocked tasks, check stats, log mood)
- **Encouraging message pools** — 8 task-added messages, 6 door-refresh messages, and rotating footer messages replace static text throughout the app
- **Adaptive headers** — completion header changes based on daily count ("on fire" at 5+, "great momentum" at 3+, "nice work" default)
- **State-aware options** — blocked task review option only appears when blocked tasks exist; search option adapts to pool state

### Files Changed
| File | Change |
|------|--------|
| `internal/tui/next_steps_view.go` | New modal view with context-aware option generation |
| `internal/tui/next_steps_view_test.go` | 20 tests covering options, keys, rendering, headers |
| `internal/tui/messages.go` | 3 new message types (ShowNextSteps, NextStepSelected, NextStepDismissed) |
| `internal/tui/styles.go` | 2 new message pools, 2 new styles |
| `internal/tui/main_model.go` | ViewNextSteps mode, handlers, wiring |
| `internal/tui/main_model_test.go` | Updated tests for new navigation flow |
| `internal/tui/doors_view.go` | Rotating footer messages |
| `internal/tui/doors_view_test.go` | Updated footer test |
| `_bmad-output/implementation-artifacts/3.7.story.md` | Story spec |

### Opportunities (not implemented)
- Could add next-steps after mood capture and door feedback too
- Streak-aware messaging (e.g., "3 day streak!" celebration variant)
- Configurable message pools via user config

## Test plan
- [x] All existing tests pass (updated 4 tests for new flow)
- [x] 20 new tests for NextStepsView
- [x] `go test ./...` passes
- [x] `make lint` clean (0 issues)
- [x] `make fmt` applied