### PR TITLE
feat: Story 6.2 - Cross-Reference Tracking

### DIFF
--- a/cmd/threedoors/main.go
+++ b/cmd/threedoors/main.go
@@ -93,7 +93,7 @@ func main() {
 	enrichWg.Wait()
 
 	isFirstRun := configErr == nil && tasks.IsFirstRun(configDir)
-	model := tui.NewMainModel(pool, tracker, provider, hc, isFirstRun)
+	model := tui.NewMainModel(pool, tracker, provider, hc, isFirstRun, enrichDB)
 
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {

--- a/cmd/threedoors/main_test.go
+++ b/cmd/threedoors/main_test.go
@@ -15,7 +15,7 @@ func newTestModel(t *testing.T) *tui.MainModel {
 	pool.AddTask(tasks.NewTask("Test task 2"))
 	pool.AddTask(tasks.NewTask("Test task 3"))
 	tracker := tasks.NewSessionTracker()
-	return tui.NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false)
+	return tui.NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false, nil)
 }
 
 func TestQuitKey(t *testing.T) {

--- a/docs/stories/6.2.story.md
+++ b/docs/stories/6.2.story.md
@@ -1,0 +1,57 @@
+# Story 6.2: Cross-Reference Tracking
+
+Status: in-progress
+
+## Story
+
+**As a** user with multiple task sources,
+**I want** tasks linked across providers,
+**so that** related items are connected regardless of source.
+
+## Acceptance Criteria
+
+1. **Link Command** (AC:1)
+   - Given the user is in command mode
+   - When the user types `:link`
+   - Then a link view opens showing the current task's details
+   - And the user can search/select a target task to link
+   - And the user can choose a relationship type (related, blocks, depends-on)
+   - And the cross-reference is stored in enrichment.db
+
+2. **Linked Indicator** (AC:2)
+   - Given a task has cross-references in enrichment.db
+   - When the user views the task in detail view
+   - Then linked tasks show a "Linked Tasks" section
+   - And each linked task displays its relationship type and text
+
+3. **Navigation to Linked Tasks** (AC:3)
+   - Given a task has linked tasks displayed in detail view
+   - When the user selects a linked task (via number key)
+   - Then the detail view navigates to the selected linked task
+
+## Quality Gates
+
+- gofumpt clean
+- golangci-lint clean
+- All tests pass
+- Rebased on main
+- All database operations check error returns
+- Cross-reference writes use transactions
+- fmt.Errorf("context: %w", err) wrapping
+
+## Implementation Notes
+
+- Enrichment DB CRUD already exists in `internal/enrichment/cross_references.go`
+- Need to wire `enrichment.DB` from main.go through to TUI views
+- Follow existing view patterns (DetailView, SearchView) for LinkView
+- `:link` command added to search_view.go executeCommand()
+
+## File List
+
+- `internal/tui/link_view.go` — New LinkView for cross-reference creation
+- `internal/tui/main_model.go` — Wire enrichDB, add ViewLink mode, handle messages
+- `internal/tui/detail_view.go` — Show linked tasks, support navigation
+- `internal/tui/search_view.go` — Add `:link` command
+- `internal/tui/messages.go` — Add link-related messages
+- `cmd/threedoors/main.go` — Pass enrichDB to NewMainModel
+- `internal/tui/link_view_test.go` — Tests for LinkView

--- a/internal/tui/detail_view.go
+++ b/internal/tui/detail_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/arcaven/ThreeDoors/internal/enrichment"
 	"github.com/arcaven/ThreeDoors/internal/tasks"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -24,6 +25,16 @@ type DetailView struct {
 	blockerInput string
 	width        int
 	tracker      *tasks.SessionTracker
+	enrichDB     *enrichment.DB
+	pool         *tasks.TaskPool
+	linkedTasks  []linkedTaskInfo
+}
+
+// linkedTaskInfo holds display info for a cross-referenced task.
+type linkedTaskInfo struct {
+	taskID       string
+	text         string
+	relationship string
 }
 
 // NewDetailView creates a detail view for the given task.
@@ -41,6 +52,40 @@ func NewDetailView(task *tasks.Task, tracker *tasks.SessionTracker) *DetailView 
 // SetWidth sets the terminal width.
 func (dv *DetailView) SetWidth(w int) {
 	dv.width = w
+}
+
+// SetEnrichDB sets the enrichment database and task pool for cross-reference display.
+func (dv *DetailView) SetEnrichDB(db *enrichment.DB, pool *tasks.TaskPool) {
+	dv.enrichDB = db
+	dv.pool = pool
+	dv.RefreshLinks()
+}
+
+// RefreshLinks reloads cross-references from the enrichment database.
+func (dv *DetailView) RefreshLinks() {
+	dv.linkedTasks = nil
+	if dv.enrichDB == nil || dv.pool == nil {
+		return
+	}
+	refs, err := dv.enrichDB.GetCrossReferences(dv.task.ID)
+	if err != nil {
+		return
+	}
+	for _, ref := range refs {
+		otherID := ref.TargetTaskID
+		if ref.SourceTaskID != dv.task.ID {
+			otherID = ref.SourceTaskID
+		}
+		text := otherID
+		if t := dv.pool.GetTask(otherID); t != nil {
+			text = t.Text
+		}
+		dv.linkedTasks = append(dv.linkedTasks, linkedTaskInfo{
+			taskID:       otherID,
+			text:         text,
+			relationship: ref.Relationship,
+		})
+	}
 }
 
 // Update handles key input in the detail view.
@@ -95,6 +140,15 @@ func (dv *DetailView) handleDetailKeys(msg tea.KeyMsg) tea.Cmd {
 		return func() tea.Msg { return ReturnToDoorsMsg{} }
 	case "m", "M":
 		return func() tea.Msg { return ShowMoodMsg{} }
+	case "l", "L":
+		task := dv.task
+		return func() tea.Msg { return ShowLinkViewMsg{SourceTask: task} }
+	case "1", "2", "3", "4", "5", "6", "7", "8", "9":
+		idx := int(msg.String()[0]-'0') - 1
+		if idx >= 0 && idx < len(dv.linkedTasks) {
+			taskID := dv.linkedTasks[idx].taskID
+			return func() tea.Msg { return NavigateToLinkedTaskMsg{TaskID: taskID} }
+		}
 	}
 	return nil
 }
