### PR TITLE
feat: Story 11.1 - Offline-First Local Change Queue (WAL)

### DIFF
--- a/cmd/threedoors/main.go
+++ b/cmd/threedoors/main.go
@@ -36,7 +36,13 @@ func main() {
 		}
 	}
 
-	provider := tasks.NewProviderFromConfig(cfg)
+	var provider tasks.TaskProvider
+	baseProvider := tasks.NewProviderFromConfig(cfg)
+	if configErr == nil {
+		provider = tasks.NewWALProvider(baseProvider, configDir)
+	} else {
+		provider = baseProvider
+	}
 	loadedTasks, err := provider.LoadTasks()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load tasks: %v\n", err)

--- a/internal/tasks/wal_provider.go
+++ b/internal/tasks/wal_provider.go
@@ -1,0 +1,342 @@
+package tasks
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	walFile            = "sync-queue.jsonl"
+	defaultMaxWALSize  = 10000
+	maxReplayRetries   = 10
+	baseBackoffSeconds = 1
+)
+
+// WALOperation represents the type of write operation stored in the WAL.
+type WALOperation string
+
+const (
+	WALOpSave         WALOperation = "save"
+	WALOpSaveBatch    WALOperation = "save_batch"
+	WALOpDelete       WALOperation = "delete"
+	WALOpMarkComplete WALOperation = "mark_complete"
+)
+
+// WALEntry represents a single write-ahead log entry.
+type WALEntry struct {
+	Sequence  int64        `json:"seq"`
+	Operation WALOperation `json:"op"`
+	TaskID    string       `json:"task_id"`
+	Task      *Task        `json:"task,omitempty"`
+	Tasks     []*Task      `json:"tasks,omitempty"`
+	Timestamp time.Time    `json:"timestamp"`
+	Retries   int          `json:"retries"`
+	LastError string       `json:"last_error,omitempty"`
+}
+
+// WALProvider wraps a TaskProvider with a write-ahead log for offline-first operation.
+// When the underlying provider is unavailable, writes are queued in a JSONL WAL file
+// and replayed in order when connectivity is restored.
+type WALProvider struct {
+	inner    TaskProvider
+	walPath  string
+	maxSize  int
+	mu       sync.Mutex
+	pending  []WALEntry
+	nextSeq  int64
+	replying bool
+}
+
+// NewWALProvider creates a WALProvider wrapping the given provider.
+// The WAL file is stored at configDir/sync-queue.jsonl.
+func NewWALProvider(inner TaskProvider, configDir string) *WALProvider {
+	wp := &WALProvider{
+		inner:   inner,
+		walPath: filepath.Join(configDir, walFile),
+		maxSize: defaultMaxWALSize,
+		nextSeq: 1,
+	}
+	wp.loadPending()
+	return wp
+}
+
+// SetMaxSize sets the maximum number of WAL entries before oldest-first eviction.
+func (wp *WALProvider) SetMaxSize(max int) {
+	wp.mu.Lock()
+	defer wp.mu.Unlock()
+	wp.maxSize = max
+}
+
+// LoadTasks delegates directly to the inner provider.
+// On successful load, attempts to replay any pending WAL entries.
+func (wp *WALProvider) LoadTasks() ([]*Task, error) {
+	tasks, err := wp.inner.LoadTasks()
+	if err != nil {
+		return nil, err
+	}
+
+	// Provider is available — try replaying pending entries
+	wp.ReplayPending()
+
+	return tasks, nil
+}
+
+// SaveTask attempts to save via the inner provider. If the provider is unavailable,
+// the operation is queued in the WAL for later replay.
+func (wp *WALProvider) SaveTask(task *Task) error {
+	err := wp.inner.SaveTask(task)
+	if err == nil {
+		return nil
+	}
+
+	// Provider unavailable — queue in WAL
+	entry := WALEntry{
+		Operation: WALOpSave,
+		TaskID:    task.ID,
+		Task:      task,
+		Timestamp: time.Now().UTC(),
+	}
+	return wp.enqueue(entry)
+}
+
+// SaveTasks attempts to save via the inner provider. If the provider is unavailable,
+// the operation is queued in the WAL for later replay.
+func (wp *WALProvider) SaveTasks(tasks []*Task) error {
+	err := wp.inner.SaveTasks(tasks)
+	if err == nil {
+		return nil
+	}
+
+	// Provider unavailable — queue in WAL
+	entry := WALEntry{
+		Operation: WALOpSaveBatch,
+		Timestamp: time.Now().UTC(),
+		Tasks:     tasks,
+	}
+	return wp.enqueue(entry)
+}
+
+// DeleteTask attempts to delete via the inner provider. If the provider is unavailable,
+// the operation is queued in the WAL for later replay.
+func (wp *WALProvider) DeleteTask(taskID string) error {
+	err := wp.inner.DeleteTask(taskID)
+	if err == nil {
+		return nil
+	}
+
+	entry := WALEntry{
+		Operation: WALOpDelete,
+		TaskID:    taskID,
+		Timestamp: time.Now().UTC(),
+	}
+	return wp.enqueue(entry)
+}
+
+// MarkComplete attempts to mark complete via the inner provider. If the provider is
+// unavailable, the operation is queued in the WAL for later replay.
+func (wp *WALProvider) MarkComplete(taskID string) error {
+	err := wp.inner.MarkComplete(taskID)
+	if err == nil {
+		return nil
+	}
+
+	entry := WALEntry{
+		Operation: WALOpMarkComplete,
+		TaskID:    taskID,
+		Timestamp: time.Now().UTC(),
+	}
+	return wp.enqueue(entry)
+}
+
+// PendingCount returns the number of pending WAL entries.
+func (wp *WALProvider) PendingCount() int {
+	wp.mu.Lock()
+	defer wp.mu.Unlock()
+	return len(wp.pending)
+}
+
+// ReplayPending attempts to replay all pending WAL entries against the inner provider.
+// Entries that succeed are removed. Entries that fail are kept with incremented retry
+// counts and exponential backoff is applied. Entries exceeding maxReplayRetries are dropped.
+func (wp *WALProvider) ReplayPending() []error {
+	wp.mu.Lock()
+	if wp.replying || len(wp.pending) == 0 {
+		wp.mu.Unlock()
+		return nil
+	}
+	wp.replying = true
+	entries := make([]WALEntry, len(wp.pending))
+	copy(entries, wp.pending)
+	wp.mu.Unlock()
+
+	var replayErrors []error
+	var remaining []WALEntry
+
+	for _, entry := range entries {
+		// Check if backoff period has elapsed
+		if entry.Retries > 0 {
+			backoff := time.Duration(math.Pow(2, float64(entry.Retries-1))) * time.Second * baseBackoffSeconds
+			if time.Since(entry.Timestamp.Add(backoff)) < 0 {
+				// Not yet time to retry — keep in queue
+				remaining = append(remaining, entry)
+				continue
+			}
+		}
+
+		err := wp.replayEntry(entry)
+		if err != nil {
+			entry.Retries++
+			entry.LastError = err.Error()
+
+			if entry.Retries >= maxReplayRetries {
+				fmt.Fprintf(os.Stderr, "Warning: dropping WAL entry seq=%d op=%s task=%s after %d retries: %v\n",
+					entry.Sequence, entry.Operation, entry.TaskID, entry.Retries, err)
+			} else {
+				remaining = append(remaining, entry)
+			}
+			replayErrors = append(replayErrors, fmt.Errorf("replay WAL entry seq=%d: %w", entry.Sequence, err))
+		}
+	}
+
+	wp.mu.Lock()
+	wp.pending = remaining
+	wp.replying = false
+	wp.mu.Unlock()
+
+	if err := wp.persistWAL(); err != nil {
+		replayErrors = append(replayErrors, fmt.Errorf("persist WAL after replay: %w", err))
+	}
+
+	return replayErrors
+}
+
+func (wp *WALProvider) replayEntry(entry WALEntry) error {
+	switch entry.Operation {
+	case WALOpSave:
+		if entry.Task == nil {
+			return fmt.Errorf("save entry missing task data")
+		}
+		return wp.inner.SaveTask(entry.Task)
+	case WALOpSaveBatch:
+		if len(entry.Tasks) == 0 {
+			return fmt.Errorf("save_batch entry missing tasks data")
+		}
+		return wp.inner.SaveTasks(entry.Tasks)
+	case WALOpDelete:
+		return wp.inner.DeleteTask(entry.TaskID)
+	case WALOpMarkComplete:
+		return wp.inner.MarkComplete(entry.TaskID)
+	default:
+		return fmt.Errorf("unknown WAL operation: %s", entry.Operation)
+	}
+}
+
+func (wp *WALProvider) enqueue(entry WALEntry) error {
+	wp.mu.Lock()
+	defer wp.mu.Unlock()
+
+	entry.Sequence = wp.nextSeq
+	wp.nextSeq++
+
+	wp.pending = append(wp.pending, entry)
+
+	// Enforce size limit with oldest-first eviction
+	if len(wp.pending) > wp.maxSize {
+		evictCount := len(wp.pending) - wp.maxSize
+		fmt.Fprintf(os.Stderr, "Warning: WAL queue exceeded max size %d, evicting %d oldest entries\n",
+			wp.maxSize, evictCount)
+		wp.pending = wp.pending[evictCount:]
+	}
+
+	return wp.persistWALLocked()
+}
+
+// persistWAL writes the current pending entries to the WAL file using atomic write.
+func (wp *WALProvider) persistWAL() error {
+	wp.mu.Lock()
+	defer wp.mu.Unlock()
+	return wp.persistWALLocked()
+}
+
+// persistWALLocked writes the WAL file. Caller must hold wp.mu.
+func (wp *WALProvider) persistWALLocked() error {
+	tmpPath := wp.walPath + ".tmp"
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create WAL temp file: %w", err)
+	}
+
+	writer := bufio.NewWriter(f)
+	encoder := json.NewEncoder(writer)
+	for _, entry := range wp.pending {
+		if err := encoder.Encode(entry); err != nil {
+			_ = f.Close()
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("encode WAL entry seq=%d: %w", entry.Sequence, err)
+		}
+	}
+
+	if err := writer.Flush(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("flush WAL temp file: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("sync WAL temp file: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close WAL temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, wp.walPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename WAL temp file: %w", err)
+	}
+
+	return nil
+}
+
+// loadPending reads existing WAL entries from the JSONL file.
+func (wp *WALProvider) loadPending() {
+	f, err := os.Open(wp.walPath)
+	if err != nil {
+		return
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on read
+
+	scanner := bufio.NewScanner(f)
+	var maxSeq int64
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry WALEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: skipping corrupt WAL entry: %v\n", err)
+			continue
+		}
+		wp.pending = append(wp.pending, entry)
+		if entry.Sequence > maxSeq {
+			maxSeq = entry.Sequence
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: error reading WAL file: %v\n", err)
+	}
+
+	wp.nextSeq = maxSeq + 1
+}

