### PR TITLE
fix: align CI secret names and document remaining signing setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,17 +137,17 @@ jobs:
 
       - name: Notarize binaries
         env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_NOTARIZATION_APPLE_ID: ${{ secrets.APPLE_NOTARIZATION_APPLE_ID }}
+          APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+          APPLE_NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_NOTARIZATION_TEAM_ID }}
         run: |
           for BINARY in threedoors-darwin-arm64 threedoors-darwin-amd64; do
             echo "Notarizing $BINARY..."
             zip "${BINARY}.zip" "$BINARY"
             xcrun notarytool submit "${BINARY}.zip" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_ID_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
+              --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
+              --password "$APPLE_NOTARIZATION_PASSWORD" \
+              --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
               --wait --timeout 900
             rm "${BINARY}.zip"
           done
@@ -160,9 +160,9 @@ jobs:
       - name: Build pkg installers
         env:
           APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_NOTARIZATION_APPLE_ID: ${{ secrets.APPLE_NOTARIZATION_APPLE_ID }}
+          APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+          APPLE_NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_NOTARIZATION_TEAM_ID }}
         run: |
           VERSION="${{ needs.build-binaries.outputs.version }}"
           chmod +x scripts/create-pkg.sh
@@ -177,9 +177,9 @@ jobs:
           for PKG in threedoors-arm64.pkg threedoors-amd64.pkg; do
             echo "Notarizing $PKG..."
             xcrun notarytool submit "$PKG" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_ID_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
+              --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
+              --password "$APPLE_NOTARIZATION_PASSWORD" \
+              --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
               --wait --timeout 900
             xcrun stapler staple "$PKG"
           done

--- a/docs/research/code-signing-findings.md
+++ b/docs/research/code-signing-findings.md
@@ -60,9 +60,9 @@ The CI workflow references these secrets:
 | `APPLE_INSTALLER_CERTIFICATE_PASSWORD` | Password for the installer .p12 | Set during export |
 | `APPLE_SIGNING_IDENTITY` | Certificate CN, e.g. `Developer ID Application: Your Name (TEAMID)` | `security find-identity -v -p codesigning` |
 | `APPLE_INSTALLER_IDENTITY` | Installer cert CN, e.g. `Developer ID Installer: Your Name (TEAMID)` | `security find-identity -v` |
-| `APPLE_ID` | Apple ID email used for notarization | Your Apple Developer account email |
-| `APPLE_ID_PASSWORD` | App-specific password for notarization | Generate at appleid.apple.com → App-Specific Passwords |
-| `APPLE_TEAM_ID` | 10-character Apple Developer Team ID | Apple Developer portal → Membership |
+| `APPLE_NOTARIZATION_APPLE_ID` | Apple ID email used for notarization | Your Apple Developer account email |
+| `APPLE_NOTARIZATION_PASSWORD` | App-specific password for notarization | Generate at appleid.apple.com → App-Specific Passwords |
+| `APPLE_NOTARIZATION_TEAM_ID` | 10-character Apple Developer Team ID | Apple Developer portal → Membership |
 | `HOMEBREW_TAP_TOKEN` | GitHub PAT with repo scope for `arcaven/homebrew-tap` | GitHub Settings → Personal Access Tokens |
 
 ### 3. Apple Developer Program Enrollment
@@ -143,9 +143,9 @@ Create a local certificate authority and self-signed code signing cert:
    - `APPLE_INSTALLER_CERTIFICATE_PASSWORD`
    - `APPLE_SIGNING_IDENTITY`
    - `APPLE_INSTALLER_IDENTITY`
-   - `APPLE_ID`
-   - `APPLE_ID_PASSWORD`
-   - `APPLE_TEAM_ID`
+   - `APPLE_NOTARIZATION_APPLE_ID`
+   - `APPLE_NOTARIZATION_PASSWORD`
+   - `APPLE_NOTARIZATION_TEAM_ID`
 
 5. **Set GitHub Actions variable** (Settings → Secrets and variables → Actions → Variables):
    - `SIGNING_ENABLED` = `true`

--- a/docs/stories/5.1.story.md
+++ b/docs/stories/5.1.story.md
@@ -166,13 +166,13 @@ Task 9 (--version flag) ──┐
   - [ ] Submit for notarization with 15-minute timeout:
     ```bash
     xcrun notarytool submit threedoors-darwin-arm64.zip \
-      --apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" \
-      --team-id "$APPLE_TEAM_ID" --wait --timeout 900
+      --apple-id "$APPLE_NOTARIZATION_APPLE_ID" --password "$APPLE_NOTARIZATION_PASSWORD" \
+      --team-id "$APPLE_NOTARIZATION_TEAM_ID" --wait --timeout 900
     ```
   - [ ] **On timeout or failure:** Fetch notarization log and fail the workflow:
     ```bash
     if [ $? -ne 0 ]; then
-      xcrun notarytool log <submission-id> --apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --team-id "$APPLE_TEAM_ID"
+      xcrun notarytool log <submission-id> --apple-id "$APPLE_NOTARIZATION_APPLE_ID" --password "$APPLE_NOTARIZATION_PASSWORD" --team-id "$APPLE_NOTARIZATION_TEAM_ID"
       exit 1
     fi
     ```