@@ -167,6 +221,17 @@ func (dv *DetailView) View() string {
 		}
 	}
 
+	if len(dv.linkedTasks) > 0 {
+		linkStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
+		s.WriteString("\n")
+		s.WriteString(linkStyle.Render("Linked Tasks:"))
+		s.WriteString("\n")
+		for i, lt := range dv.linkedTasks {
+			relStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+			fmt.Fprintf(&s, "  %d. [%s] %s\n", i+1, relStyle.Render(lt.relationship), lt.text)
+		}
+	}
+
 	s.WriteString("\n")
 	s.WriteString(separatorStyle.Render("─────────────────────────────────"))
 	s.WriteString("\n\n")
@@ -175,7 +240,11 @@ func (dv *DetailView) View() string {
 		s.WriteString("Blocker reason (Enter to submit, Esc to cancel):\n")
 		s.WriteString("> " + dv.blockerInput + "_\n")
 	} else {
-		s.WriteString(helpStyle.Render("[C]omplete [B]locked [I]n-progress [E]xpand [F]ork [P]rocrastinate [R]ework [M]ood [Esc]Back"))
+		help := "[C]omplete [B]locked [I]n-progress [L]ink [P]rocrastinate [R]ework [M]ood [Esc]Back"
+		if len(dv.linkedTasks) > 0 {
+			help += " | 1-9: jump to linked task"
+		}
+		s.WriteString(helpStyle.Render(help))
 	}
 
 	return detailBorder.Width(w).Render(s.String())

