### PR TITLE
feat: Story 10.1 - First-Run Onboarding Experience

### DIFF
--- a/cmd/threedoors/main.go
+++ b/cmd/threedoors/main.go
@@ -92,7 +92,8 @@ func main() {
 	// Wait for enrichment DB to be ready before creating the model
 	enrichWg.Wait()
 
-	model := tui.NewMainModel(pool, tracker, provider, hc)
+	isFirstRun := configErr == nil && tasks.IsFirstRun(configDir)
+	model := tui.NewMainModel(pool, tracker, provider, hc, isFirstRun)
 
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {

--- a/cmd/threedoors/main_test.go
+++ b/cmd/threedoors/main_test.go
@@ -15,7 +15,7 @@ func newTestModel(t *testing.T) *tui.MainModel {
 	pool.AddTask(tasks.NewTask("Test task 2"))
 	pool.AddTask(tasks.NewTask("Test task 3"))
 	tracker := tasks.NewSessionTracker()
-	return tui.NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil)
+	return tui.NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false)
 }
 
 func TestQuitKey(t *testing.T) {

--- a/docs/stories/10.1.story.md
+++ b/docs/stories/10.1.story.md
@@ -1,0 +1,69 @@
+# Story 10.1: Welcome Flow & Three Doors Explanation
+
+## Story
+
+As a new user,
+I want a guided welcome on first launch,
+So that I understand the Three Doors concept.
+
+## Status
+
+In Progress
+
+## Prerequisites
+
+- Epic 3 (Enhanced Interaction) - COMPLETE
+
+## Acceptance Criteria
+
+**Given** first-run detected (no `~/.threedoors/` directory or `onboarding_complete: false`)
+**When** the application launches
+**Then** welcome screen with branding and concept explanation displays
+**And** interactive key bindings walkthrough lets user try keys
+**And** skip option available at every step
+**And** onboarding state persisted (`onboarding_complete: true` in config)
+
+## Technical Design
+
+### First-Run Detection
+
+- Check for `onboarding_complete: true` in `~/.threedoors/config.yaml`
+- If missing or false, show onboarding before doors view
+- Pass `isFirstRun` flag to `NewMainModel()`
+
+### OnboardingView Implementation
+
+Multi-step wizard flow following existing view patterns:
+
+1. **Welcome** - App branding, Three Doors concept explanation
+2. **Key Bindings** - Interactive walkthrough of navigation keys (A/W/D/S, Enter, etc.)
+3. **Done** - Summary and transition to main app
+
+Each step has a skip option (Esc or 's' to skip remaining).
+
+### Integration Points
+
+- Add `ViewOnboarding` to `ViewMode` enum
+- Add `OnboardingView` field to `MainModel`
+- Add `OnboardingCompletedMsg` message type
+- On completion, persist `onboarding_complete: true` to config.yaml
+- Transition to doors view after onboarding
+
+### Files Modified
+
+- `internal/tui/onboarding_view.go` (new)
+- `internal/tui/onboarding_view_test.go` (new)
+- `internal/tui/main_model.go` (add ViewOnboarding, integration)
+- `internal/tui/messages.go` (add OnboardingCompletedMsg)
+- `internal/tasks/onboarding.go` (new - first-run detection)
+- `internal/tasks/onboarding_test.go` (new)
+- `cmd/threedoors/main.go` (pass isFirstRun to NewMainModel)
+
+## Quality Gate
+
+- gofumpt formatted
+- golangci-lint passes
+- All tests pass
+- Table-driven tests for >2 cases
+- stdlib testing only (no testify)
+- t.Helper() in helpers, t.Cleanup() for cleanup

--- a/internal/tasks/onboarding.go
+++ b/internal/tasks/onboarding.go
@@ -1,0 +1,82 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// OnboardingConfig holds onboarding state persisted to config.yaml.
+type OnboardingConfig struct {
+	OnboardingComplete bool `yaml:"onboarding_complete"`
+}
+
+// IsFirstRun checks whether onboarding has been completed by reading config.yaml.
+// Returns true if onboarding has not been completed (or config doesn't exist).
+func IsFirstRun(configDir string) bool {
+	data, err := os.ReadFile(configDir + "/config.yaml")
+	if err != nil {
+		return true
+	}
+	if len(data) == 0 {
+		return true
+	}
+
+	var cfg OnboardingConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return true
+	}
+	return !cfg.OnboardingComplete
+}
+
+// MarkOnboardingComplete persists onboarding_complete: true to config.yaml.
+// It preserves existing config fields by reading, merging, and rewriting.
+func MarkOnboardingComplete(configDir string) error {
+	configPath := configDir + "/config.yaml"
+
+	// Read existing config as a generic map to preserve all fields
+	existing := make(map[string]interface{})
+	data, err := os.ReadFile(configPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read config: %w", err)
+	}
+	if len(data) > 0 {
+		if err := yaml.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("parse config: %w", err)
+		}
+	}
+
+	existing["onboarding_complete"] = true
+
+	out, err := yaml.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	tmpPath := configPath + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+
+	if _, err := f.Write(out); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	_ = f.Close()
+
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	return nil
+}

