### PR TITLE
feat: Story 7.1 - Adapter Registry & Runtime Discovery

### DIFF
--- a/cmd/threedoors/main.go
+++ b/cmd/threedoors/main.go
@@ -22,6 +22,9 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Register built-in adapters with the global registry
+	tasks.RegisterBuiltinAdapters(tasks.DefaultRegistry())
+
 	configDir, configErr := tasks.GetConfigDirPath()
 	var cfg *tasks.ProviderConfig
 	if configErr != nil {

--- a/internal/tasks/adapters.go
+++ b/internal/tasks/adapters.go
@@ -1,0 +1,17 @@
+package tasks
+
+// RegisterBuiltinAdapters registers the built-in task provider adapters
+// with the given registry. This should be called during application startup.
+func RegisterBuiltinAdapters(reg *Registry) {
+	// Text file provider: YAML-based local file storage
+	_ = reg.Register("textfile", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+
+	// Apple Notes provider: wrapped in FallbackProvider for graceful degradation
+	_ = reg.Register("applenotes", func(config *ProviderConfig) (TaskProvider, error) {
+		primary := NewAppleNotesProvider(config.NoteTitle)
+		fallback := NewTextFileProvider()
+		return NewFallbackProvider(primary, fallback), nil
+	})
+}

--- a/internal/tasks/provider_factory.go
+++ b/internal/tasks/provider_factory.go
@@ -6,16 +6,26 @@ import (
 )
 
 // NewProviderFromConfig creates a TaskProvider based on the given configuration.
+// It first attempts to look up the provider in the default registry.
+// If the registry has a matching factory, it uses that; otherwise it falls back
+// to built-in defaults for backward compatibility.
 func NewProviderFromConfig(config *ProviderConfig) TaskProvider {
-	switch config.Provider {
-	case "applenotes":
-		primary := NewAppleNotesProvider(config.NoteTitle)
-		fallback := NewTextFileProvider()
-		return NewFallbackProvider(primary, fallback)
-	case "textfile", "":
-		return NewTextFileProvider()
-	default:
-		fmt.Fprintf(os.Stderr, "Warning: unknown provider %q, using textfile\n", config.Provider)
-		return NewTextFileProvider()
+	reg := DefaultRegistry()
+
+	name := config.Provider
+	if name == "" {
+		name = "textfile"
 	}
+
+	if reg.IsRegistered(name) {
+		provider, err := reg.InitProvider(name, config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: adapter %q failed to initialize: %v, using textfile\n", name, err)
+			return NewTextFileProvider()
+		}
+		return provider
+	}
+
+	fmt.Fprintf(os.Stderr, "Warning: unknown provider %q, using textfile\n", name)
+	return NewTextFileProvider()
 }

--- a/internal/tasks/provider_factory_test.go
+++ b/internal/tasks/provider_factory_test.go
@@ -4,7 +4,21 @@ import (
 	"testing"
 )
 
+// setupTestRegistry resets the default registry and registers built-in adapters.
+func setupTestRegistry(t *testing.T) {
+	t.Helper()
+	// Replace the default registry with a fresh one for test isolation
+	orig := defaultRegistry
+	defaultRegistry = NewRegistry()
+	RegisterBuiltinAdapters(defaultRegistry)
+	t.Cleanup(func() {
+		defaultRegistry = orig
+	})
+}
+
 func TestNewProviderFromConfig_TextFile(t *testing.T) {
+	setupTestRegistry(t)
+
 	cfg := &ProviderConfig{Provider: "textfile", NoteTitle: "ThreeDoors Tasks"}
 
 	provider := NewProviderFromConfig(cfg)
@@ -19,6 +33,8 @@ func TestNewProviderFromConfig_TextFile(t *testing.T) {
 }
 
 func TestNewProviderFromConfig_AppleNotes(t *testing.T) {
+	setupTestRegistry(t)
+
 	cfg := &ProviderConfig{Provider: "applenotes", NoteTitle: "My Tasks"}
 
 	provider := NewProviderFromConfig(cfg)
@@ -33,6 +49,8 @@ func TestNewProviderFromConfig_AppleNotes(t *testing.T) {
 }
 
 func TestNewProviderFromConfig_EmptyProvider_DefaultsToTextFile(t *testing.T) {
+	setupTestRegistry(t)
+
 	cfg := &ProviderConfig{Provider: "", NoteTitle: "ThreeDoors Tasks"}
 
 	provider := NewProviderFromConfig(cfg)
@@ -47,6 +65,8 @@ func TestNewProviderFromConfig_EmptyProvider_DefaultsToTextFile(t *testing.T) {
 }
 
 func TestNewProviderFromConfig_UnknownProvider_DefaultsToTextFile(t *testing.T) {
+	setupTestRegistry(t)
+
 	cfg := &ProviderConfig{Provider: "unknown", NoteTitle: "ThreeDoors Tasks"}
 
 	provider := NewProviderFromConfig(cfg)

--- a/internal/tasks/registry.go
+++ b/internal/tasks/registry.go
@@ -1,0 +1,145 @@
+package tasks
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+// AdapterFactory creates a TaskProvider from the given configuration.
+// If initialization fails, it should return an error rather than panicking.
+type AdapterFactory func(config *ProviderConfig) (TaskProvider, error)
+
+// Registry manages adapter registration and runtime discovery of TaskProvider implementations.
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]AdapterFactory
+	active    map[string]TaskProvider
+}
+
+// NewRegistry creates a new empty adapter registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		factories: make(map[string]AdapterFactory),
+		active:    make(map[string]TaskProvider),
+	}
+}
+
+// Register adds an adapter factory to the registry under the given name.
+// Returns an error if the name is empty or already registered.
+func (r *Registry) Register(name string, factory AdapterFactory) error {
+	if name == "" {
+		return fmt.Errorf("register adapter: name must not be empty")
+	}
+	if factory == nil {
+		return fmt.Errorf("register adapter %q: factory must not be nil", name)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.factories[name]; exists {
+		return fmt.Errorf("register adapter %q: already registered", name)
+	}
+
+	r.factories[name] = factory
+	return nil
+}
+
+// ListProviders returns the names of all registered adapters in no particular order.
+func (r *Registry) ListProviders() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.factories))
+	for name := range r.factories {
+		names = append(names, name)
+	}
+	return names
+}
+
+// GetProvider returns the active provider instance for the given name.
+// If the provider has not been initialized yet, it returns an error.
+func (r *Registry) GetProvider(name string) (TaskProvider, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	provider, ok := r.active[name]
+	if !ok {
+		return nil, fmt.Errorf("get provider %q: not active", name)
+	}
+	return provider, nil
+}
+
+// ActiveProviders returns all currently initialized and active provider instances.
+func (r *Registry) ActiveProviders() []TaskProvider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providers := make([]TaskProvider, 0, len(r.active))
+	for _, p := range r.active {
+		providers = append(providers, p)
+	}
+	return providers
+}
+
+// InitProvider initializes a registered adapter with the given config and marks it as active.
+// If initialization fails, a warning is logged and the error is returned,
+// but the registry remains usable for other adapters.
+func (r *Registry) InitProvider(name string, config *ProviderConfig) (TaskProvider, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	factory, ok := r.factories[name]
+	if !ok {
+		return nil, fmt.Errorf("init provider %q: not registered", name)
+	}
+
+	provider, err := factory(config)
+	if err != nil {
+		log.Printf("Warning: adapter %q failed to initialize: %v", name, err)
+		return nil, fmt.Errorf("init provider %q: %w", name, err)
+	}
+
+	r.active[name] = provider
+	return provider, nil
+}
+
+// InitAll attempts to initialize all registered adapters with the given config.
+// Adapters that fail to initialize are logged as warnings but do not prevent
+// other adapters from initializing. Returns the number of successfully initialized adapters.
+func (r *Registry) InitAll(config *ProviderConfig) int {
+	r.mu.Lock()
+	names := make([]string, 0, len(r.factories))
+	for name := range r.factories {
+		names = append(names, name)
+	}
+	r.mu.Unlock()
+
+	initialized := 0
+	for _, name := range names {
+		if _, err := r.InitProvider(name, config); err != nil {
+			log.Printf("Warning: skipping adapter %q: %v", name, err)
+			continue
+		}
+		initialized++
+	}
+	return initialized
+}
+
+// IsRegistered returns true if an adapter with the given name has been registered.
+func (r *Registry) IsRegistered(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, ok := r.factories[name]
+	return ok
+}
+
+// defaultRegistry is the global adapter registry used by the application.
+var defaultRegistry = NewRegistry()
+
+// DefaultRegistry returns the global adapter registry.
+func DefaultRegistry() *Registry {
+	return defaultRegistry
+}