--- a/internal/tui/link_view.go
+++ b/internal/tui/link_view.go
@@ -1,0 +1,241 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arcaven/ThreeDoors/internal/enrichment"
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// LinkViewStep tracks the current step in the link creation flow.
+type LinkViewStep int
+
+const (
+	linkStepSelectTarget LinkViewStep = iota
+	linkStepSelectRelationship
+)
+
+var relationshipOptions = []string{"related", "blocks", "depends-on"}
+
+// LinkView handles creating cross-references between tasks.
+type LinkView struct {
+	sourceTask    *tasks.Task
+	pool          *tasks.TaskPool
+	enrichDB      *enrichment.DB
+	step          LinkViewStep
+	searchInput   string
+	results       []*tasks.Task
+	selectedIndex int
+	relIndex      int
+	width         int
+}
+
+// NewLinkView creates a new link creation view.
+func NewLinkView(source *tasks.Task, pool *tasks.TaskPool, db *enrichment.DB) *LinkView {
+	return &LinkView{
+		sourceTask:    source,
+		pool:          pool,
+		enrichDB:      db,
+		step:          linkStepSelectTarget,
+		selectedIndex: -1,
+	}
+}
+
+// SetWidth sets the terminal width.
+func (lv *LinkView) SetWidth(w int) {
+	lv.width = w
+}
+
+// Update handles key input for the link view.
+func (lv *LinkView) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch lv.step {
+		case linkStepSelectTarget:
+			return lv.handleTargetSelection(msg)
+		case linkStepSelectRelationship:
+			return lv.handleRelationshipSelection(msg)
+		}
+	}
+	return nil
+}
+
+func (lv *LinkView) handleTargetSelection(msg tea.KeyMsg) tea.Cmd {
+	switch msg.Type {
+	case tea.KeyEscape:
+		return func() tea.Msg { return LinkCancelledMsg{} }
+	case tea.KeyEnter:
+		if lv.selectedIndex >= 0 && lv.selectedIndex < len(lv.results) {
+			lv.step = linkStepSelectRelationship
+			lv.relIndex = 0
+		}
+		return nil
+	case tea.KeyUp:
+		if lv.selectedIndex > 0 {
+			lv.selectedIndex--
+		}
+		return nil
+	case tea.KeyDown:
+		if lv.selectedIndex < len(lv.results)-1 {
+			lv.selectedIndex++
+		}
+		return nil
+	case tea.KeyBackspace:
+		if len(lv.searchInput) > 0 {
+			lv.searchInput = lv.searchInput[:len(lv.searchInput)-1]
+			lv.filterTasks()
+		}
+		return nil
+	default:
+		if msg.Type == tea.KeyRunes && len(msg.Runes) > 0 {
+			lv.searchInput += string(msg.Runes)
+			lv.filterTasks()
+		}
+		return nil
+	}
+}
+
+func (lv *LinkView) handleRelationshipSelection(msg tea.KeyMsg) tea.Cmd {
+	switch msg.Type {
+	case tea.KeyEscape:
+		lv.step = linkStepSelectTarget
+		return nil
+	case tea.KeyEnter:
+		return lv.createLink()
+	case tea.KeyUp:
+		if lv.relIndex > 0 {
+			lv.relIndex--
+		}
+		return nil
+	case tea.KeyDown:
+		if lv.relIndex < len(relationshipOptions)-1 {
+			lv.relIndex++
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (lv *LinkView) filterTasks() {
+	lv.results = nil
+	lv.selectedIndex = -1
+	if lv.searchInput == "" {
+		// Show all tasks except the source
+		allTasks := lv.pool.GetAllTasks()
+		for _, t := range allTasks {
+			if t.ID != lv.sourceTask.ID {
+				lv.results = append(lv.results, t)
+			}
+		}
+	} else {
+		lowerQuery := strings.ToLower(lv.searchInput)
+		allTasks := lv.pool.GetAllTasks()
+		for _, t := range allTasks {
+			if t.ID != lv.sourceTask.ID && strings.Contains(strings.ToLower(t.Text), lowerQuery) {
+				lv.results = append(lv.results, t)
+			}
+		}
+	}
+	if len(lv.results) > 0 {
+		lv.selectedIndex = 0
+	}
+}
+
+func (lv *LinkView) createLink() tea.Cmd {
+	if lv.selectedIndex < 0 || lv.selectedIndex >= len(lv.results) {
+		return nil
+	}
+	target := lv.results[lv.selectedIndex]
+	rel := relationshipOptions[lv.relIndex]
+
+	ref := &enrichment.CrossReference{
+		SourceTaskID: lv.sourceTask.ID,
+		TargetTaskID: target.ID,
+		SourceSystem: "user",
+		Relationship: rel,
+	}
+	if err := lv.enrichDB.AddCrossReference(ref); err != nil {
+		return func() tea.Msg {
+			return FlashMsg{Text: fmt.Sprintf("Failed to create link: %v", err)}
+		}
+	}
+
+	sourceID := lv.sourceTask.ID
+	targetID := target.ID
+	return func() tea.Msg {
+		return LinkCreatedMsg{
+			SourceTaskID: sourceID,
+			TargetTaskID: targetID,
+			Relationship: rel,
+		}
+	}
+}
+
+// View renders the link creation view.
+func (lv *LinkView) View() string {
+	s := strings.Builder{}
+
+	w := lv.width - 6
+	if w < 40 {
+		w = 40
+	}
+
+	s.WriteString(headerStyle.Render("LINK TASK"))
+	s.WriteString("\n\n")
+
+	sourceStyle := lipgloss.NewStyle().Bold(true)
+	fmt.Fprintf(&s, "Source: %s\n\n", sourceStyle.Render(lv.sourceTask.Text))
+
+	switch lv.step {
+	case linkStepSelectTarget:
+		s.WriteString("Search for target task:\n")
+		fmt.Fprintf(&s, "> %s_\n\n", lv.searchInput)
+
+		if len(lv.results) == 0 && lv.searchInput != "" {
+			s.WriteString(helpStyle.Render("No matching tasks found"))
+			s.WriteString("\n")
+		} else {
+			maxShow := 10
+			if len(lv.results) < maxShow {
+				maxShow = len(lv.results)
+			}
+			for i := 0; i < maxShow; i++ {
+				t := lv.results[i]
+				line := fmt.Sprintf("  %s", t.Text)
+				if i == lv.selectedIndex {
+					line = searchSelectedStyle.Render(line)
+				} else {
+					line = searchResultStyle.Render(line)
+				}
+				s.WriteString(line)
+				s.WriteString("\n")
+			}
+			if len(lv.results) > maxShow {
+				fmt.Fprintf(&s, "  ... and %d more\n", len(lv.results)-maxShow)
+			}
+		}
+		s.WriteString("\n")
+		s.WriteString(helpStyle.Render("Type to search | ↑/↓ navigate | Enter select | Esc cancel"))
+
+	case linkStepSelectRelationship:
+		target := lv.results[lv.selectedIndex]
+		targetStyle := lipgloss.NewStyle().Bold(true)
+		fmt.Fprintf(&s, "Target: %s\n\n", targetStyle.Render(target.Text))
+		s.WriteString("Select relationship:\n\n")
+		for i, rel := range relationshipOptions {
+			if i == lv.relIndex {
+				fmt.Fprintf(&s, "  > %s\n", rel)
+			} else {
+				fmt.Fprintf(&s, "    %s\n", rel)
+			}
+		}
+		s.WriteString("\n")
+		s.WriteString(helpStyle.Render("↑/↓ select | Enter confirm | Esc back"))
+	}
+
+	return detailBorder.Width(w).Render(s.String())
+}

--- a/internal/tui/link_view_test.go
+++ b/internal/tui/link_view_test.go
@@ -1,0 +1,381 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arcaven/ThreeDoors/internal/enrichment"
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func setupLinkTest(t *testing.T) (*LinkView, *tasks.Task, *tasks.Task, *enrichment.DB) {
+	t.Helper()
+	source := tasks.NewTask("Source task")
+	target := tasks.NewTask("Target task")
+
+	pool := tasks.NewTaskPool()
+	pool.AddTask(source)
+	pool.AddTask(target)
+
+	dbPath := filepath.Join(t.TempDir(), "test-enrichment.db")
+	db, err := enrichment.Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open enrichment db: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("failed to close db: %v", closeErr)
+		}
+		_ = os.Remove(dbPath)
+	})
+
+	lv := NewLinkView(source, pool, db)
+	return lv, source, target, db
+}
+
+func TestLinkView_InitialState(t *testing.T) {
+	lv, source, _, _ := setupLinkTest(t)
+
+	if lv.sourceTask != source {
+		t.Error("source task should be set")
+	}
+	if lv.step != linkStepSelectTarget {
+		t.Error("initial step should be target selection")
+	}
+	if lv.selectedIndex != -1 {
+		t.Error("initial selected index should be -1")
+	}
+}
+
+func TestLinkView_SearchFiltersTargets(t *testing.T) {
+	lv, _, _, _ := setupLinkTest(t)
+
+	// Type "Targ" to search
+	for _, r := range "Targ" {
+		lv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	if len(lv.results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(lv.results))
+	}
+	if lv.results[0].Text != "Target task" {
+		t.Errorf("expected 'Target task', got %q", lv.results[0].Text)
+	}
+}
+
+func TestLinkView_ExcludesSourceTask(t *testing.T) {
+	lv, source, _, _ := setupLinkTest(t)
+
+	// Type "Source" to search
+	for _, r := range "Source" {
+		lv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	for _, r := range lv.results {
+		if r.ID == source.ID {
+			t.Error("source task should be excluded from results")
+		}
+	}
+}
+
+func TestLinkView_EscCancels(t *testing.T) {
+	lv, _, _, _ := setupLinkTest(t)
+
+	cmd := lv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc should produce a command")
+	}
+	msg := cmd()
+	if _, ok := msg.(LinkCancelledMsg); !ok {
+		t.Errorf("expected LinkCancelledMsg, got %T", msg)
+	}
+}
+
+func TestLinkView_SelectTargetAndRelationship(t *testing.T) {
+	lv, _, _, db := setupLinkTest(t)
+
+	// Type to filter
+	for _, r := range "Target" {
+		lv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	// Enter to select target
+	lv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if lv.step != linkStepSelectRelationship {
+		t.Fatal("should advance to relationship selection")
+	}
+
+	// Default is "related" (index 0); press Enter to confirm
+	cmd := lv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("confirming should produce a command")
+	}
+	msg := cmd()
+	linkMsg, ok := msg.(LinkCreatedMsg)
+	if !ok {
+		t.Fatalf("expected LinkCreatedMsg, got %T", msg)
+	}
+	if linkMsg.Relationship != "related" {
+		t.Errorf("expected relationship 'related', got %q", linkMsg.Relationship)
+	}
+
+	// Verify the cross-reference was stored
+	refs, err := db.GetCrossReferences(linkMsg.SourceTaskID)
+	if err != nil {
+		t.Fatalf("failed to get cross references: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 cross reference, got %d", len(refs))
+	}
+	if refs[0].Relationship != "related" {
+		t.Errorf("stored relationship should be 'related', got %q", refs[0].Relationship)
+	}
+}
+
+func TestLinkView_RelationshipNavigation(t *testing.T) {
+	lv, _, _, _ := setupLinkTest(t)
+
+	// Type to filter and select
+	for _, r := range "Target" {
+		lv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	lv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if lv.relIndex != 0 {
+		t.Fatal("default relationship index should be 0")
+	}
+
+	// Navigate down
+	lv.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if lv.relIndex != 1 {
+		t.Errorf("expected relIndex 1, got %d", lv.relIndex)
+	}
+
+	lv.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if lv.relIndex != 2 {
+		t.Errorf("expected relIndex 2, got %d", lv.relIndex)
+	}
+
+	// Can't go past end
+	lv.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if lv.relIndex != 2 {
+		t.Errorf("should stay at 2, got %d", lv.relIndex)
+	}
+
+	// Navigate up
+	lv.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if lv.relIndex != 1 {
+		t.Errorf("expected relIndex 1 after up, got %d", lv.relIndex)
+	}
+}
+
+func TestLinkView_EscFromRelationshipReturnsToTarget(t *testing.T) {
+	lv, _, _, _ := setupLinkTest(t)
+
+	for _, r := range "Target" {
+		lv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	lv.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if lv.step != linkStepSelectRelationship {
+		t.Fatal("should be on relationship step")
+	}
+
+	lv.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if lv.step != linkStepSelectTarget {
+		t.Error("esc from relationship should return to target selection")
+	}
+}
+
+func TestLinkView_ViewRendering(t *testing.T) {
+	lv, _, _, _ := setupLinkTest(t)
+	lv.SetWidth(80)
+
+	view := lv.View()
+	if !strings.Contains(view, "LINK TASK") {
+		t.Error("view should contain header")
+	}
+	if !strings.Contains(view, "Source task") {
+		t.Error("view should show source task")
+	}
+}
+
+func TestDetailView_LinkedTasksDisplay(t *testing.T) {
+	source := tasks.NewTask("Source task")
+	target := tasks.NewTask("Target task")
+
+	pool := tasks.NewTaskPool()
+	pool.AddTask(source)
+	pool.AddTask(target)
+
+	dbPath := filepath.Join(t.TempDir(), "test-enrichment.db")
+	db, err := enrichment.Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open enrichment db: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("failed to close db: %v", closeErr)
+		}
+		_ = os.Remove(dbPath)
+	})
+
+	// Create a cross-reference
+	ref := &enrichment.CrossReference{
+		SourceTaskID: source.ID,
+		TargetTaskID: target.ID,
+		SourceSystem: "user",
+		Relationship: "related",
+	}
+	if addErr := db.AddCrossReference(ref); addErr != nil {
+		t.Fatalf("failed to add cross reference: %v", addErr)
+	}
+
+	dv := NewDetailView(source, nil)
+	dv.SetEnrichDB(db, pool)
+	dv.SetWidth(80)
+
+	view := dv.View()
+	if !strings.Contains(view, "Linked Tasks") {
+		t.Error("detail view should show 'Linked Tasks' section")
+	}
+	if !strings.Contains(view, "Target task") {
+		t.Error("detail view should show linked task text")
+	}
+	if !strings.Contains(view, "related") {
+		t.Error("detail view should show relationship type")
+	}
+}
+
+func TestDetailView_NoLinkedTasks_NoSection(t *testing.T) {
+	source := tasks.NewTask("Source task")
+	pool := tasks.NewTaskPool()
+	pool.AddTask(source)
+
+	dbPath := filepath.Join(t.TempDir(), "test-enrichment.db")
+	db, err := enrichment.Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open enrichment db: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("failed to close db: %v", closeErr)
+		}
+		_ = os.Remove(dbPath)
+	})
+
+	dv := NewDetailView(source, nil)
+	dv.SetEnrichDB(db, pool)
+	dv.SetWidth(80)
+
+	view := dv.View()
+	if strings.Contains(view, "Linked Tasks") {
+		t.Error("detail view should NOT show 'Linked Tasks' when none exist")
+	}
+}
+
+func TestDetailView_NavigateToLinkedTask(t *testing.T) {
+	source := tasks.NewTask("Source task")
+	target := tasks.NewTask("Target task")
+
+	pool := tasks.NewTaskPool()
+	pool.AddTask(source)
+	pool.AddTask(target)
+
+	dbPath := filepath.Join(t.TempDir(), "test-enrichment.db")
+	db, err := enrichment.Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open enrichment db: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("failed to close db: %v", closeErr)
+		}
+		_ = os.Remove(dbPath)
+	})
+
+	ref := &enrichment.CrossReference{
+		SourceTaskID: source.ID,
+		TargetTaskID: target.ID,
+		SourceSystem: "user",
+		Relationship: "blocks",
+	}
+	if addErr := db.AddCrossReference(ref); addErr != nil {
+		t.Fatalf("failed to add cross reference: %v", addErr)
+	}
+
+	dv := NewDetailView(source, nil)
+	dv.SetEnrichDB(db, pool)
+
+	// Press "1" to navigate to first linked task
+	cmd := dv.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	if cmd == nil {
+		t.Fatal("pressing '1' with a linked task should produce a command")
+	}
+	msg := cmd()
+	navMsg, ok := msg.(NavigateToLinkedTaskMsg)
+	if !ok {
+		t.Fatalf("expected NavigateToLinkedTaskMsg, got %T", msg)
+	}
+	if navMsg.TaskID != target.ID {
+		t.Errorf("expected target task ID %s, got %s", target.ID, navMsg.TaskID)
+	}
+}
+
+func TestMainModel_LinkCommandFlow(t *testing.T) {
+	source := tasks.NewTask("Source task")
+	target := tasks.NewTask("Target task")
+
+	pool := tasks.NewTaskPool()
+	pool.AddTask(source)
+	pool.AddTask(target)
+
+	dbPath := filepath.Join(t.TempDir(), "test-enrichment.db")
+	db, err := enrichment.Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open enrichment db: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("failed to close db: %v", closeErr)
+		}
+		_ = os.Remove(dbPath)
+	})
+
+	tracker := tasks.NewSessionTracker()
+	m := NewMainModel(pool, tracker, &testProvider{}, nil, false, db)
+
+	// Open detail view for source task
+	m.detailView = NewDetailView(source, tracker)
+	m.detailView.SetEnrichDB(db, pool)
+	m.viewMode = ViewDetail
+
+	// Send ShowLinkViewMsg
+	m.Update(ShowLinkViewMsg{SourceTask: source})
+
+	if m.viewMode != ViewLink {
+		t.Errorf("expected ViewLink mode, got %d", m.viewMode)
+	}
+	if m.linkView == nil {
+		t.Fatal("linkView should be created")
+	}
+}
+
+func TestMainModel_ShowLinkViewMsg_NoEnrichDB(t *testing.T) {
+	pool := tasks.NewTaskPool()
+	pool.AddTask(tasks.NewTask("task"))
+	tracker := tasks.NewSessionTracker()
+	m := NewMainModel(pool, tracker, &testProvider{}, nil, false, nil)
+
+	m.Update(ShowLinkViewMsg{SourceTask: pool.GetAllTasks()[0]})
+
+	if m.viewMode == ViewLink {
+		t.Error("should NOT enter ViewLink when enrichDB is nil")
+	}
+	if m.flash == "" {
+		t.Error("should show flash message about unavailable DB")
+	}
+}

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/arcaven/ThreeDoors/internal/enrichment"
 	"github.com/arcaven/ThreeDoors/internal/tasks"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -27,6 +28,7 @@ const (
 	ViewAvoidancePrompt
 	ViewInsights
 	ViewOnboarding
+	ViewLink
 )
 
 // MainModel is the root Bubbletea model that orchestrates view transitions.