--- a/internal/tasks/onboarding_test.go
+++ b/internal/tasks/onboarding_test.go
@@ -1,0 +1,137 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsFirstRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configYAML string
+		noFile     bool
+		want       bool
+	}{
+		{
+			name:   "no config directory",
+			noFile: true,
+			want:   true,
+		},
+		{
+			name:       "empty config file",
+			configYAML: "",
+			want:       true,
+		},
+		{
+			name:       "config without onboarding field",
+			configYAML: "provider: textfile\n",
+			want:       true,
+		},
+		{
+			name:       "onboarding_complete false",
+			configYAML: "onboarding_complete: false\n",
+			want:       true,
+		},
+		{
+			name:       "onboarding_complete true",
+			configYAML: "onboarding_complete: true\n",
+			want:       false,
+		},
+		{
+			name:       "onboarding complete with other fields",
+			configYAML: "provider: textfile\nonboarding_complete: true\nvalues:\n  - focus\n",
+			want:       false,
+		},
+		{
+			name:       "invalid yaml",
+			configYAML: ":::invalid",
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+
+			if !tt.noFile {
+				if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(tt.configYAML), 0o644); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+
+			got := IsFirstRun(dir)
+			if got != tt.want {
+				t.Errorf("IsFirstRun() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarkOnboardingComplete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates config when none exists", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		if err := MarkOnboardingComplete(dir); err != nil {
+			t.Fatalf("MarkOnboardingComplete() error: %v", err)
+		}
+
+		if IsFirstRun(dir) {
+			t.Error("expected IsFirstRun() = false after marking complete")
+		}
+	})
+
+	t.Run("preserves existing config fields", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		existing := "provider: applenotes\nnote_title: My Tasks\nvalues:\n    - focus\n"
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(existing), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		if err := MarkOnboardingComplete(dir); err != nil {
+			t.Fatalf("MarkOnboardingComplete() error: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config: %v", err)
+		}
+
+		content := string(data)
+		if !strings.Contains(content, "onboarding_complete: true") {
+			t.Errorf("config missing onboarding_complete: true, got:\n%s", content)
+		}
+		if !strings.Contains(content, "provider: applenotes") {
+			t.Errorf("config lost provider field, got:\n%s", content)
+		}
+		if !strings.Contains(content, "note_title: My Tasks") {
+			t.Errorf("config lost note_title field, got:\n%s", content)
+		}
+	})
+
+	t.Run("idempotent when already complete", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("onboarding_complete: true\n"), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		if err := MarkOnboardingComplete(dir); err != nil {
+			t.Fatalf("MarkOnboardingComplete() error: %v", err)
+		}
+
+		if IsFirstRun(dir) {
+			t.Error("expected IsFirstRun() = false")
+		}
+	})
+}

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -26,6 +26,7 @@ const (
 	ViewNextSteps
 	ViewAvoidancePrompt
 	ViewInsights
+	ViewOnboarding
 )
 
 // MainModel is the root Bubbletea model that orchestrates view transitions.