--- a/internal/tasks/registry_test.go
+++ b/internal/tasks/registry_test.go
@@ -1,0 +1,231 @@
+package tasks
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// stubFactory returns a factory that creates a TextFileProvider.
+func stubFactory() AdapterFactory {
+	return func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	}
+}
+
+// failingFactory returns a factory that always returns an error.
+func failingFactory() AdapterFactory {
+	return func(config *ProviderConfig) (TaskProvider, error) {
+		return nil, fmt.Errorf("init failed")
+	}
+}
+
+func TestRegistry_Register(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		adapter string
+		factory AdapterFactory
+		wantErr bool
+	}{
+		{"valid registration", "test-adapter", stubFactory(), false},
+		{"empty name", "", stubFactory(), true},
+		{"nil factory", "nil-factory", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reg := NewRegistry()
+
+			err := reg.Register(tt.adapter, tt.factory)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Register() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegistry_Register_DuplicateName(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("dup", stubFactory()); err != nil {
+		t.Fatalf("first Register() failed: %v", err)
+	}
+	if err := reg.Register("dup", stubFactory()); err == nil {
+		t.Error("second Register() should have failed for duplicate name")
+	}
+}
+
+func TestRegistry_ListProviders(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("alpha", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register("beta", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+
+	names := reg.ListProviders()
+	sort.Strings(names)
+
+	if len(names) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(names))
+	}
+	if names[0] != "alpha" || names[1] != "beta" {
+		t.Errorf("expected [alpha beta], got %v", names)
+	}
+}
+
+func TestRegistry_ListProviders_Empty(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	names := reg.ListProviders()
+	if len(names) != 0 {
+		t.Errorf("expected 0 providers, got %d", len(names))
+	}
+}
+
+func TestRegistry_GetProvider_NotActive(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("inactive", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := reg.GetProvider("inactive")
+	if err == nil {
+		t.Error("GetProvider() should fail for uninitialized provider")
+	}
+}
+
+func TestRegistry_GetProvider_Active(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("active", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := defaultProviderConfig()
+	if _, err := reg.InitProvider("active", cfg); err != nil {
+		t.Fatalf("InitProvider() failed: %v", err)
+	}
+
+	provider, err := reg.GetProvider("active")
+	if err != nil {
+		t.Fatalf("GetProvider() failed: %v", err)
+	}
+	if provider == nil {
+		t.Error("GetProvider() returned nil provider")
+	}
+}
+
+func TestRegistry_ActiveProviders(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("one", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register("two", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := defaultProviderConfig()
+	if _, err := reg.InitProvider("one", cfg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.InitProvider("two", cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	active := reg.ActiveProviders()
+	if len(active) != 2 {
+		t.Errorf("expected 2 active providers, got %d", len(active))
+	}
+}
+
+func TestRegistry_ActiveProviders_Empty(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	active := reg.ActiveProviders()
+	if len(active) != 0 {
+		t.Errorf("expected 0 active providers, got %d", len(active))
+	}
+}
+
+func TestRegistry_InitProvider_NotRegistered(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	_, err := reg.InitProvider("missing", defaultProviderConfig())
+	if err == nil {
+		t.Error("InitProvider() should fail for unregistered provider")
+	}
+}
+
+func TestRegistry_InitProvider_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("broken", failingFactory()); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := reg.InitProvider("broken", defaultProviderConfig())
+	if err == nil {
+		t.Error("InitProvider() should fail when factory returns error")
+	}
+
+	// Should not be in active providers
+	active := reg.ActiveProviders()
+	if len(active) != 0 {
+		t.Errorf("failed adapter should not be active, got %d active", len(active))
+	}
+}
+
+func TestRegistry_InitAll_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("good", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register("bad", failingFactory()); err != nil {
+		t.Fatal(err)
+	}
+
+	count := reg.InitAll(defaultProviderConfig())
+	if count != 1 {
+		t.Errorf("expected 1 successful init, got %d", count)
+	}
+
+	active := reg.ActiveProviders()
+	if len(active) != 1 {
+		t.Errorf("expected 1 active provider, got %d", len(active))
+	}
+}
+
+func TestRegistry_IsRegistered(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	if err := reg.Register("exists", stubFactory()); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reg.IsRegistered("exists") {
+		t.Error("IsRegistered() should return true for registered adapter")
+	}
+	if reg.IsRegistered("nope") {
+		t.Error("IsRegistered() should return false for unregistered adapter")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements a formal `Registry` type (`internal/tasks/registry.go`) with `Register(name, factory)`, `ListProviders()`, `GetProvider(name)`, `ActiveProviders()`, `InitProvider()`, and `InitAll()` methods
- Failed adapter initialization logs a warning and continues — does not crash the application
- Migrates existing TextFile and AppleNotes adapters to the registry pattern via `RegisterBuiltinAdapters()` (`internal/tasks/adapters.go`)
- Updates `NewProviderFromConfig` to use registry lookup instead of hard-coded switch statement
- Registers built-in adapters at application startup in `main()`

## Acceptance Criteria Met

- [x] Adapters register via `registry.Register(name, factory)` pattern
- [x] Failed adapter initialization logs warning and continues with other adapters
- [x] Registry exposes `ListProviders()`, `GetProvider(name)`, and `ActiveProviders()` methods
- [x] Existing text file and Apple Notes adapters migrated to registry pattern

## Test Plan

- [x] Registry lifecycle tests (register, list, get, active)
- [x] Duplicate name registration rejected
- [x] Empty name / nil factory validation
- [x] Failed adapter initialization doesn't crash, not added to active
- [x] Partial failure in InitAll (good adapter succeeds, bad adapter warned)
- [x] Provider factory tests updated for registry-backed lookup
- [x] All existing tests pass unchanged
- [x] Race detector clean (`go test -race`)
- [x] golangci-lint: 0 issues
- [x] gofumpt formatted

## Quality Gates

- [x] gofumpt ✓
- [x] golangci-lint ✓
- [x] tests pass ✓
- [x] rebased on main ✓
- [x] errors handled with context wrapping ✓

## Future Opportunities (not in scope)

- Story 7.2: Config-driven provider selection with per-adapter config schemas
- Story 7.3: Adapter developer guide & contract tests
- External/plugin adapter loading via Go plugins or shared libraries