### PR TITLE
feat: Story 10.2 - Values/Goals Setup & Task Import in Onboarding

### DIFF
--- a/docs/stories/10.2.story.md
+++ b/docs/stories/10.2.story.md
@@ -1,0 +1,71 @@
+# Story 10.2: Values/Goals Setup & Task Import
+
+## Story
+
+As a new user,
+I want to set up values/goals and import tasks during onboarding,
+So that the tool is immediately useful.
+
+## Status
+
+In Progress
+
+## Prerequisites
+
+- Story 10.1 (Welcome Flow & Three Doors Explanation) - COMPLETE
+
+## Acceptance Criteria
+
+**Given** onboarding flow reaches setup step
+**When** user enters values/goals
+**Then** values persist to config.yaml
+**And** import detection for common task sources (text, Markdown)
+**And** import preview shows tasks before importing
+**And** step is skippable; manual import via `:import` command later
+
+## Technical Design
+
+### Extended Onboarding Flow
+
+Add two new steps to the onboarding wizard after keybindings:
+
+1. Welcome (existing)
+2. Key Bindings (existing)
+3. **Values/Goals Setup** (NEW) - reuse ValuesConfig persistence
+4. **Task Import** (NEW) - detect and import from text/Markdown files
+5. Done (existing, updated summary)
+
+### Values/Goals Onboarding Step
+
+- Inline text input for entering 1-5 values/goals
+- Reuse existing `ValuesConfig` and `SaveValuesConfig()` for persistence
+- Skippable with Esc (values entered so far are saved)
+
+### Task Import Step
+
+- Allow user to enter a file path for import
+- Support formats: plain text (one task per line), Markdown (checkbox syntax)
+- Preview: show count and first few tasks before confirming
+- Import creates Task objects and saves via provider
+- Skippable with Esc
+
+### New Files
+
+- `internal/tasks/task_importer.go` - file parsing logic
+- `internal/tasks/task_importer_test.go` - tests
+
+### Modified Files
+
+- `internal/tui/onboarding_view.go` - add values/goals + import steps
+- `internal/tui/onboarding_view_test.go` - update tests
+- `internal/tui/main_model.go` - handle new onboarding messages
+- `internal/tui/messages.go` - add OnboardingTasksImportedMsg
+
+## Quality Gate
+
+- gofumpt formatted
+- golangci-lint passes
+- All tests pass
+- Table-driven tests for >2 cases
+- stdlib testing only (no testify)
+- t.Helper() in helpers, t.Cleanup() for cleanup

--- a/internal/tasks/task_importer.go
+++ b/internal/tasks/task_importer.go
@@ -1,0 +1,171 @@
+package tasks
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ImportResult holds the outcome of a task import operation.
+type ImportResult struct {
+	Tasks      []*Task
+	SourcePath string
+	Format     string // "text" or "markdown"
+}
+
+// ImportTasksFromFile reads tasks from a file at the given path.
+// Supports plain text (one task per line) and Markdown (checkbox syntax).
+func ImportTasksFromFile(path string) (*ImportResult, error) {
+	absPath, err := expandPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("expand path: %w", err)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("read file %q: %w", absPath, err)
+	}
+
+	format := detectFormat(absPath, string(data))
+	var imported []*Task
+
+	switch format {
+	case "markdown":
+		imported = parseMarkdownTasks(string(data))
+	default:
+		imported = parseTextTasks(string(data))
+	}
+
+	return &ImportResult{
+		Tasks:      imported,
+		SourcePath: absPath,
+		Format:     format,
+	}, nil
+}
+
+// detectFormat determines the file format based on extension and content.
+func detectFormat(path string, content string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == ".md" || ext == ".markdown" {
+		return "markdown"
+	}
+
+	// Check content for markdown checkbox patterns
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "- [ ] ") || strings.HasPrefix(line, "- [x] ") ||
+			strings.HasPrefix(line, "- [X] ") || strings.HasPrefix(line, "* [ ] ") ||
+			strings.HasPrefix(line, "* [x] ") || strings.HasPrefix(line, "* [X] ") {
+			return "markdown"
+		}
+	}
+
+	return "text"
+}
+
+// parseTextTasks parses plain text with one task per line.
+func parseTextTasks(content string) []*Task {
+	var result []*Task
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" || strings.HasPrefix(text, "#") {
+			continue
+		}
+		// Strip leading list markers (-, *, numbers)
+		text = stripListMarker(text)
+		if text == "" {
+			continue
+		}
+		if len(text) > 500 {
+			text = text[:500]
+		}
+		result = append(result, NewTask(text))
+	}
+	return result
+}
+
+// parseMarkdownTasks parses Markdown checkbox items.
+func parseMarkdownTasks(content string) []*Task {
+	var result []*Task
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		text, completed := parseCheckbox(line)
+		if text == "" {
+			continue
+		}
+		if len(text) > 500 {
+			text = text[:500]
+		}
+		task := NewTask(text)
+		if completed {
+			now := task.CreatedAt
+			task.Status = StatusComplete
+			task.CompletedAt = &now
+		}
+		result = append(result, task)
+	}
+	return result
+}
+
+// parseCheckbox extracts task text from a Markdown checkbox line.
+// Returns the text and whether the checkbox was checked.
+// Returns empty string if the line is not a checkbox.
+func parseCheckbox(line string) (string, bool) {
+	prefixes := []struct {
+		prefix    string
+		completed bool
+	}{
+		{"- [x] ", true},
+		{"- [X] ", true},
+		{"* [x] ", true},
+		{"* [X] ", true},
+		{"- [ ] ", false},
+		{"* [ ] ", false},
+	}
+
+	for _, p := range prefixes {
+		if strings.HasPrefix(line, p.prefix) {
+			text := strings.TrimSpace(line[len(p.prefix):])
+			return text, p.completed
+		}
+	}
+	return "", false
+}
+
+// stripListMarker removes common list markers from a line.
+func stripListMarker(line string) string {
+	// Remove "- ", "* ", "1. ", "2) " etc.
+	if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") {
+		return strings.TrimSpace(line[2:])
+	}
+
+	// Numbered lists: "1. " or "1) "
+	for i, c := range line {
+		if c >= '0' && c <= '9' {
+			continue
+		}
+		if (c == '.' || c == ')') && i > 0 && i < len(line)-1 && line[i+1] == ' ' {
+			return strings.TrimSpace(line[i+2:])
+		}
+		break
+	}
+
+	return line
+}
+
+// expandPath expands ~ to home directory and cleans the path.
+func expandPath(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get home dir: %w", err)
+		}
+		path = filepath.Join(home, path[2:])
+	}
+	return filepath.Clean(path), nil
+}

