### PR TITLE
fix: bump notarization timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
               --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
               --password "$APPLE_NOTARIZATION_PASSWORD" \
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
-              --wait --timeout 900
+              --wait --timeout 1800
             rm "${BINARY}.zip"
           done
 
@@ -180,7 +180,7 @@ jobs:
               --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
               --password "$APPLE_NOTARIZATION_PASSWORD" \
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
-              --wait --timeout 900
+              --wait --timeout 1800
             xcrun stapler staple "$PKG"
           done
 


### PR DESCRIPTION
## Summary

- Bumped `xcrun notarytool submit --wait --timeout` from 900s to 1800s (30 minutes) for both binary and pkg notarization steps

## Why

Our first-ever notarization submission timed out at 15m 6s. First submissions from a new Apple Developer account undergo extra validation and can take 15-30+ minutes. Routine submissions typically complete in 1-5 minutes — we can reduce this back to 900s once we've confirmed that.

## Test plan

- [ ] Merge and verify the `sign-and-notarize` job completes without hitting the timeout