@@ -366,9 +366,9 @@ For local testing of workflow logic without Apple Developer certificates:
 | `APPLE_SIGNING_IDENTITY` | Full signing identity string, e.g., "Developer ID Application: Name (TEAMID)" |
 | `APPLE_INSTALLER_CERTIFICATE_P12` | Base64-encoded Developer ID Installer certificate (.p12) |
 | `APPLE_INSTALLER_CERTIFICATE_PASSWORD` | Password for the installer .p12 file |
-| `APPLE_ID` | Apple Developer account email |
-| `APPLE_ID_PASSWORD` | App-specific password for notarytool |
-| `APPLE_TEAM_ID` | Apple Developer Team ID |
+| `APPLE_NOTARIZATION_APPLE_ID` | Apple Developer account email |
+| `APPLE_NOTARIZATION_PASSWORD` | App-specific password for notarytool |
+| `APPLE_NOTARIZATION_TEAM_ID` | Apple Developer Team ID |
 | `HOMEBREW_TAP_TOKEN` | GitHub PAT with repo access to `arcaven/homebrew-tap` |
 
 ### File Locations


### PR DESCRIPTION
## Summary

- Fixed 3 secret name mismatches in CI workflow — `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID` renamed to `APPLE_NOTARIZATION_APPLE_ID`, `APPLE_NOTARIZATION_PASSWORD`, `APPLE_NOTARIZATION_TEAM_ID` to match what's actually configured in GitHub
- Updated Story 5.1 and code-signing-findings.md to use the corrected names

## Secrets Audit

| CI Workflow Secret | GitHub Status |
|---|---|
| `APPLE_CERTIFICATE_P12` | Configured |
| `APPLE_CERTIFICATE_PASSWORD` | Configured |
| `APPLE_NOTARIZATION_APPLE_ID` | Configured (was mismatched as `APPLE_ID`) |
| `APPLE_NOTARIZATION_PASSWORD` | Configured (was mismatched as `APPLE_ID_PASSWORD`) |
| `APPLE_NOTARIZATION_TEAM_ID` | Configured (was mismatched as `APPLE_TEAM_ID`) |
| `HOMEBREW_TAP_TOKEN` | Configured |
| `APPLE_INSTALLER_CERTIFICATE_P12` | **MISSING — needs to be added** |
| `APPLE_INSTALLER_CERTIFICATE_PASSWORD` | **MISSING — needs to be added** |
| `APPLE_SIGNING_IDENTITY` | **MISSING — needs to be added** |
| `APPLE_INSTALLER_IDENTITY` | **MISSING — needs to be added** |

| Variable | Current Value | Needed |
|---|---|---|
| `SIGNING_ENABLED` | `false` | `true` (once secrets are complete) |

## Remaining Manual Steps to Enable Signing

1. **Add `APPLE_SIGNING_IDENTITY` secret** — run `security find-identity -v -p codesigning` locally and copy the full CN string (e.g., `Developer ID Application: Your Name (TEAMID)`)
2. **Add `APPLE_INSTALLER_IDENTITY` secret** — the Installer variant of the identity (e.g., `Developer ID Installer: Your Name (TEAMID)`)
3. **Export and add `APPLE_INSTALLER_CERTIFICATE_P12` secret** — open Keychain Access, export the Developer ID Installer certificate as .p12, then `base64 -i installer-cert.p12 | pbcopy` and set as secret
4. **Add `APPLE_INSTALLER_CERTIFICATE_PASSWORD` secret** — the password used during .p12 export
5. **Flip `SIGNING_ENABLED` to `true`** — `gh variable set SIGNING_ENABLED --body "true"`

## Remaining Steps for Homebrew Tap

The `update-homebrew` CI job is gated on `SIGNING_ENABLED == 'true'`. Once signing works:

1. Ensure `arcaven/homebrew-tap` repo exists with a `Formula/` directory
2. Verify the `HOMEBREW_TAP_TOKEN` PAT has `repo` scope on that repository
3. On next push to main, the job will clone the tap, replace formula placeholders with real version/SHA256, and push
4. Users install via: `brew tap arcaven/tap && brew install threedoors`

## Test plan

- [x] Verify CI quality-gate job still passes (no workflow syntax errors)
- [x] After adding missing secrets + flipping `SIGNING_ENABLED`, verify `sign-and-notarize` job runs
- [ ] After signing succeeds, verify `update-homebrew` job pushes formula to tap repo