--- a/internal/tasks/task_importer_test.go
+++ b/internal/tasks/task_importer_test.go
@@ -1,0 +1,315 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    string
+	}{
+		{
+			name:    "markdown extension",
+			path:    "tasks.md",
+			content: "some content",
+			want:    "markdown",
+		},
+		{
+			name:    "markdown extension uppercase",
+			path:    "tasks.MARKDOWN",
+			content: "some content",
+			want:    "markdown",
+		},
+		{
+			name:    "text extension",
+			path:    "tasks.txt",
+			content: "some content",
+			want:    "text",
+		},
+		{
+			name:    "no extension with checkbox content",
+			path:    "tasks",
+			content: "- [ ] Buy groceries\n- [x] Walk the dog",
+			want:    "markdown",
+		},
+		{
+			name:    "no extension plain text",
+			path:    "tasks",
+			content: "Buy groceries\nWalk the dog",
+			want:    "text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := detectFormat(tt.path, tt.content)
+			if got != tt.want {
+				t.Errorf("detectFormat(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTextTasks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantTexts []string
+	}{
+		{
+			name:      "simple lines",
+			content:   "Buy groceries\nWalk the dog\nWrite code",
+			wantCount: 3,
+			wantTexts: []string{"Buy groceries", "Walk the dog", "Write code"},
+		},
+		{
+			name:      "with list markers",
+			content:   "- Buy groceries\n* Walk the dog\n1. Write code\n2) Read a book",
+			wantCount: 4,
+			wantTexts: []string{"Buy groceries", "Walk the dog", "Write code", "Read a book"},
+		},
+		{
+			name:      "skips empty lines and comments",
+			content:   "Buy groceries\n\n# Shopping list\nWalk the dog\n\n",
+			wantCount: 2,
+			wantTexts: []string{"Buy groceries", "Walk the dog"},
+		},
+		{
+			name:      "empty content",
+			content:   "",
+			wantCount: 0,
+		},
+		{
+			name:      "whitespace only",
+			content:   "   \n  \n\n",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseTextTasks(tt.content)
+			if len(got) != tt.wantCount {
+				t.Fatalf("parseTextTasks() returned %d tasks, want %d", len(got), tt.wantCount)
+			}
+			for i, wantText := range tt.wantTexts {
+				if got[i].Text != wantText {
+					t.Errorf("task[%d].Text = %q, want %q", i, got[i].Text, wantText)
+				}
+			}
+		})
+	}
+}
+
+func TestParseMarkdownTasks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		content       string
+		wantCount     int
+		wantTexts     []string
+		wantCompleted []bool
+	}{
+		{
+			name:          "mixed checkboxes",
+			content:       "- [ ] Buy groceries\n- [x] Walk the dog\n- [ ] Write code",
+			wantCount:     3,
+			wantTexts:     []string{"Buy groceries", "Walk the dog", "Write code"},
+			wantCompleted: []bool{false, true, false},
+		},
+		{
+			name:          "asterisk markers",
+			content:       "* [ ] Task one\n* [X] Task two",
+			wantCount:     2,
+			wantTexts:     []string{"Task one", "Task two"},
+			wantCompleted: []bool{false, true},
+		},
+		{
+			name:      "ignores non-checkbox lines",
+			content:   "# My Tasks\n- [ ] Real task\nSome random text\n- [x] Done task",
+			wantCount: 2,
+			wantTexts: []string{"Real task", "Done task"},
+		},
+		{
+			name:      "empty content",
+			content:   "",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseMarkdownTasks(tt.content)
+			if len(got) != tt.wantCount {
+				t.Fatalf("parseMarkdownTasks() returned %d tasks, want %d", len(got), tt.wantCount)
+			}
+			for i, wantText := range tt.wantTexts {
+				if got[i].Text != wantText {
+					t.Errorf("task[%d].Text = %q, want %q", i, got[i].Text, wantText)
+				}
+			}
+			for i, wantDone := range tt.wantCompleted {
+				isComplete := got[i].Status == StatusComplete
+				if isComplete != wantDone {
+					t.Errorf("task[%d] completed = %v, want %v", i, isComplete, wantDone)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCheckbox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		line          string
+		wantText      string
+		wantCompleted bool
+	}{
+		{"unchecked dash", "- [ ] Buy milk", "Buy milk", false},
+		{"checked dash", "- [x] Walk dog", "Walk dog", true},
+		{"checked dash uppercase", "- [X] Code review", "Code review", true},
+		{"unchecked asterisk", "* [ ] Read book", "Read book", false},
+		{"checked asterisk", "* [x] Send email", "Send email", true},
+		{"not a checkbox", "Buy groceries", "", false},
+		{"heading", "# Tasks", "", false},
+		{"plain list", "- Buy groceries", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			text, completed := parseCheckbox(tt.line)
+			if text != tt.wantText {
+				t.Errorf("parseCheckbox(%q) text = %q, want %q", tt.line, text, tt.wantText)
+			}
+			if completed != tt.wantCompleted {
+				t.Errorf("parseCheckbox(%q) completed = %v, want %v", tt.line, completed, tt.wantCompleted)
+			}
+		})
+	}
+}
+
+func TestStripListMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"dash", "- Buy groceries", "Buy groceries"},
+		{"asterisk", "* Walk the dog", "Walk the dog"},
+		{"numbered dot", "1. Write code", "Write code"},
+		{"numbered paren", "2) Read a book", "Read a book"},
+		{"no marker", "Buy groceries", "Buy groceries"},
+		{"double digit", "12. Big list item", "Big list item"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := stripListMarker(tt.line)
+			if got != tt.want {
+				t.Errorf("stripListMarker(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImportTasksFromFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tasks.txt")
+		content := "Buy groceries\nWalk the dog\nWrite code"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := ImportTasksFromFile(path)
+		if err != nil {
+			t.Fatalf("ImportTasksFromFile() error = %v", err)
+		}
+		if result.Format != "text" {
+			t.Errorf("format = %q, want %q", result.Format, "text")
+		}
+		if len(result.Tasks) != 3 {
+			t.Errorf("got %d tasks, want 3", len(result.Tasks))
+		}
+	})
+
+	t.Run("markdown file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tasks.md")
+		content := "# My Tasks\n- [ ] Buy groceries\n- [x] Walk the dog\n- [ ] Write code"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := ImportTasksFromFile(path)
+		if err != nil {
+			t.Fatalf("ImportTasksFromFile() error = %v", err)
+		}
+		if result.Format != "markdown" {
+			t.Errorf("format = %q, want %q", result.Format, "markdown")
+		}
+		if len(result.Tasks) != 3 {
+			t.Errorf("got %d tasks, want 3", len(result.Tasks))
+		}
+	})
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		t.Parallel()
+		_, err := ImportTasksFromFile("/nonexistent/path/tasks.txt")
+		if err == nil {
+			t.Error("ImportTasksFromFile() expected error for nonexistent file")
+		}
+	})
+}
+
+func TestExpandPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absolute path unchanged", func(t *testing.T) {
+		t.Parallel()
+		got, err := expandPath("/tmp/tasks.txt")
+		if err != nil {
+			t.Fatalf("expandPath() error = %v", err)
+		}
+		if got != "/tmp/tasks.txt" {
+			t.Errorf("expandPath() = %q, want %q", got, "/tmp/tasks.txt")
+		}
+	})
+
+	t.Run("tilde expansion", func(t *testing.T) {
+		t.Parallel()
+		got, err := expandPath("~/tasks.txt")
+		if err != nil {
+			t.Fatalf("expandPath() error = %v", err)
+		}
+		home, _ := os.UserHomeDir()
+		want := filepath.Join(home, "tasks.txt")
+		if got != want {
+			t.Errorf("expandPath() = %q, want %q", got, want)
+		}
+	})
+}

