### PR TITLE
docs: PR analysis-derived quality gates, NFRs, and coding standards

### DIFF
--- a/docs/architecture/coding-standards.md
+++ b/docs/architecture/coding-standards.md
@@ -104,4 +104,133 @@
 
 **Reference Implementation:** See `FileManager.SaveTasks()` in Section 5 (Components)
 
+## PR-Analysis-Derived Rules (Mandatory)
+
+> These rules are derived from analysis of all 49 PRs (#1–#49). Each rule prevents a specific class of defect that recurred across multiple PRs.
+
+### Rule 9: Always use fmt.Fprintf, never WriteString+Sprintf
+
+**MUST Follow:**
+
+```go
+// ❌ WRONG — triggers staticcheck QF1012, creates unnecessary allocation
+buf.WriteString(fmt.Sprintf("Score: %d", score))
+
+// ✅ CORRECT — direct formatted write
+fmt.Fprintf(buf, "Score: %d", score)
+```
+
+This applies to ALL `*bytes.Buffer`, `*strings.Builder`, and any `io.Writer`. No exceptions.
+
+*Evidence: 11+ violations across PRs #42, #44, #45 required 5 fix-up commits. This was the single most recurring lint failure in the project.*
+
+### Rule 10: Check ALL error return values — including Close, Remove, WriteFile
+
+**MUST Follow:**
+
+```go
+// ❌ WRONG — errcheck violation
+defer f.Close()
+
+// ✅ CORRECT — check error on writable file handles
+defer func() {
+    if cerr := f.Close(); cerr != nil && err == nil {
+        err = fmt.Errorf("closing file: %w", cerr)
+    }
+}()
+
+// ❌ WRONG — ignoring cleanup error
+os.Remove(tempPath)
+
+// ✅ CORRECT — check or explicitly document why ignored
+if err := os.Remove(tempPath); err != nil && !os.IsNotExist(err) {
+    log.Printf("warning: failed to clean up temp file: %v", err)
+}
+```
+
+In test code, use `t.Helper()` patterns or `require.NoError()` — do not assign errors to `_`.
+
+*Evidence: 18+ errcheck violations across PRs #16, #42, #43. `f.Close()` was the most common offender (6 instances).*
+
+### Rule 11: Escape all user input in AppleScript/shell interpolation
+
+**MUST Follow:**
+
+```go
+// ❌ WRONG — injection vulnerability
+script := fmt.Sprintf(`tell app "Notes" to show note "%s"`, noteTitle)
+
+// ✅ CORRECT — escape for AppleScript string context
+escaped := strings.ReplaceAll(noteTitle, `\`, `\\`)
+escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+script := fmt.Sprintf(`tell app "Notes" to show note "%s"`, escaped)
+```
+
+Every dynamic command construction MUST have a corresponding test with special characters.
+
+*Evidence: PR #17 had an AppleScript injection vulnerability via unescaped note titles.*
+
+### Rule 12: Call time.Now() once per operation, reuse the result
+
+**MUST Follow:**
+
+```go
+// ❌ WRONG — inconsistent timestamps across loop iterations
+for _, task := range tasks {
+    task.ParsedAt = time.Now().UTC()
+}
+
+// ✅ CORRECT — single timestamp for the batch
+now := time.Now().UTC()
+for _, task := range tasks {
+    task.ParsedAt = now
+}
+```
+
+*Evidence: PR #17 called time.Now() inside a parseNoteBody loop.*
+
+### Rule 13: Fix lint categories by sweeping the entire codebase
+
+**MUST Follow:**
+
+When CI reports a lint violation (e.g., QF1012 on line 117), search the ENTIRE codebase for all instances of that pattern and fix them all in a single commit. Do NOT fix only the reported lines.
+
+```bash
+# After fixing a QF1012 violation, verify no others exist:
+grep -rn "WriteString(fmt.Sprintf" internal/ cmd/ --include="*.go"
+# Must produce zero results
+```
+
+*Evidence: PR #42 fixed QF1012 incrementally across 3 separate commits, each revealing new instances on different lines.*
+
+## Pre-PR Verification Checklist
+
+Run this sequence before every PR submission. All checks MUST pass:
+
+```bash
+# 1. Format
+gofumpt -l -w .
+
+# 2. Lint (zero issues required)
+golangci-lint run ./...
+
+# 3. Tests (all must pass)
+go test ./...
+
+# 4. Verify no WriteString+Sprintf anti-pattern
+! grep -rn "WriteString(fmt.Sprintf" internal/ cmd/ --include="*.go"
+
+# 5. Verify no unchecked Close on writable files
+# (manual review — look for bare `defer f.Close()` on files opened for writing)
+
+# 6. Rebase onto latest main
+git fetch upstream main && git rebase upstream/main
+
+# 7. Re-run format after rebase (rebase can introduce drift)
+gofumpt -l -w .
+
+# 8. Scope check — only story-related files changed
+git diff --stat upstream/main...HEAD
+```
+
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -1207,3 +1207,130 @@ So that Epic 4's learning algorithm is evidence-informed.
 **And** evidence assessment for "progress over perfection"
 **And** actionable recommendations for Epic 4
 **And** bibliography with accessible references
+
+---
+
+## Appendix: PR-Analysis-Derived Quality Acceptance Criteria
+
+> **Source:** Systematic analysis of all 49 PRs (#1–#49) in arcaven/ThreeDoors, examining every delta between initial PR submission and final merge. These ACs are derived from recurring defect patterns and MUST be included in all future stories.
+
+### Issue Categorization Summary
+
+Analysis of 49 PRs found 18 PRs (37%) required post-submission changes. The remaining 31 PRs (63%) merged cleanly on first submission. Issue breakdown by category:
+
+| Category | PRs Affected | % of Issues | Root Cause |
+|----------|-------------|-------------|------------|
+| **Lint/static analysis** (errcheck + staticcheck) | #16, #42, #43, #44, #45 | 23% | Code not linted before push |
+| **Logic/correctness bugs** | #14, #17, #18, #19, #44 | 16% | Insufficient edge-case thinking in ACs |
+| **Merge conflicts** | #3, #5, #19, #23, #42 | 16% | Stale branches, no pre-PR rebase |
+| **gofumpt formatting** | #9, #23, #24, #42 | 13% | Formatter not run before push |
+| **Missing test coverage** | #5, #7, #16, #20 | 13% | No coverage gate in story ACs |
+| **Silently ignored errors** | #16, #17 | 6% | No errcheck enforcement in ACs |
+| **Duplicate/wasted work** | #14, #49 | 6% | Parallel agents implementing same story |
+| **Security vulnerabilities** | #17 | 3% | No input sanitization AC |
+| **Scope creep** | #5 | 3% | No scope-limiting AC |
+
+### Mandatory Quality ACs for All Future Stories
+
+Every story in Epics 4–15 MUST include the following acceptance criteria in addition to feature-specific ACs. These are NON-NEGOTIABLE and derived from empirical PR failure data.
+
+#### AC-Q1: Formatting Gate (PRs #9, #23, #24, #42)
+
+```
+GIVEN code changes are ready for PR
+WHEN `gofumpt -l .` is executed from the repository root
+THEN zero files are listed (all files are properly formatted)
+```
+
+#### AC-Q2: Full Lint Gate (PRs #16, #42, #43, #44, #45)
+
+```
+GIVEN code changes are ready for PR
+WHEN `golangci-lint run ./...` is executed
+THEN zero issues are reported
+AND specifically: no errcheck violations (all error return values checked, including f.Close(), os.Remove(), os.WriteFile())
+AND specifically: no staticcheck QF1012 violations (never use WriteString(fmt.Sprintf(...)), always use fmt.Fprintf())
+AND specifically: no staticcheck S1009 violations (no redundant nil checks before len())
+AND specifically: no staticcheck S1011 violations (use append(slice, other...) not loops)
+```
+
+#### AC-Q3: Test Coverage Gate (PRs #5, #7, #16, #20)
+
+```
+GIVEN code changes are ready for PR
+WHEN `go test ./...` is executed
+THEN all tests pass
+AND new code paths have corresponding test cases
+AND no existing test files are deleted without equivalent replacement coverage
+AND test assertions verify actual outcomes (not just "no error")
+```
+
+#### AC-Q4: Rebase Gate (PRs #3, #5, #19, #23, #42)
+
+```
+GIVEN code changes are ready for PR
+WHEN the branch is compared against upstream/main
+THEN the branch is rebased onto the latest upstream/main with zero conflicts
+AND `gofumpt -l .` still produces zero output after rebase (rebase can introduce formatting drift)
+```
+
+#### AC-Q5: Scope Gate (PR #5)
+
+```
+GIVEN code changes are ready for PR
+WHEN `git diff --stat` is reviewed
+THEN all changed files are directly related to the story's acceptance criteria
+AND no unrelated directories or configuration files are included
+```
+
+#### AC-Q6: Input Sanitization Gate (PR #17)
+
+```
+GIVEN the story involves constructing dynamic commands, scripts, or queries (AppleScript, SQL, shell, etc.)
+WHEN user-provided or external data is interpolated into the command
+THEN all interpolated values are properly escaped/sanitized for the target language
+AND injection test cases are included for special characters (quotes, backslashes, semicolons)
+```
+
+#### AC-Q7: Error Handling Gate (PRs #16, #17)
+
+```
+GIVEN code changes include function calls that return errors
+WHEN reviewing the code diff
+THEN no error return values are silently discarded (assigned to `_` or ignored)
+AND deferred Close() calls on writable files use error-checking patterns
+AND error messages include context via fmt.Errorf("context: %w", err) wrapping
+```
+
+#### AC-Q8: Determinism Gate (PRs #14, #18)
+
+```
+GIVEN code changes involve ordering, randomization, or time-dependent behavior
+WHEN the same inputs are provided
+THEN outputs are deterministic (sorted collections, seeded randomness, or documented non-determinism)
+AND randomized outputs have anti-repeat guards (no consecutive identical selections)
+AND time.Now() is called once per logical operation, not inside loops
+```
+
+### Per-Story Defect Tracing
+
+The following maps each affected story to the specific PR issues it produced:
+
+| Story | PR(s) | Issues Found | Missing AC That Would Have Prevented It |
+|-------|-------|-------------|----------------------------------------|
+| 1.1 | #2 | 26 latent lint issues (discovered in PR #8) | AC-Q2 (lint gate) |
+| 1.2 | #4 | Latent lint issues | AC-Q2 (lint gate) |
+| 1.3 | #3→#5, #7 | Out-of-order impl, merge conflicts, deleted 324 test lines, scope creep (agents/ dir) | AC-Q3 (test gate), AC-Q4 (rebase gate), AC-Q5 (scope gate) |
+| 1.3a | #14 | Non-deterministic ordering, state mutation bug, duplicate of #13 | AC-Q8 (determinism gate) |
+| 1.5 | #16 | 3 CI failures: errcheck, staticcheck S1009, Makefile error swallowing | AC-Q2 (lint gate), AC-Q7 (error gate) |
+| 1.6 | #18 | Consecutive greeting repeats | AC-Q8 (determinism gate) |
+| 1.7 | #8, #9, #10 | CI itself introduced; PR #9 merged with gofumpt failure → PR #10 hotfix | AC-Q1 (formatting gate) |
+| 2.1 | #20 | Missing provider tests, weak assertions, %s vs %q in errors | AC-Q3 (test gate), AC-Q7 (error gate) |
+| 2.3 | #17 | AppleScript injection, silently ignored error, time consistency bug | AC-Q6 (input sanitization), AC-Q7 (error gate), AC-Q8 (determinism gate) |
+| 2.6 | #19 | Stale view state, wrong test target (file vs dir), 2 rounds of merge conflicts | AC-Q3 (test gate), AC-Q4 (rebase gate) |
+| 3.1 | #23 | gofumpt after rebase, merge conflict | AC-Q1 (formatting gate), AC-Q4 (rebase gate) |
+| 3.2 | #24 | gofumpt formatting failure | AC-Q1 (formatting gate) |
+| 4.2 | #43 | 8 errcheck violations, 3 CI failures | AC-Q2 (lint gate) |
+| 4.3 | #44 | staticcheck QF1012 + S1009, logic bugs (duplicate task, case-sensitive mood) | AC-Q2 (lint gate) |
+| 4.4 | #45, #49 | staticcheck S1011 + QF1012, duplicate PR from parallel agent | AC-Q2 (lint gate) |
+| 4.5 | #42 | 4 CI failures, 5-file merge conflict, gofumpt + errcheck + QF1012 (fixed incrementally) | AC-Q1, AC-Q2, AC-Q4 (all gates) |

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -235,3 +235,27 @@ These non-functional requirements establish code quality gates that all contribu
 **NFR-CQ5:** All fix-up commits must be squashed before PR submission — PRs should contain a single clean commit or logically separated commits, not iterative fix-up trails (Evidence: ~15 PRs contained avoidable "fix: address code review findings" commits)
 
 ---
+
+## Systemic NFRs Derived from PR Analysis (PRs #1–#49)
+
+> Analysis of all 49 PRs found 18 (37%) required post-submission changes. These NFRs prevent recurring defect classes. For detailed code examples and patterns, see `docs/architecture/coding-standards.md` Rules 9–13.
+
+| NFR ID | Requirement | Coding Standard | Evidence |
+|--------|------------|-----------------|----------|
+| **NFR-SB1** | Use `fmt.Fprintf()` not `WriteString(Sprintf())` for all string building | Rule 9 | PRs #42, #44, #45 (11+ instances, 5 fix-ups) |
+| **NFR-SB2** | Sweep entire codebase when fixing a lint category, not just reported lines | Rule 13 | PR #42 (3 incremental fix commits) |
+| **NFR-EH1** | Check ALL error return values including `f.Close()`, `os.Remove()`, `os.WriteFile()` | Rule 10 | PRs #16, #42, #43 (18+ violations) |
+| **NFR-EH2** | Makefile targets must not silently swallow errors | Rule 10 | PR #16 |
+| **NFR-EH3** | Configuration/setup errors must be handled or explicitly documented as ignored | Rule 10 | PR #17 |
+| **NFR-IS1** | Escape all user strings interpolated into AppleScript/shell/interpreted languages | Rule 11 | PR #17 (injection vulnerability) |
+| **NFR-IS2** | Include test cases with special characters for dynamic command construction | Rule 11 | PR #17 |
+| **NFR-TQ1** | Deleting test cases requires equivalent replacement coverage in the same PR | — | PRs #5, #7 (324 deleted lines, retroactive fix) |
+| **NFR-TQ2** | Test assertions must verify actual outcomes, not just absence of errors | — | PR #20 |
+| **NFR-TQ3** | Collections must be tested for ordering; non-ordered results must be sorted | — | PR #14 (non-deterministic search) |
+| **NFR-TR1** | `time.Now()` called once per operation, reused — never inside loops | Rule 12 | PR #17 |
+| **NFR-TR2** | Random selection must include anti-repeat guard | — | PR #18 |
+| **NFR-BH1** | Re-run `gofumpt` after every rebase (rebase can introduce formatting drift) | — | PR #23 |
+| **NFR-BH2** | Implement stories in dependency order to avoid merge conflicts | — | PRs #3, #5 |
+| **NFR-BH3** | Coordinate parallel agent story assignments to prevent duplicate work | — | PRs #14/#13, #49/#45 (1,157+ lines wasted) |
+
+---


### PR DESCRIPTION
## Summary

Systematic analysis of **all 49 PRs (#1–#49)** examining every delta between initial PR submission and final merge. Found **18 PRs (37%) required post-submission changes** across 9 defect categories.

### Key Findings

| Category | PRs Affected | % of Issues |
|----------|-------------|-------------|
| Lint/static analysis (errcheck + staticcheck) | #16, #42, #43, #44, #45 | 23% |
| Logic/correctness bugs | #14, #17, #18, #19, #44 | 16% |
| Merge conflicts | #3, #5, #19, #23, #42 | 16% |
| gofumpt formatting | #9, #23, #24, #42 | 13% |
| Missing test coverage | #5, #7, #16, #20 | 13% |
| Silently ignored errors | #16, #17 | 6% |
| Duplicate/wasted work | #14, #49 | 6% |
| Security vulnerabilities | #17 | 3% |
| Scope creep | #5 | 3% |

### Deliverables

**A) `docs/prd/epics-and-stories.md`** — Appendix with:
- Issue categorization summary table with percentages
- 8 mandatory quality ACs (AC-Q1 through AC-Q8) in BDD format for all future stories
- Per-story defect tracing table mapping 16 stories to their PR issues and which AC would have prevented them

**B) `docs/prd/requirements.md`** — 15 systemic NFRs in cross-reference table format:
- NFR-SB1/2: String building (fmt.Fprintf, codebase-wide lint sweeps)
- NFR-EH1/2/3: Error handling (errcheck, Makefile errors, config errors)
- NFR-IS1/2: Input sanitization (AppleScript injection, special char tests)
- NFR-TQ1/2/3: Test quality (no coverage regression, outcome assertions, ordering)
- NFR-TR1/2: Time & randomness (single time.Now(), anti-repeat guards)
- NFR-BH1/2/3: Branch hygiene (post-rebase formatting, dependency order, agent coordination)

**C) `docs/architecture/coding-standards.md`** — 5 new rules with code examples:
- Rule 9: Always use fmt.Fprintf, never WriteString+Sprintf (staticcheck QF1012)
- Rule 10: Check ALL error return values including Close/Remove/WriteFile (errcheck)
- Rule 11: Escape all user input in AppleScript/shell interpolation (injection prevention)
- Rule 12: Call time.Now() once per operation, reuse the result
- Rule 13: Fix lint categories by sweeping the entire codebase
- Pre-PR verification checklist (8-step bash sequence)

### Design Decisions

- **Single source of truth**: Detailed rules + code examples live in `coding-standards.md`; `requirements.md` cross-references via NFR table
- **DRY after /simplify review**: Initial draft had ~360 lines with duplicated evidence citations across files; consolidated to 280 lines
- **Scope**: Only adds appendices/sections to existing files — no structural changes to existing content

### Opportunities (Not Implemented)

- Could add a `make pre-pr` target automating the pre-PR checklist
- Could add a Git pre-push hook enforcing gofumpt + golangci-lint
- The `docs/architecture/pr-submission-standards.md` file (referenced in existing requirements.md line 225) partially overlaps with the new pre-PR checklist and could be consolidated

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm no existing content was modified (only additions at end of files)
- [ ] Cross-check that NFR table in requirements.md correctly references Rules 9-13 in coding-standards.md
- [ ] Verify PR numbers in evidence citations match actual PR titles