--- a/internal/tasks/wal_provider_test.go
+++ b/internal/tasks/wal_provider_test.go
@@ -1,0 +1,406 @@
+package tasks
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mockProvider is a test double for TaskProvider that can simulate failures.
+type mockProvider struct {
+	tasks          []*Task
+	saveErr        error
+	deleteErr      error
+	completeErr    error
+	loadErr        error
+	saveCalls      int
+	deleteCalls    int
+	completeCalls  int
+	saveBatchCalls int
+}
+
+func (m *mockProvider) LoadTasks() ([]*Task, error) {
+	if m.loadErr != nil {
+		return nil, m.loadErr
+	}
+	return m.tasks, nil
+}
+
+func (m *mockProvider) SaveTask(task *Task) error {
+	m.saveCalls++
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.tasks = append(m.tasks, task)
+	return nil
+}
+
+func (m *mockProvider) SaveTasks(tasks []*Task) error {
+	m.saveBatchCalls++
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.tasks = tasks
+	return nil
+}
+
+func (m *mockProvider) DeleteTask(taskID string) error {
+	m.deleteCalls++
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	filtered := make([]*Task, 0, len(m.tasks))
+	for _, t := range m.tasks {
+		if t.ID != taskID {
+			filtered = append(filtered, t)
+		}
+	}
+	m.tasks = filtered
+	return nil
+}
+
+func (m *mockProvider) MarkComplete(taskID string) error {
+	m.completeCalls++
+	return m.completeErr
+}
+
+func newTestWALProvider(t *testing.T) (*WALProvider, *mockProvider, string) {
+	t.Helper()
+	dir := t.TempDir()
+	mock := &mockProvider{}
+	wp := NewWALProvider(mock, dir)
+	return wp, mock, dir
+}
+
+func TestWALProvider_SaveTask_PassesThrough(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+
+	task := NewTask("test task")
+	if err := wp.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask failed: %v", err)
+	}
+
+	if mock.saveCalls != 1 {
+		t.Errorf("expected 1 save call, got %d", mock.saveCalls)
+	}
+	if wp.PendingCount() != 0 {
+		t.Errorf("expected 0 pending entries, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_SaveTask_QueuesOnFailure(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+	mock.saveErr = errors.New("provider unavailable")
+
+	task := NewTask("test task")
+	if err := wp.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask should not return error when queuing: %v", err)
+	}
+
+	if wp.PendingCount() != 1 {
+		t.Errorf("expected 1 pending entry, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_DeleteTask_QueuesOnFailure(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+	mock.deleteErr = errors.New("provider unavailable")
+
+	if err := wp.DeleteTask("task-123"); err != nil {
+		t.Fatalf("DeleteTask should not return error when queuing: %v", err)
+	}
+
+	if wp.PendingCount() != 1 {
+		t.Errorf("expected 1 pending entry, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_MarkComplete_QueuesOnFailure(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+	mock.completeErr = errors.New("provider unavailable")
+
+	if err := wp.MarkComplete("task-123"); err != nil {
+		t.Fatalf("MarkComplete should not return error when queuing: %v", err)
+	}
+
+	if wp.PendingCount() != 1 {
+		t.Errorf("expected 1 pending entry, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_ReplayPending_Success(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+
+	// Queue entries while provider is down
+	mock.saveErr = errors.New("provider unavailable")
+	task := NewTask("replay me")
+	_ = wp.SaveTask(task)
+
+	if wp.PendingCount() != 1 {
+		t.Fatalf("expected 1 pending entry, got %d", wp.PendingCount())
+	}
+
+	// Restore provider
+	mock.saveErr = nil
+	errs := wp.ReplayPending()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors on replay, got %v", errs)
+	}
+
+	if wp.PendingCount() != 0 {
+		t.Errorf("expected 0 pending entries after replay, got %d", wp.PendingCount())
+	}
+
+	// save was called once for the initial attempt + once for replay
+	if mock.saveCalls != 2 {
+		t.Errorf("expected 2 save calls (initial + replay), got %d", mock.saveCalls)
+	}
+}
+
+func TestWALProvider_ReplayPending_OrderPreserved(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+
+	mock.saveErr = errors.New("provider unavailable")
+	_ = wp.SaveTask(NewTask("first"))
+	_ = wp.SaveTask(NewTask("second"))
+	_ = wp.SaveTask(NewTask("third"))
+
+	if wp.PendingCount() != 3 {
+		t.Fatalf("expected 3 pending entries, got %d", wp.PendingCount())
+	}
+
+	// Replay and verify order by checking mock.tasks
+	mock.saveErr = nil
+	errs := wp.ReplayPending()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+
+	if len(mock.tasks) != 3 {
+		t.Fatalf("expected 3 tasks after replay, got %d", len(mock.tasks))
+	}
+
+	// Verify order matches queue order
+	if mock.tasks[0].Text != "first" {
+		t.Errorf("expected first task text 'first', got %q", mock.tasks[0].Text)
+	}
+	if mock.tasks[1].Text != "second" {
+		t.Errorf("expected second task text 'second', got %q", mock.tasks[1].Text)
+	}
+	if mock.tasks[2].Text != "third" {
+		t.Errorf("expected third task text 'third', got %q", mock.tasks[2].Text)
+	}
+
+	if wp.PendingCount() != 0 {
+		t.Errorf("expected 0 pending, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_QueueSizeLimit(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+	wp.SetMaxSize(3)
+	mock.saveErr = errors.New("provider unavailable")
+
+	for i := 0; i < 5; i++ {
+		_ = wp.SaveTask(NewTask("task"))
+	}
+
+	if wp.PendingCount() != 3 {
+		t.Errorf("expected 3 pending entries (max size), got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_QueueEvictsOldest(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+	wp.SetMaxSize(2)
+	mock.saveErr = errors.New("provider unavailable")
+
+	_ = wp.SaveTask(NewTask("oldest"))
+	_ = wp.SaveTask(NewTask("middle"))
+	_ = wp.SaveTask(NewTask("newest"))
+
+	if wp.PendingCount() != 2 {
+		t.Fatalf("expected 2 pending entries, got %d", wp.PendingCount())
+	}
+
+	// Replay to verify oldest was evicted
+	mock.saveErr = nil
+	wp.ReplayPending()
+
+	if len(mock.tasks) != 2 {
+		t.Fatalf("expected 2 replayed tasks, got %d", len(mock.tasks))
+	}
+	if mock.tasks[0].Text != "middle" {
+		t.Errorf("expected 'middle', got %q", mock.tasks[0].Text)
+	}
+	if mock.tasks[1].Text != "newest" {
+		t.Errorf("expected 'newest', got %q", mock.tasks[1].Text)
+	}
+}
+
+func TestWALProvider_Persistence(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mock := &mockProvider{saveErr: errors.New("provider unavailable")}
+	wp := NewWALProvider(mock, dir)
+
+	task := NewTask("persisted task")
+	_ = wp.SaveTask(task)
+
+	// Verify WAL file exists
+	walPath := filepath.Join(dir, walFile)
+	if _, err := os.Stat(walPath); err != nil {
+		t.Fatalf("WAL file should exist: %v", err)
+	}
+
+	// Create new WALProvider from same dir — should load pending entries
+	mock2 := &mockProvider{}
+	wp2 := NewWALProvider(mock2, dir)
+
+	if wp2.PendingCount() != 1 {
+		t.Errorf("expected 1 pending entry loaded from WAL file, got %d", wp2.PendingCount())
+	}
+
+	// Replay with working provider
+	wp2.ReplayPending()
+
+	if len(mock2.tasks) != 1 {
+		t.Fatalf("expected 1 task replayed, got %d", len(mock2.tasks))
+	}
+	if mock2.tasks[0].Text != "persisted task" {
+		t.Errorf("expected 'persisted task', got %q", mock2.tasks[0].Text)
+	}
+}
+
+func TestWALProvider_LoadTasks_TriggersReplay(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+
+	// Queue a save while provider is down
+	mock.saveErr = errors.New("down")
+	_ = wp.SaveTask(NewTask("queued"))
+
+	// Restore provider and call LoadTasks
+	mock.saveErr = nil
+	tasks, err := wp.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks failed: %v", err)
+	}
+	// LoadTasks returns what the inner provider has (initially empty from mock)
+	_ = tasks
+
+	// Replay should have been triggered by LoadTasks
+	if wp.PendingCount() != 0 {
+		t.Errorf("expected 0 pending after LoadTasks triggered replay, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_ReplayPending_Empty(t *testing.T) {
+	t.Parallel()
+	wp, _, _ := newTestWALProvider(t)
+
+	errs := wp.ReplayPending()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for empty replay, got %v", errs)
+	}
+}
+
+func TestWALProvider_ReplayPending_RetryIncrement(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+
+	// Queue entry
+	mock.saveErr = errors.New("unavailable")
+	_ = wp.SaveTask(NewTask("retry me"))
+
+	// Replay with provider still down — should increment retry count
+	errs := wp.ReplayPending()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+
+	if wp.PendingCount() != 1 {
+		t.Errorf("expected 1 pending entry still queued, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_SaveTasks_QueuesOnFailure(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+	mock.saveErr = errors.New("provider unavailable")
+
+	tasks := []*Task{NewTask("a"), NewTask("b")}
+	if err := wp.SaveTasks(tasks); err != nil {
+		t.Fatalf("SaveTasks should not return error when queuing: %v", err)
+	}
+
+	if wp.PendingCount() != 1 {
+		t.Errorf("expected 1 pending entry (batch), got %d", wp.PendingCount())
+	}
+
+	// Replay
+	mock.saveErr = nil
+	wp.ReplayPending()
+
+	if mock.saveBatchCalls != 2 { // 1 initial + 1 replay
+		t.Errorf("expected 2 save batch calls, got %d", mock.saveBatchCalls)
+	}
+}
+
+func TestWALProvider_DeleteTask_PassesThrough(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+	mock.tasks = []*Task{NewTask("to delete")}
+	taskID := mock.tasks[0].ID
+
+	if err := wp.DeleteTask(taskID); err != nil {
+		t.Fatalf("DeleteTask failed: %v", err)
+	}
+
+	if mock.deleteCalls != 1 {
+		t.Errorf("expected 1 delete call, got %d", mock.deleteCalls)
+	}
+	if wp.PendingCount() != 0 {
+		t.Errorf("expected 0 pending, got %d", wp.PendingCount())
+	}
+}
+
+func TestWALProvider_MixedOperations(t *testing.T) {
+	t.Parallel()
+	wp, mock, _ := newTestWALProvider(t)
+
+	// All operations fail
+	mock.saveErr = errors.New("down")
+	mock.deleteErr = errors.New("down")
+	mock.completeErr = errors.New("down")
+
+	_ = wp.SaveTask(NewTask("save"))
+	_ = wp.DeleteTask("del-123")
+	_ = wp.MarkComplete("comp-456")
+
+	if wp.PendingCount() != 3 {
+		t.Fatalf("expected 3 pending entries, got %d", wp.PendingCount())
+	}
+
+	// Restore and replay
+	mock.saveErr = nil
+	mock.deleteErr = nil
+	mock.completeErr = nil
+
+	errs := wp.ReplayPending()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+	if wp.PendingCount() != 0 {
+		t.Errorf("expected 0 pending after replay, got %d", wp.PendingCount())
+	}
+}


### PR DESCRIPTION
## Summary

- Implements a Write-Ahead Log (WAL) provider (`WALProvider`) that wraps any `TaskProvider` for offline-first operation
- When the underlying provider is unavailable, all write operations (save, delete, mark complete) are queued in `~/.threedoors/sync-queue.jsonl` (JSONL format)
- Queued operations replay in order when connectivity restores, with exponential backoff for retries
- Configurable queue size limit (default 10,000 entries) with oldest-first eviction when exceeded
- Core functionality (door selection, local task management) remains completely unaffected by sync state
- WAL file uses atomic write pattern (tmp → sync → rename) per coding-standards.md

## Files Changed

- `internal/tasks/wal_provider.go` — New WAL provider implementation (WALEntry, WALProvider, replay logic)
- `internal/tasks/wal_provider_test.go` — 15 table-driven tests covering passthrough, queuing, replay, persistence, eviction, mixed ops
- `cmd/threedoors/main.go` — Wire WALProvider around the base provider

## Acceptance Criteria

- [x] WAL in `~/.threedoors/sync-queue.jsonl` for pending changes
- [x] All adapter write operations go through the queue
- [x] Queue replay on connectivity restoration with ordered application
- [x] Failed replays retry with exponential backoff
- [x] Queue size limit with oldest-first eviction (configurable, default 10000)
- [x] Core functionality unaffected by sync state

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — zero warnings
- [x] `make fmt` — gofumpt clean
- [x] `go test -race` — no race conditions
- [x] `make build` — compiles successfully