--- a/internal/tui/main_model.go
+++ b/internal/tui/main_model.go
@@ -507,6 +507,25 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case OnboardingCompletedMsg:
 		m.onboardingView = nil
 		m.viewMode = ViewDoors
+		// Save values if provided
+		if len(msg.Values) > 0 {
+			m.valuesConfig = &tasks.ValuesConfig{Values: msg.Values}
+			if path, err := tasks.GetValuesConfigPath(); err == nil {
+				if saveErr := tasks.SaveValuesConfig(path, m.valuesConfig); saveErr != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to save values config: %v\n", saveErr)
+				}
+			}
+		}
+		// Import tasks if provided
+		if len(msg.ImportedTasks) > 0 {
+			for _, t := range msg.ImportedTasks {
+				m.pool.AddTask(t)
+			}
+			if err := m.saveTasks(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to save imported tasks: %v\n", err)
+			}
+			m.flash = fmt.Sprintf("%d tasks imported!", len(msg.ImportedTasks))
+		}
 		m.doorsView.RefreshDoors()
 		// Persist onboarding state
 		if configDir, err := tasks.GetConfigDirPath(); err == nil {
@@ -514,7 +533,11 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				fmt.Fprintf(os.Stderr, "warning: failed to save onboarding state: %v\n", markErr)
 			}
 		}
-		return m, nil
+		var cmd tea.Cmd
+		if m.flash != "" {
+			cmd = ClearFlashCmd()
+		}
+		return m, cmd
 
 	case FlashMsg:
 		m.flash = msg.Text

--- a/internal/tui/onboarding_view.go
+++ b/internal/tui/onboarding_view.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -13,30 +15,85 @@ type onboardingStep int
 const (
 	stepWelcome onboardingStep = iota
 	stepKeybindings
+	stepValues
+	stepImport
+	stepImportPreview
 	stepDone
 )
 