@@ -44,6 +45,7 @@ type MainModel struct {
 	nextStepsView       *NextStepsView
 	avoidancePromptView *AvoidancePromptView
 	insightsView        *InsightsView
+	onboardingView      *OnboardingView
 	pool                *tasks.TaskPool
 	tracker             *tasks.SessionTracker
 	provider            tasks.TaskProvider
@@ -61,7 +63,8 @@ type MainModel struct {
 }
 
 // NewMainModel creates the root application model.
-func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider tasks.TaskProvider, hc *tasks.HealthChecker) *MainModel {
+// If isFirstRun is true, the onboarding wizard is shown before the doors view.
+func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider tasks.TaskProvider, hc *tasks.HealthChecker, isFirstRun bool) *MainModel {
 	// Load values config
 	var valuesConfig *tasks.ValuesConfig
 	if path, err := tasks.GetValuesConfigPath(); err == nil {
@@ -95,7 +98,7 @@ func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider 
 	doorsView.SetAvoidanceData(patternReport)
 	doorsView.SetInsightsData(pa, cc)
 
-	return &MainModel{
+	m := &MainModel{
 		viewMode:          ViewDoors,
 		doorsView:         doorsView,
 		pool:              pool,
@@ -108,6 +111,13 @@ func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider 
 		valuesConfig:      valuesConfig,
 		promptedTasks:     make(map[string]bool),
 	}
+
+	if isFirstRun {
+		m.onboardingView = NewOnboardingView()
+		m.viewMode = ViewOnboarding
+	}
+
+	return m
 }
 
 // Init implements tea.Model.
@@ -154,6 +164,9 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.avoidancePromptView != nil {
 			m.avoidancePromptView.SetWidth(msg.Width)
+		}
+		if m.onboardingView != nil {
+			m.onboardingView.SetWidth(msg.Width)
 		}
 		return m, nil
 
@@ -482,6 +495,18 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case OnboardingCompletedMsg:
+		m.onboardingView = nil
+		m.viewMode = ViewDoors
+		m.doorsView.RefreshDoors()
+		// Persist onboarding state
+		if configDir, err := tasks.GetConfigDirPath(); err == nil {
+			if markErr := tasks.MarkOnboardingComplete(configDir); markErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to save onboarding state: %v\n", markErr)
+			}
+		}
+		return m, nil
+
 	case FlashMsg:
 		m.flash = msg.Text
 		return m, ClearFlashCmd()
@@ -513,6 +538,8 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateNextSteps(msg)
 	case ViewAvoidancePrompt:
 		return m.updateAvoidancePrompt(msg)
+	case ViewOnboarding:
+		return m.updateOnboarding(msg)
 	}
 
 	return m, nil