@@ -46,6 +48,7 @@ type MainModel struct {
 	avoidancePromptView *AvoidancePromptView
 	insightsView        *InsightsView
 	onboardingView      *OnboardingView
+	linkView            *LinkView
 	pool                *tasks.TaskPool
 	tracker             *tasks.SessionTracker
 	provider            tasks.TaskProvider
@@ -54,6 +57,7 @@ type MainModel struct {
 	patternReport       *tasks.PatternReport
 	patternAnalyzer     *tasks.PatternAnalyzer
 	valuesConfig        *tasks.ValuesConfig
+	enrichDB            *enrichment.DB
 	flash               string
 	width               int
 	height              int
@@ -64,7 +68,7 @@ type MainModel struct {
 
 // NewMainModel creates the root application model.
 // If isFirstRun is true, the onboarding wizard is shown before the doors view.
-func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider tasks.TaskProvider, hc *tasks.HealthChecker, isFirstRun bool) *MainModel {
+func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider tasks.TaskProvider, hc *tasks.HealthChecker, isFirstRun bool, enrichDB *enrichment.DB) *MainModel {
 	// Load values config
 	var valuesConfig *tasks.ValuesConfig
 	if path, err := tasks.GetValuesConfigPath(); err == nil {
@@ -109,6 +113,7 @@ func NewMainModel(pool *tasks.TaskPool, tracker *tasks.SessionTracker, provider 
 		patternReport:     patternReport,
 		patternAnalyzer:   pa,
 		valuesConfig:      valuesConfig,
+		enrichDB:          enrichDB,
 		promptedTasks:     make(map[string]bool),
 	}
 
@@ -167,6 +172,9 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.onboardingView != nil {
 			m.onboardingView.SetWidth(msg.Width)
+		}
+		if m.linkView != nil {
+			m.linkView.SetWidth(msg.Width)
 		}
 		return m, nil
 
@@ -232,6 +240,7 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.previousView = ViewSearch
 		m.detailView = NewDetailView(msg.Task, m.tracker)
+		m.detailView.SetEnrichDB(m.enrichDB, m.pool)
 		m.detailView.SetWidth(m.width)
 		m.viewMode = ViewDetail
 		return m, nil
@@ -459,12 +468,14 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.detailView = NewDetailView(msg.Task, m.tracker)
+			m.detailView.SetEnrichDB(m.enrichDB, m.pool)
 			m.detailView.SetWidth(m.width)
 			m.viewMode = ViewDetail
 			m.flash = "Taking it on!"
 			return m, ClearFlashCmd()
 		case "breakdown":
 			m.detailView = NewDetailView(msg.Task, m.tracker)
+			m.detailView.SetEnrichDB(m.enrichDB, m.pool)
 			m.detailView.SetWidth(m.width)
 			m.viewMode = ViewDetail
 			return m, nil
@@ -507,6 +518,60 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case ShowLinkViewMsg:
+		if m.enrichDB == nil {
+			m.flash = "Enrichment database not available"
+			return m, ClearFlashCmd()
+		}
+		// Use the task from detail view if available, otherwise from the message
+		sourceTask := msg.SourceTask
+		if sourceTask == nil && m.detailView != nil {
+			sourceTask = m.detailView.task
+		}
+		if sourceTask == nil {
+			m.flash = "Open a task first, then use :link"
+			return m, ClearFlashCmd()
+		}
+		m.linkView = NewLinkView(sourceTask, m.pool, m.enrichDB)
+		m.linkView.SetWidth(m.width)
+		m.previousView = m.viewMode
+		m.viewMode = ViewLink
+		return m, nil
+
+	case LinkCreatedMsg:
+		m.linkView = nil
+		m.flash = fmt.Sprintf("Linked: %s", msg.Relationship)
+		// Return to detail view if we came from there
+		if m.previousView == ViewDetail && m.detailView != nil {
+			m.detailView.RefreshLinks()
+			m.viewMode = ViewDetail
+		} else {
+			m.viewMode = ViewDoors
+			m.doorsView.RefreshDoors()
+		}
+		return m, ClearFlashCmd()
+
+	case LinkCancelledMsg:
+		m.linkView = nil
+		if m.previousView == ViewDetail && m.detailView != nil {
+			m.viewMode = ViewDetail
+		} else {
+			m.viewMode = ViewDoors
+		}
+		return m, nil
+
+	case NavigateToLinkedTaskMsg:
+		target := m.pool.GetTask(msg.TaskID)
+		if target == nil {
+			m.flash = "Linked task not found in pool"
+			return m, ClearFlashCmd()
+		}
+		m.detailView = NewDetailView(target, m.tracker)
+		m.detailView.SetEnrichDB(m.enrichDB, m.pool)
+		m.detailView.SetWidth(m.width)
+		m.viewMode = ViewDetail
+		return m, nil
+
 	case FlashMsg:
 		m.flash = msg.Text
 		return m, ClearFlashCmd()
@@ -540,6 +605,8 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateAvoidancePrompt(msg)
 	case ViewOnboarding:
 		return m.updateOnboarding(msg)
+	case ViewLink:
+		return m.updateLink(msg)
 	}
 
 	return m, nil
@@ -584,6 +651,7 @@ func (m *MainModel) updateDoors(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.tracker.RecordDoorSelection(m.doorsView.selectedDoorIndex, task.Text)
 				}
 				m.detailView = NewDetailView(task, m.tracker)
+				m.detailView.SetEnrichDB(m.enrichDB, m.pool)
 				m.detailView.SetWidth(m.width)
 				m.viewMode = ViewDetail
 			}
@@ -693,6 +761,14 @@ func (m *MainModel) updateOnboarding(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *MainModel) updateLink(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.linkView == nil {
+		return m, nil
+	}
+	cmd := m.linkView.Update(msg)
+	return m, cmd
+}
+
 func (m *MainModel) updateValues(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.valuesView == nil {
 		return m, nil
@@ -774,6 +850,10 @@ func (m *MainModel) View() string {
 	case ViewOnboarding:
 		if m.onboardingView != nil {
 			view = m.onboardingView.View()
+		}
+	case ViewLink:
+		if m.linkView != nil {
+			view = m.linkView.View()
 		}
 	default:
 		view = m.doorsView.View()

--- a/internal/tui/main_model_test.go
+++ b/internal/tui/main_model_test.go
@@ -52,7 +52,7 @@ func makeModel(texts ...string) *MainModel {
 func makeModelWithProvider(provider tasks.TaskProvider, texts ...string) *MainModel {
 	pool := makePool(texts...)
 	tracker := tasks.NewSessionTracker()
-	return NewMainModel(pool, tracker, provider, nil, false)
+	return NewMainModel(pool, tracker, provider, nil, false, nil)
 }
 
 func keyMsg(s string) tea.Msg {
@@ -301,7 +301,7 @@ func TestDoorsView_RendersHelpText(t *testing.T) {
 func TestDoorsView_AllTasksDone_ShowsMessage(t *testing.T) {
 	pool := tasks.NewTaskPool()
 	tracker := tasks.NewSessionTracker()
-	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false)
+	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false, nil)
 	view := m.View()
 	if !strings.Contains(view, "All tasks done") {
 		t.Errorf("View should show 'All tasks done' when pool is empty, got: %s", view)
@@ -667,7 +667,7 @@ func TestColonKey_OpensSearchInCommandMode(t *testing.T) {
 func TestTaskAddedMsg_EmptyPool_AddsTask(t *testing.T) {
 	pool := tasks.NewTaskPool()
 	tracker := tasks.NewSessionTracker()
-	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false)
+	m := NewMainModel(pool, tracker, tasks.NewTextFileProvider(), nil, false, nil)
 
 	if m.pool.Count() != 0 {
 		t.Fatal("pool should start empty")

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -143,6 +143,26 @@ type ReturnToSearchMsg struct {
 // ShowInsightsMsg is sent to open the insights dashboard view.
 type ShowInsightsMsg struct{}
 
+// ShowLinkViewMsg is sent when :link is selected from command palette.
+type ShowLinkViewMsg struct {
+	SourceTask *tasks.Task
+}
+
+// LinkCreatedMsg is sent when a cross-reference has been created.
+type LinkCreatedMsg struct {
+	SourceTaskID string
+	TargetTaskID string
+	Relationship string
+}
+
+// LinkCancelledMsg is sent when the user cancels link creation.
+type LinkCancelledMsg struct{}
+
+// NavigateToLinkedTaskMsg is sent when the user selects a linked task to navigate to.
+type NavigateToLinkedTaskMsg struct {
+	TaskID string
+}
+
 // ClearFlashCmd returns a command that clears the flash after a delay.
 func ClearFlashCmd() tea.Cmd {
 	return tea.Tick(flashDuration, func(_ time.Time) tea.Msg {

--- a/internal/tui/search_view.go
+++ b/internal/tui/search_view.go
@@ -178,12 +178,15 @@ func (sv *SearchView) executeCommand() tea.Cmd {
 		}
 		return func() tea.Msg { return ShowValuesSetupMsg{} }
 
+	case "link":
+		return func() tea.Msg { return ShowLinkViewMsg{} }
+
 	case "tag":
 		return func() tea.Msg { return ShowTagViewMsg{} }
 
 	case "help":
 		return func() tea.Msg {
-			return FlashMsg{Text: "Commands: :add <text>, :add-ctx, :add --why, :tag, :goals [edit], :mood [mood], :stats, :dashboard, :insights [mood|avoidance], :health, :help, :quit | Keys: / search, a/w/d select, s re-roll, Enter open, m mood, q quit"}
+			return FlashMsg{Text: "Commands: :add <text>, :add-ctx, :add --why, :link, :tag, :goals [edit], :mood [mood], :stats, :dashboard, :insights [mood|avoidance], :health, :help, :quit"}
 		}
 
 	case "quit", "exit":


### PR DESCRIPTION
## Summary

- Wire `enrichment.DB` from `main.go` through `MainModel` to TUI views, enabling cross-reference features
- Add `:link` command to search/command palette for creating cross-references between tasks
- Create `LinkView` with two-step flow: search/select target task, then choose relationship type (related, blocks, depends-on)
- Show "Linked Tasks" section in `DetailView` when cross-references exist in `enrichment.db`
- Support navigation to linked tasks via number keys (1-9) from detail view
- Add `[L]ink` keyboard shortcut to detail view action bar
- 13 new tests covering link creation, filtering, navigation, and edge cases

## Files Changed

- `cmd/threedoors/main.go` — Pass `enrichDB` to `NewMainModel`
- `internal/tui/main_model.go` — Add `ViewLink` mode, wire enrichDB, handle link messages
- `internal/tui/detail_view.go` — Show linked tasks section, support navigation keys
- `internal/tui/search_view.go` — Add `:link` command
- `internal/tui/messages.go` — Add `ShowLinkViewMsg`, `LinkCreatedMsg`, `LinkCancelledMsg`, `NavigateToLinkedTaskMsg`
- `internal/tui/link_view.go` — New view for cross-reference creation flow
- `internal/tui/link_view_test.go` — 13 tests for link functionality
- `docs/stories/6.2.story.md` — Story file

## Acceptance Criteria Coverage

- [x] AC:1 — `:link` command opens LinkView, user can search/select target, choose relationship, stored in enrichment.db
- [x] AC:2 — Linked tasks show "Linked Tasks" section in detail view with relationship type
- [x] AC:3 — Number keys (1-9) navigate to linked tasks from detail view

## Test plan

- [x] `go test ./... -count=1` — all 6 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofumpt -l .` — clean
- [x] `go vet ./...` — clean

## Notes

- Resolved merge conflicts with Story 10.1 (onboarding) that was merged concurrently — both `isFirstRun` and `enrichDB` params now accepted by `NewMainModel`
- Cross-reference CRUD already existed in `internal/enrichment/cross_references.go` from Story 5.1-enrichment (PR #53); this PR builds the TUI integration layer on top