-// OnboardingView guides first-time users through the Three Doors concept.
+const onboardingTotalSteps = 5
+
+// OnboardingView guides first-time users through the Three Doors concept,
+// values/goals setup, and task import.
 type OnboardingView struct {
 	step       onboardingStep
 	width      int
 	triedKeys  map[string]bool
 	lastAction string
+
+	// Values/goals state
+	values    []string
+	textInput textinput.Model
+
+	// Import state
+	importResult *tasks.ImportResult
+	importError  string
 }
 
 // OnboardingCompletedMsg is sent when onboarding finishes.
-type OnboardingCompletedMsg struct{}
+type OnboardingCompletedMsg struct {
+	Values        []string
+	ImportedTasks []*tasks.Task
+}
 
 // NewOnboardingView creates a new onboarding wizard.
 func NewOnboardingView() *OnboardingView {
+	ti := textinput.New()
+	ti.CharLimit = 200
+	ti.Width = 40
+
 	return &OnboardingView{
 		triedKeys: make(map[string]bool),
+		textInput: ti,
 	}
 }
 
 // SetWidth sets the terminal width for rendering.
 func (ov *OnboardingView) SetWidth(w int) {
 	ov.width = w
+	if w > 6 {
+		ov.textInput.Width = w - 6
+	}
+}
+
+func (ov *OnboardingView) completeMsg() tea.Cmd {
+	values := ov.values
+	var imported []*tasks.Task
+	if ov.importResult != nil {
+		imported = ov.importResult.Tasks
+	}
+	return func() tea.Msg {
+		return OnboardingCompletedMsg{
+			Values:        values,
+			ImportedTasks: imported,
+		}
+	}
+}
+
+func (ov *OnboardingView) stepNumber() int {
+	switch ov.step {
+	case stepWelcome:
+		return 1
+	case stepKeybindings:
+		return 2
+	case stepValues:
+		return 3
+	case stepImport, stepImportPreview:
+		return 4
+	case stepDone:
+		return 5
+	}
+	return 1
 }
 
 // Update handles key input for the onboarding wizard.
@@ -45,46 +102,172 @@ func (ov *OnboardingView) Update(msg tea.Msg) tea.Cmd {
 	case tea.KeyMsg:
 		key := msg.String()
 
-		// Skip remaining onboarding at any step
-		if key == "esc" || key == "ctrl+c" {
-			return func() tea.Msg { return OnboardingCompletedMsg{} }
+		// Skip remaining onboarding at any step (except when typing)
+		if key == "ctrl+c" {
+			return ov.completeMsg()
 		}
 
 		switch ov.step {
 		case stepWelcome:
-			if key == "enter" || key == " " {
-				ov.step = stepKeybindings
-			}
-			return nil
-
+			return ov.updateWelcome(key)
 		case stepKeybindings:
-			switch key {
-			case "enter":
-				ov.step = stepDone
-				return nil
-			case "a", "left":
-				ov.triedKeys["left"] = true
-				ov.lastAction = "Left door selected!"
-			case "w", "up":
-				ov.triedKeys["up"] = true
-				ov.lastAction = "Center door selected!"
-			case "d", "right":
-				ov.triedKeys["right"] = true
-				ov.lastAction = "Right door selected!"
-			case "s", "down":
-				ov.triedKeys["reroll"] = true
-				ov.lastAction = "Doors re-rolled!"
-			default:
-				ov.lastAction = ""
-			}
-			return nil
-
+			return ov.updateKeybindings(key)
+		case stepValues:
+			return ov.updateValues(msg)
+		case stepImport:
+			return ov.updateImport(msg)
+		case stepImportPreview:
+			return ov.updateImportPreview(key)
 		case stepDone:
-			if key == "enter" || key == " " {
-				return func() tea.Msg { return OnboardingCompletedMsg{} }
-			}
+			return ov.updateDone(key)
+		}
+	}
+
+	// Let textinput handle non-key messages when active
+	if ov.step == stepValues || ov.step == stepImport {
+		var cmd tea.Cmd
+		ov.textInput, cmd = ov.textInput.Update(msg)
+		return cmd
+	}
+
+	return nil
+}
+
+func (ov *OnboardingView) updateWelcome(key string) tea.Cmd {
+	if key == "esc" {
+		return ov.completeMsg()
+	}
+	if key == "enter" || key == " " {
+		ov.step = stepKeybindings
+	}
+	return nil
+}
+
+func (ov *OnboardingView) updateKeybindings(key string) tea.Cmd {
+	if key == "esc" {
+		return ov.completeMsg()
+	}
+	switch key {
+	case "enter":
+		ov.step = stepValues
+		ov.textInput.Placeholder = "Enter a value or goal..."
+		ov.textInput.SetValue("")
+		ov.textInput.Focus()
+	case "a", "left":
+		ov.triedKeys["left"] = true
+		ov.lastAction = "Left door selected!"
+	case "w", "up":
+		ov.triedKeys["up"] = true
+		ov.lastAction = "Center door selected!"
+	case "d", "right":
+		ov.triedKeys["right"] = true
+		ov.lastAction = "Right door selected!"
+	case "s", "down":
+		ov.triedKeys["reroll"] = true
+		ov.lastAction = "Doors re-rolled!"
+	default:
+		ov.lastAction = ""
+	}
+	return nil
+}
+
+func (ov *OnboardingView) updateValues(msg tea.KeyMsg) tea.Cmd {
+	key := msg.String()
+
+	switch msg.Type {
+	case tea.KeyEscape:
+		ov.step = stepImport
+		ov.textInput.Placeholder = "Path to task file (e.g. ~/tasks.txt)..."
+		ov.textInput.SetValue("")
+		ov.importError = ""
+		return nil
+
+	case tea.KeyEnter:
+		text := strings.TrimSpace(ov.textInput.Value())
+		if text == "" {
+			// Empty enter = done with values, move to import
+			ov.step = stepImport
+			ov.textInput.Placeholder = "Path to task file (e.g. ~/tasks.txt)..."
+			ov.textInput.SetValue("")
+			ov.importError = ""
 			return nil
 		}
+		if len(ov.values) >= 5 {
+			return nil
+		}
+		if len(text) > 200 {
+			text = text[:200]
+		}
+		ov.values = append(ov.values, text)
+		ov.textInput.SetValue("")
+		if len(ov.values) >= 5 {
+			ov.step = stepImport
+			ov.textInput.Placeholder = "Path to task file (e.g. ~/tasks.txt)..."
+			ov.importError = ""
+		}
+		return nil
+	}
+
+	_ = key
+	var cmd tea.Cmd
+	ov.textInput, cmd = ov.textInput.Update(msg)
+	return cmd
+}
+
+func (ov *OnboardingView) updateImport(msg tea.KeyMsg) tea.Cmd {
+	switch msg.Type {
+	case tea.KeyEscape:
+		ov.step = stepDone
+		ov.textInput.Blur()
+		return nil
+
+	case tea.KeyEnter:
+		path := strings.TrimSpace(ov.textInput.Value())
+		if path == "" {
+			// Skip import
+			ov.step = stepDone
+			ov.textInput.Blur()
+			return nil
+		}
+
+		result, err := tasks.ImportTasksFromFile(path)
+		if err != nil {
+			ov.importError = err.Error()
+			return nil
+		}
+		if len(result.Tasks) == 0 {
+			ov.importError = "No tasks found in file"
+			return nil
+		}
+
+		ov.importResult = result
+		ov.importError = ""
+		ov.step = stepImportPreview
+		ov.textInput.Blur()
+		return nil
+	}
+
+	var cmd tea.Cmd
+	ov.textInput, cmd = ov.textInput.Update(msg)
+	return cmd
+}
+
+func (ov *OnboardingView) updateImportPreview(key string) tea.Cmd {
+	switch key {
+	case "esc", "n":
+		// Reject import
+		ov.importResult = nil
+		ov.step = stepDone
+	case "enter", "y":
+		// Accept import
+		ov.step = stepDone
+	}
+	return nil
+}
+
+func (ov *OnboardingView) updateDone(key string) tea.Cmd {
+	if key == "esc" || key == "enter" || key == " " {
+		return ov.completeMsg()
 	}
 	return nil
 }