@@ -658,6 +685,14 @@ func (m *MainModel) updateAvoidancePrompt(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *MainModel) updateOnboarding(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.onboardingView == nil {
+		return m, nil
+	}
+	cmd := m.onboardingView.Update(msg)
+	return m, cmd
+}
+
 func (m *MainModel) updateValues(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.valuesView == nil {
 		return m, nil
@@ -735,6 +770,10 @@ func (m *MainModel) View() string {
 	case ViewAvoidancePrompt:
 		if m.avoidancePromptView != nil {
 			view = m.avoidancePromptView.View()
+		}
+	case ViewOnboarding:
+		if m.onboardingView != nil {
+			view = m.onboardingView.View()
 		}
 	default:
 		view = m.doorsView.View()

--- a/internal/tui/main_model_test.go
+++ b/internal/tui/main_model_test.go
@@ -52,7 +52,7 @@ func makeModel(texts ...string) *MainModel {
 func makeModelWithProvider(provider tasks.TaskProvider, texts ...string) *MainModel {
 	pool := makePool(texts...)
 	tracker := tasks.NewSessionTracker()
-	return NewMainModel(pool, tracker, provider, nil)
+	return NewMainModel(pool, tracker, provider, nil, false)
 }
 
 func keyMsg(s string) tea.Msg {
@@ -301,7 +301,7 @@ func TestDoorsView_RendersHelpText(t *testing.T) {
 func TestDoorsView_AllTasksDone_ShowsMessage(t *testing.T) {
 	pool := tasks.NewTaskPool()
 	tracker := tasks.NewSessionTracker()
-	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil)
+	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false)
 	view := m.View()
 	if !strings.Contains(view, "All tasks done") {
 		t.Errorf("View should show 'All tasks done' when pool is empty, got: %s", view)
@@ -667,7 +667,7 @@ func TestColonKey_OpensSearchInCommandMode(t *testing.T) {
 func TestTaskAddedMsg_EmptyPool_AddsTask(t *testing.T) {
 	pool := tasks.NewTaskPool()
 	tracker := tasks.NewSessionTracker()
-	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil)
+	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false)
 
 	if m.pool.Count() != 0 {
 		t.Fatal("pool should start empty")

--- a/internal/tui/onboarding_view.go
+++ b/internal/tui/onboarding_view.go
@@ -1,0 +1,193 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// onboardingStep tracks the current step in the onboarding wizard.
+type onboardingStep int
+
+const (
+	stepWelcome onboardingStep = iota
+	stepKeybindings
+	stepDone
+)
+
+// OnboardingView guides first-time users through the Three Doors concept.
+type OnboardingView struct {
+	step       onboardingStep
+	width      int
+	triedKeys  map[string]bool
+	lastAction string
+}
+
+// OnboardingCompletedMsg is sent when onboarding finishes.
+type OnboardingCompletedMsg struct{}
+
+// NewOnboardingView creates a new onboarding wizard.
+func NewOnboardingView() *OnboardingView {
+	return &OnboardingView{
+		triedKeys: make(map[string]bool),
+	}
+}
+
+// SetWidth sets the terminal width for rendering.
+func (ov *OnboardingView) SetWidth(w int) {
+	ov.width = w
+}
+
+// Update handles key input for the onboarding wizard.
+func (ov *OnboardingView) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		key := msg.String()
+
+		// Skip remaining onboarding at any step
+		if key == "esc" || key == "ctrl+c" {
+			return func() tea.Msg { return OnboardingCompletedMsg{} }
+		}
+
+		switch ov.step {
+		case stepWelcome:
+			if key == "enter" || key == " " {
+				ov.step = stepKeybindings
+			}
+			return nil
+
+		case stepKeybindings:
+			switch key {
+			case "enter":
+				ov.step = stepDone
+				return nil
+			case "a", "left":
+				ov.triedKeys["left"] = true
+				ov.lastAction = "Left door selected!"
+			case "w", "up":
+				ov.triedKeys["up"] = true
+				ov.lastAction = "Center door selected!"
+			case "d", "right":
+				ov.triedKeys["right"] = true
+				ov.lastAction = "Right door selected!"
+			case "s", "down":
+				ov.triedKeys["reroll"] = true
+				ov.lastAction = "Doors re-rolled!"
+			default:
+				ov.lastAction = ""
+			}
+			return nil
+
+		case stepDone:
+			if key == "enter" || key == " " {
+				return func() tea.Msg { return OnboardingCompletedMsg{} }
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// View renders the current onboarding step.
+func (ov *OnboardingView) View() string {
+	w := ov.width - 6
+	if w < 40 {
+		w = 40
+	}
+
+	var content string
+	switch ov.step {
+	case stepWelcome:
+		content = ov.viewWelcome()
+	case stepKeybindings:
+		content = ov.viewKeybindings()
+	case stepDone:
+		content = ov.viewDone()
+	}
+
+	return detailBorder.Width(w).Render(content)
+}
+
+func (ov *OnboardingView) viewWelcome() string {
+	var s strings.Builder
+
+	fmt.Fprintf(&s, "%s\n\n", headerStyle.Render("Welcome to ThreeDoors"))
+
+	fmt.Fprintf(&s, "ThreeDoors helps you overcome task paralysis by\n")
+	fmt.Fprintf(&s, "showing you just %s at a time.\n\n", headerStyle.Render("three tasks"))
+
+	fmt.Fprintf(&s, "Instead of staring at a long to-do list,\n")
+	fmt.Fprintf(&s, "you pick from three doors — like a game show.\n\n")
+
+	fmt.Fprintf(&s, "The trick? %s.\n", headerStyle.Render("There are no wrong answers"))
+	fmt.Fprintf(&s, "Every door leads to progress.\n\n")
+
+	stepIndicator := helpStyle.Render("Step 1 of 3")
+	fmt.Fprintf(&s, "%s\n", stepIndicator)
+	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter to continue | Esc to skip"))
+
+	return s.String()
+}
+
+func (ov *OnboardingView) viewKeybindings() string {
+	var s strings.Builder
+
+	fmt.Fprintf(&s, "%s\n\n", headerStyle.Render("Key Bindings"))
+	fmt.Fprintf(&s, "Try the keys below to see how navigation works:\n\n")
+
+	keys := []struct {
+		keys   string
+		action string
+		tried  string
+	}{
+		{"A / Left Arrow", "Select left door", "left"},
+		{"W / Up Arrow", "Select center door", "up"},
+		{"D / Right Arrow", "Select right door", "right"},
+		{"S / Down Arrow", "Re-roll doors", "reroll"},
+	}
+
+	for _, k := range keys {
+		check := "  "
+		if ov.triedKeys[k.tried] {
+			check = flashStyle.Render("* ")
+		}
+		fmt.Fprintf(&s, "  %s%-16s  %s\n", check, k.keys, k.action)
+	}
+
+	if ov.lastAction != "" {
+		fmt.Fprintf(&s, "\n  %s\n", flashStyle.Render(ov.lastAction))
+	}
+
+	triedCount := len(ov.triedKeys)
+	fmt.Fprintf(&s, "\n%s\n", helpStyle.Render(fmt.Sprintf("Tried %d of 4 keys", triedCount)))
+
+	stepIndicator := helpStyle.Render("Step 2 of 3")
+	fmt.Fprintf(&s, "%s\n", stepIndicator)
+	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter to continue | Esc to skip"))
+
+	return s.String()
+}
+
+func (ov *OnboardingView) viewDone() string {
+	var s strings.Builder
+
+	fmt.Fprintf(&s, "%s\n\n", headerStyle.Render("You're All Set!"))
+
+	fmt.Fprintf(&s, "Here are a few more keys you'll find useful:\n\n")
+
+	fmt.Fprintf(&s, "  %-16s  %s\n", "Enter", "Open selected task")
+	fmt.Fprintf(&s, "  %-16s  %s\n", "C", "Complete a task")
+	fmt.Fprintf(&s, "  %-16s  %s\n", "M", "Log your mood")
+	fmt.Fprintf(&s, "  %-16s  %s\n", "/", "Search tasks")
+	fmt.Fprintf(&s, "  %-16s  %s\n", ":", "Command palette")
+	fmt.Fprintf(&s, "  %-16s  %s\n", "Q", "Quit")
+
+	fmt.Fprintf(&s, "\n%s\n\n", headerStyle.Render("Remember: progress over perfection."))
+
+	stepIndicator := helpStyle.Render("Step 3 of 3")
+	fmt.Fprintf(&s, "%s\n", stepIndicator)
+	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter to start | Esc to skip"))
+
+	return s.String()
+}

--- a/internal/tui/onboarding_view_test.go
+++ b/internal/tui/onboarding_view_test.go
@@ -1,0 +1,231 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestOnboardingView_StepProgression(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+
+	// Initial state should be welcome step
+	view := ov.View()
+	if !strings.Contains(view, "Welcome to ThreeDoors") {
+		t.Error("expected welcome step on init")
+	}
+	if !strings.Contains(view, "Step 1 of 3") {
+		t.Error("expected step 1 indicator")
+	}
+
+	// Press Enter to advance to keybindings
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	view = ov.View()
+	if !strings.Contains(view, "Key Bindings") {
+		t.Error("expected keybindings step after Enter")
+	}
+	if !strings.Contains(view, "Step 2 of 3") {
+		t.Error("expected step 2 indicator")
+	}
+
+	// Press Enter to advance to done
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	view = ov.View()
+	if !strings.Contains(view, "You're All Set") {
+		t.Error("expected done step after Enter")
+	}
+	if !strings.Contains(view, "Step 3 of 3") {
+		t.Error("expected step 3 indicator")
+	}
+
+	// Press Enter to complete onboarding
+	cmd := ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command on final Enter")
+	}
+	msg := cmd()
+	if _, ok := msg.(OnboardingCompletedMsg); !ok {
+		t.Errorf("expected OnboardingCompletedMsg, got %T", msg)
+	}
+}
+
+func TestOnboardingView_SkipAtEveryStep(t *testing.T) {
+	t.Parallel()
+
+	steps := []struct {
+		name string
+		step onboardingStep
+	}{
+		{"welcome", stepWelcome},
+		{"keybindings", stepKeybindings},
+		{"done", stepDone},
+	}
+
+	for _, tt := range steps {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ov := NewOnboardingView()
+			ov.step = tt.step
+
+			cmd := ov.Update(tea.KeyMsg{Type: tea.KeyEscape})
+			if cmd == nil {
+				t.Fatal("expected command on Esc")
+			}
+			msg := cmd()
+			if _, ok := msg.(OnboardingCompletedMsg); !ok {
+				t.Errorf("expected OnboardingCompletedMsg on Esc at step %s, got %T", tt.name, msg)
+			}
+		})
+	}
+}
+
+func TestOnboardingView_KeybindingsInteractive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		key        tea.KeyMsg
+		triedKey   string
+		lastAction string
+	}{
+		{
+			name:       "left door with A",
+			key:        tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}},
+			triedKey:   "left",
+			lastAction: "Left door selected!",
+		},
+		{
+			name:       "center door with W",
+			key:        tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}},
+			triedKey:   "up",
+			lastAction: "Center door selected!",
+		},
+		{
+			name:       "right door with D",
+			key:        tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}},
+			triedKey:   "right",
+			lastAction: "Right door selected!",
+		},
+		{
+			name:       "reroll with S",
+			key:        tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}},
+			triedKey:   "reroll",
+			lastAction: "Doors re-rolled!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ov := NewOnboardingView()
+			ov.step = stepKeybindings
+
+			ov.Update(tt.key)
+
+			if !ov.triedKeys[tt.triedKey] {
+				t.Errorf("expected triedKeys[%q] = true", tt.triedKey)
+			}
+			if ov.lastAction != tt.lastAction {
+				t.Errorf("lastAction = %q, want %q", ov.lastAction, tt.lastAction)
+			}
+		})
+	}
+}
+
+func TestOnboardingView_TriedKeysCount(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepKeybindings
+
+	// Try all four keys
+	keys := []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune{'a'}},
+		{Type: tea.KeyRunes, Runes: []rune{'w'}},
+		{Type: tea.KeyRunes, Runes: []rune{'d'}},
+		{Type: tea.KeyRunes, Runes: []rune{'s'}},
+	}
+
+	for _, k := range keys {
+		ov.Update(k)
+	}
+
+	if len(ov.triedKeys) != 4 {
+		t.Errorf("triedKeys count = %d, want 4", len(ov.triedKeys))
+	}
+
+	view := ov.View()
+	if !strings.Contains(view, "Tried 4 of 4") {
+		t.Error("expected 'Tried 4 of 4' in view")
+	}
+}
+
+func TestOnboardingView_SetWidth(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.SetWidth(120)
+
+	if ov.width != 120 {
+		t.Errorf("width = %d, want 120", ov.width)
+	}
+}
+
+func TestOnboardingView_WelcomeContent(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.SetWidth(80)
+	view := ov.View()
+
+	expectedPhrases := []string{
+		"Welcome to ThreeDoors",
+		"three tasks",
+		"no wrong answers",
+		"Esc to skip",
+	}
+
+	for _, phrase := range expectedPhrases {
+		if !strings.Contains(view, phrase) {
+			t.Errorf("welcome view missing phrase: %q", phrase)
+		}
+	}
+}
+
+func TestOnboardingView_DoneContent(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepDone
+	ov.SetWidth(80)
+	view := ov.View()
+
+	expectedPhrases := []string{
+		"You're All Set",
+		"Enter",
+		"Search tasks",
+		"Command palette",
+		"progress over perfection",
+	}
+
+	for _, phrase := range expectedPhrases {
+		if !strings.Contains(view, phrase) {
+			t.Errorf("done view missing phrase: %q", phrase)
+		}
+	}
+}
+
+func TestOnboardingView_SpaceAdvances(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+
+	// Space should advance from welcome to keybindings
+	ov.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if ov.step != stepKeybindings {
+		t.Errorf("step = %d, want stepKeybindings after space", ov.step)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds first-run detection via `onboarding_complete` flag in `~/.threedoors/config.yaml`
- Implements 3-step onboarding wizard: welcome/concept, interactive keybindings, summary
- Skip option (Esc) available at every step per AC requirements
- Onboarding state persisted on completion, preserving existing config fields
- Integrates into MainModel following established view patterns

## Files Changed

**New:**
- `internal/tasks/onboarding.go` — `IsFirstRun()` and `MarkOnboardingComplete()` with atomic write
- `internal/tasks/onboarding_test.go` — 10 test cases (table-driven, stdlib only)
- `internal/tui/onboarding_view.go` — `OnboardingView` with 3-step wizard
- `internal/tui/onboarding_view_test.go` — 8 test functions covering all steps, skip, keys
- `docs/stories/10.1.story.md` — Story spec

**Modified:**
- `internal/tui/main_model.go` — Added `ViewOnboarding`, `OnboardingCompletedMsg` handler, delegation
- `cmd/threedoors/main.go` — Added first-run detection, pass to `NewMainModel`
- Test files updated for new `isFirstRun` parameter

## Acceptance Criteria Verification

- [x] First-run detected (no `onboarding_complete: true` in config)
- [x] Welcome screen with branding and concept explanation
- [x] Interactive key bindings walkthrough (tracks tried keys)
- [x] Skip option available at every step (Esc)
- [x] Onboarding state persisted (`onboarding_complete: true` in config)

## Quality Gate

- [x] gofumpt — zero formatting issues
- [x] golangci-lint — zero warnings
- [x] All tests pass (all packages)
- [x] Table-driven tests, stdlib only, t.Parallel()
- [x] Rebased on upstream/main
- [x] /simplify review passed — code is clean

## Notes for Future Work

- Atomic write pattern is duplicated across 4 files (onboarding.go, values_config.go, write_queue.go, file_manager.go) — could be extracted to shared utility
- Story 10.2 (Values/Goals Setup & Task Import during onboarding) can extend this wizard with additional steps

## Test plan

- [x] Verify `IsFirstRun` returns true when no config exists
- [x] Verify `IsFirstRun` returns false when `onboarding_complete: true`
- [x] Verify `MarkOnboardingComplete` preserves existing config fields
- [x] Verify onboarding wizard progresses through all 3 steps
- [x] Verify Esc skips at every step
- [x] Verify interactive keybindings track tried keys
- [x] Verify all existing tests still pass