@@ -102,6 +285,12 @@ func (ov *OnboardingView) View() string {
 		content = ov.viewWelcome()
 	case stepKeybindings:
 		content = ov.viewKeybindings()
+	case stepValues:
+		content = ov.viewValues()
+	case stepImport:
+		content = ov.viewImport()
+	case stepImportPreview:
+		content = ov.viewImportPreview()
 	case stepDone:
 		content = ov.viewDone()
 	}
@@ -123,8 +312,7 @@ func (ov *OnboardingView) viewWelcome() string {
 	fmt.Fprintf(&s, "The trick? %s.\n", headerStyle.Render("There are no wrong answers"))
 	fmt.Fprintf(&s, "Every door leads to progress.\n\n")
 
-	stepIndicator := helpStyle.Render("Step 1 of 3")
-	fmt.Fprintf(&s, "%s\n", stepIndicator)
+	fmt.Fprintf(&s, "%s\n", helpStyle.Render(fmt.Sprintf("Step %d of %d", ov.stepNumber(), onboardingTotalSteps)))
 	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter to continue | Esc to skip"))
 
 	return s.String()
@@ -162,9 +350,110 @@ func (ov *OnboardingView) viewKeybindings() string {
 	triedCount := len(ov.triedKeys)
 	fmt.Fprintf(&s, "\n%s\n", helpStyle.Render(fmt.Sprintf("Tried %d of 4 keys", triedCount)))
 
-	stepIndicator := helpStyle.Render("Step 2 of 3")
-	fmt.Fprintf(&s, "%s\n", stepIndicator)
+	fmt.Fprintf(&s, "%s\n", helpStyle.Render(fmt.Sprintf("Step %d of %d", ov.stepNumber(), onboardingTotalSteps)))
 	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter to continue | Esc to skip"))
+
+	return s.String()
+}
+
+func (ov *OnboardingView) viewValues() string {
+	var s strings.Builder
+
+	fmt.Fprintf(&s, "%s\n\n", headerStyle.Render("Values & Goals"))
+	fmt.Fprintf(&s, "What matters most to you? These will appear\n")
+	fmt.Fprintf(&s, "as a reminder during your task sessions.\n\n")
+
+	if len(ov.values) > 0 {
+		fmt.Fprintf(&s, "%s\n", valuesHeaderStyle.Render("Your values:"))
+		for i, v := range ov.values {
+			fmt.Fprintf(&s, "  %d. %s\n", i+1, v)
+		}
+		fmt.Fprintf(&s, "\n")
+	}
+
+	fmt.Fprintf(&s, "%s\n\n", ov.textInput.View())
+
+	count := len(ov.values)
+	remaining := 5 - count
+	if count == 0 {
+		fmt.Fprintf(&s, "%s\n", helpStyle.Render("Type a value/goal and press Enter"))
+	} else if remaining > 0 {
+		fmt.Fprintf(&s, "%s\n", helpStyle.Render(fmt.Sprintf("Added %d/5 | Enter to add more | Empty Enter to continue", count)))
+	} else {
+		fmt.Fprintf(&s, "%s\n", helpStyle.Render("Maximum 5 values reached"))
+	}
+
+	fmt.Fprintf(&s, "%s\n", helpStyle.Render(fmt.Sprintf("Step %d of %d", ov.stepNumber(), onboardingTotalSteps)))
+	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter empty to continue | Esc to skip"))
+
+	return s.String()
+}
+
+func (ov *OnboardingView) viewImport() string {
+	var s strings.Builder
+
+	fmt.Fprintf(&s, "%s\n\n", headerStyle.Render("Import Tasks"))
+	fmt.Fprintf(&s, "Already have tasks in a file? Import them now.\n")
+	fmt.Fprintf(&s, "Supports plain text (one per line) and Markdown checkboxes.\n\n")
+
+	fmt.Fprintf(&s, "%s\n", ov.textInput.View())
+
+	if ov.importError != "" {
+		fmt.Fprintf(&s, "\n%s\n", healthFailStyle.Render(ov.importError))
+	}
+
+	fmt.Fprintf(&s, "\n%s\n", helpStyle.Render("Enter a file path or leave empty to skip"))
+	fmt.Fprintf(&s, "%s\n", helpStyle.Render("You can also import later with :import"))
+	fmt.Fprintf(&s, "%s\n", helpStyle.Render(fmt.Sprintf("Step %d of %d", ov.stepNumber(), onboardingTotalSteps)))
+	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter to import | Esc to skip"))
+
+	return s.String()
+}
+
+func (ov *OnboardingView) viewImportPreview() string {
+	var s strings.Builder
+
+	fmt.Fprintf(&s, "%s\n\n", headerStyle.Render("Import Preview"))
+
+	if ov.importResult == nil {
+		fmt.Fprintf(&s, "No tasks to preview.\n")
+		return s.String()
+	}
+
+	total := len(ov.importResult.Tasks)
+	todoCount := 0
+	for _, t := range ov.importResult.Tasks {
+		if t.Status == tasks.StatusTodo {
+			todoCount++
+		}
+	}
+
+	fmt.Fprintf(&s, "Found %s in %s format.\n", headerStyle.Render(fmt.Sprintf("%d tasks", total)), ov.importResult.Format)
+	if todoCount < total {
+		fmt.Fprintf(&s, "%d incomplete, %d already done.\n", todoCount, total-todoCount)
+	}
+	fmt.Fprintf(&s, "\n")
+
+	// Show first few tasks as preview
+	previewMax := 5
+	if previewMax > total {
+		previewMax = total
+	}
+	fmt.Fprintf(&s, "%s\n", valuesHeaderStyle.Render("Preview:"))
+	for i := 0; i < previewMax; i++ {
+		t := ov.importResult.Tasks[i]
+		status := "[ ]"
+		if t.Status == tasks.StatusComplete {
+			status = "[x]"
+		}
+		fmt.Fprintf(&s, "  %s %s\n", status, t.Text)
+	}
+	if total > previewMax {
+		fmt.Fprintf(&s, "  %s\n", helpStyle.Render(fmt.Sprintf("... and %d more", total-previewMax)))
+	}
+
+	fmt.Fprintf(&s, "\n%s\n", helpStyle.Render(fmt.Sprintf("Step %d of %d", ov.stepNumber(), onboardingTotalSteps)))
+	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter/y to import | Esc/n to skip"))
 
 	return s.String()
 }
@@ -173,6 +462,17 @@ func (ov *OnboardingView) viewDone() string {
 	var s strings.Builder
 
 	fmt.Fprintf(&s, "%s\n\n", headerStyle.Render("You're All Set!"))
+
+	// Summary of what was set up
+	if len(ov.values) > 0 {
+		fmt.Fprintf(&s, "%s %d values/goals saved\n", flashStyle.Render("*"), len(ov.values))
+	}
+	if ov.importResult != nil && len(ov.importResult.Tasks) > 0 {
+		fmt.Fprintf(&s, "%s %d tasks imported\n", flashStyle.Render("*"), len(ov.importResult.Tasks))
+	}
+	if len(ov.values) > 0 || (ov.importResult != nil && len(ov.importResult.Tasks) > 0) {
+		fmt.Fprintf(&s, "\n")
+	}
 
 	fmt.Fprintf(&s, "Here are a few more keys you'll find useful:\n\n")
 
@@ -185,8 +485,7 @@ func (ov *OnboardingView) viewDone() string {
 
 	fmt.Fprintf(&s, "\n%s\n\n", headerStyle.Render("Remember: progress over perfection."))
 
-	stepIndicator := helpStyle.Render("Step 3 of 3")
-	fmt.Fprintf(&s, "%s\n", stepIndicator)
+	fmt.Fprintf(&s, "%s\n", helpStyle.Render(fmt.Sprintf("Step %d of %d", ov.stepNumber(), onboardingTotalSteps)))
 	fmt.Fprintf(&s, "%s", helpStyle.Render("Enter to start | Esc to skip"))
 
 	return s.String()

--- a/internal/tui/onboarding_view_test.go
+++ b/internal/tui/onboarding_view_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,14 +13,15 @@ func TestOnboardingView_StepProgression(t *testing.T) {
 	t.Parallel()
 
 	ov := NewOnboardingView()
+	ov.SetWidth(80)
 
 	// Initial state should be welcome step
 	view := ov.View()
 	if !strings.Contains(view, "Welcome to ThreeDoors") {
 		t.Error("expected welcome step on init")
 	}
-	if !strings.Contains(view, "Step 1 of 3") {
-		t.Error("expected step 1 indicator")
+	if !strings.Contains(view, "Step 1 of 5") {
+		t.Error("expected step 1 of 5 indicator")
 	}
 
 	// Press Enter to advance to keybindings
@@ -27,18 +30,38 @@ func TestOnboardingView_StepProgression(t *testing.T) {
 	if !strings.Contains(view, "Key Bindings") {
 		t.Error("expected keybindings step after Enter")
 	}
-	if !strings.Contains(view, "Step 2 of 3") {
-		t.Error("expected step 2 indicator")
+	if !strings.Contains(view, "Step 2 of 5") {
+		t.Error("expected step 2 of 5 indicator")
 	}
 
-	// Press Enter to advance to done
+	// Press Enter to advance to values
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	view = ov.View()
+	if !strings.Contains(view, "Values & Goals") {
+		t.Error("expected values step after Enter")
+	}
+	if !strings.Contains(view, "Step 3 of 5") {
+		t.Error("expected step 3 of 5 indicator")
+	}
+
+	// Press Enter with empty to advance to import
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	view = ov.View()
+	if !strings.Contains(view, "Import Tasks") {
+		t.Error("expected import step after empty Enter on values")
+	}
+	if !strings.Contains(view, "Step 4 of 5") {
+		t.Error("expected step 4 of 5 indicator")
+	}
+
+	// Press Enter with empty to advance to done (skip import)
 	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	view = ov.View()
 	if !strings.Contains(view, "You're All Set") {
-		t.Error("expected done step after Enter")
+		t.Error("expected done step after empty Enter on import")
 	}
-	if !strings.Contains(view, "Step 3 of 3") {
-		t.Error("expected step 3 indicator")
+	if !strings.Contains(view, "Step 5 of 5") {
+		t.Error("expected step 5 of 5 indicator")
 	}
 
 	// Press Enter to complete onboarding
@@ -79,6 +102,34 @@ func TestOnboardingView_SkipAtEveryStep(t *testing.T) {
 				t.Errorf("expected OnboardingCompletedMsg on Esc at step %s, got %T", tt.name, msg)
 			}
 		})
+	}
+}
+
+func TestOnboardingView_ValuesSkipOnEsc(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepValues
+	ov.textInput.Focus()
+
+	// Esc should skip to import step
+	ov.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if ov.step != stepImport {
+		t.Errorf("step = %d, want stepImport after Esc on values", ov.step)
+	}
+}
+
+func TestOnboardingView_ImportSkipOnEsc(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepImport
+	ov.textInput.Focus()
+
+	// Esc should skip to done step
+	ov.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if ov.step != stepDone {
+		t.Errorf("step = %d, want stepDone after Esc on import", ov.step)
 	}
 }
 
@@ -140,6 +191,7 @@ func TestOnboardingView_TriedKeysCount(t *testing.T) {
 
 	ov := NewOnboardingView()
 	ov.step = stepKeybindings
+	ov.SetWidth(80)
 
 	// Try all four keys
 	keys := []tea.KeyMsg{
@@ -227,5 +279,239 @@ func TestOnboardingView_SpaceAdvances(t *testing.T) {
 	ov.Update(tea.KeyMsg{Type: tea.KeySpace})
 	if ov.step != stepKeybindings {
 		t.Errorf("step = %d, want stepKeybindings after space", ov.step)
+	}
+}
+
+func TestOnboardingView_ValuesEntry(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepValues
+	ov.textInput.Focus()
+	ov.SetWidth(80)
+
+	// Type a value and press Enter
+	ov.textInput.SetValue("Be kind")
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if len(ov.values) != 1 {
+		t.Fatalf("expected 1 value, got %d", len(ov.values))
+	}
+	if ov.values[0] != "Be kind" {
+		t.Errorf("value = %q, want %q", ov.values[0], "Be kind")
+	}
+
+	// Should still be on values step
+	if ov.step != stepValues {
+		t.Errorf("step = %d, want stepValues after adding value", ov.step)
+	}
+
+	// View should show the value
+	view := ov.View()
+	if !strings.Contains(view, "Be kind") {
+		t.Error("values view should show entered value")
+	}
+}
+
+func TestOnboardingView_ValuesMaxFive(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepValues
+	ov.textInput.Focus()
+
+	for i := 0; i < 5; i++ {
+		ov.textInput.SetValue("value")
+		ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	}
+
+	if len(ov.values) != 5 {
+		t.Fatalf("expected 5 values, got %d", len(ov.values))
+	}
+	// Should auto-advance to import
+	if ov.step != stepImport {
+		t.Errorf("step = %d, want stepImport after 5 values", ov.step)
+	}
+}
+
+func TestOnboardingView_ImportWithFile(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp file with tasks
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.txt")
+	if err := os.WriteFile(path, []byte("Task one\nTask two\nTask three"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ov := NewOnboardingView()
+	ov.step = stepImport
+	ov.textInput.Focus()
+	ov.SetWidth(80)
+
+	// Enter the file path
+	ov.textInput.SetValue(path)
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Should advance to preview
+	if ov.step != stepImportPreview {
+		t.Fatalf("step = %d, want stepImportPreview", ov.step)
+	}
+	if ov.importResult == nil {
+		t.Fatal("expected importResult to be set")
+	}
+	if len(ov.importResult.Tasks) != 3 {
+		t.Errorf("imported %d tasks, want 3", len(ov.importResult.Tasks))
+	}
+
+	// View should show preview
+	view := ov.View()
+	if !strings.Contains(view, "Import Preview") {
+		t.Error("expected import preview view")
+	}
+	if !strings.Contains(view, "3 tasks") {
+		t.Error("expected '3 tasks' in preview")
+	}
+}
+
+func TestOnboardingView_ImportPreviewAccept(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp file
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.txt")
+	if err := os.WriteFile(path, []byte("Task one\nTask two"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ov := NewOnboardingView()
+	ov.step = stepImport
+	ov.textInput.Focus()
+	ov.textInput.SetValue(path)
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Accept import
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if ov.step != stepDone {
+		t.Errorf("step = %d, want stepDone after accepting import", ov.step)
+	}
+	if ov.importResult == nil {
+		t.Error("expected importResult to remain after accept")
+	}
+}
+
+func TestOnboardingView_ImportPreviewReject(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp file
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.txt")
+	if err := os.WriteFile(path, []byte("Task one\nTask two"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ov := NewOnboardingView()
+	ov.step = stepImport
+	ov.textInput.Focus()
+	ov.textInput.SetValue(path)
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Reject import
+	ov.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if ov.step != stepDone {
+		t.Errorf("step = %d, want stepDone after rejecting import", ov.step)
+	}
+	if ov.importResult != nil {
+		t.Error("expected importResult to be nil after reject")
+	}
+}
+
+func TestOnboardingView_ImportInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepImport
+	ov.textInput.Focus()
+	ov.SetWidth(80)
+
+	ov.textInput.SetValue("/nonexistent/path/tasks.txt")
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Should stay on import step with error
+	if ov.step != stepImport {
+		t.Errorf("step = %d, want stepImport after invalid path", ov.step)
+	}
+	if ov.importError == "" {
+		t.Error("expected importError to be set")
+	}
+
+	// Error should show in view (importError is rendered with styling,
+	// so check for a substring of the error message)
+	view := ov.View()
+	if !strings.Contains(view, "nonexistent") {
+		t.Error("expected error message in view")
+	}
+}
+
+func TestOnboardingView_CompletedMsgCarriesData(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp file
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.txt")
+	if err := os.WriteFile(path, []byte("Task one\nTask two"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ov := NewOnboardingView()
+	ov.step = stepValues
+	ov.textInput.Focus()
+
+	// Add a value
+	ov.textInput.SetValue("Focus")
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Skip to import
+	ov.textInput.SetValue("")
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Import tasks
+	ov.textInput.SetValue(path)
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Accept
+	ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Complete onboarding
+	cmd := ov.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command on final Enter")
+	}
+
+	msg := cmd()
+	completed, ok := msg.(OnboardingCompletedMsg)
+	if !ok {
+		t.Fatalf("expected OnboardingCompletedMsg, got %T", msg)
+	}
+
+	if len(completed.Values) != 1 || completed.Values[0] != "Focus" {
+		t.Errorf("Values = %v, want [Focus]", completed.Values)
+	}
+	if len(completed.ImportedTasks) != 2 {
+		t.Errorf("ImportedTasks = %d, want 2", len(completed.ImportedTasks))
+	}
+}
+
+func TestOnboardingView_DoneSummary(t *testing.T) {
+	t.Parallel()
+
+	ov := NewOnboardingView()
+	ov.step = stepDone
+	ov.values = []string{"Be kind", "Stay focused"}
+	ov.SetWidth(80)
+
+	view := ov.View()
+	if !strings.Contains(view, "2 values/goals saved") {
+		t.Error("done view should show values summary")
 	}
 }


### PR DESCRIPTION
## Summary

- Extends the first-run onboarding wizard from 3 steps to 5 steps
- Adds **Values/Goals Setup** step: inline text input for 1-5 values that persist to `config.yaml` via existing `ValuesConfig`
- Adds **Task Import** step: enter a file path to import tasks from plain text (one per line) or Markdown (checkbox syntax `- [ ]`/`- [x]`), with preview before confirming
- Both new steps are fully skippable (Esc or empty Enter)
- `OnboardingCompletedMsg` now carries values and imported tasks back to `MainModel` for persistence

## Changes

### New Files
- `internal/tasks/task_importer.go` — File parsing for text and Markdown formats, tilde expansion, format auto-detection
- `internal/tasks/task_importer_test.go` — Table-driven tests for all parsing functions
- `docs/stories/10.2.story.md` — Story specification

### Modified Files
- `internal/tui/onboarding_view.go` — 5-step wizard (Welcome → Keybindings → Values → Import → Done)
- `internal/tui/onboarding_view_test.go` — Comprehensive test coverage for all new steps
- `internal/tui/main_model.go` — Handle values + imported tasks from `OnboardingCompletedMsg`

## Test plan

- [x] `make fmt` — gofumpt passes
- [x] `make lint` — golangci-lint zero issues
- [x] `make test` — all tests pass
- [x] `go test -race ./...` — no data races
- [x] Values entry: 1-5 values, max 200 chars, persisted to config.yaml
- [x] Import: text and Markdown formats detected and parsed
- [x] Import preview: shows task count and first 5 tasks
- [x] Import accept/reject: Enter accepts, Esc/n rejects
- [x] Skip: Esc skips any step, values entered so far are preserved
- [x] OnboardingCompletedMsg carries values + tasks to MainModel

## Acceptance Criteria (Story 10.2)

- [x] Values persist to config.yaml
- [x] Import detection for common task sources (text, Markdown)
- [x] Import preview shows tasks before importing
- [x] Step is skippable; manual import via `:import` command later

## Notes

- The `:import` command for post-onboarding import is not yet implemented (future story scope)
- Task import supports `~` expansion for home directory paths
- Markdown format auto-detected by file extension (`.md`) or checkbox content