### PR TITLE
feat: Story 7.2 - Config-Driven Provider Selection

### DIFF
--- a/cmd/threedoors/main.go
+++ b/cmd/threedoors/main.go
@@ -31,8 +31,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Warning: config dir not found: %v, using defaults\n", configErr)
 		cfg = &tasks.ProviderConfig{Provider: "textfile", NoteTitle: "ThreeDoors Tasks"}
 	} else {
+		configPath := filepath.Join(configDir, "config.yaml")
+
+		// Generate sample config on first run if none exists
+		if err := tasks.GenerateSampleConfig(configPath, tasks.DefaultRegistry()); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to generate sample config: %v\n", err)
+		}
+
 		var loadErr error
-		cfg, loadErr = tasks.LoadProviderConfig(filepath.Join(configDir, "config.yaml"))
+		cfg, loadErr = tasks.LoadProviderConfig(configPath)
 		if loadErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: config load failed: %v, using defaults\n", loadErr)
 			cfg = &tasks.ProviderConfig{Provider: "textfile", NoteTitle: "ThreeDoors Tasks"}

--- a/docs/stories/7.2.story.md
+++ b/docs/stories/7.2.story.md
@@ -1,0 +1,93 @@
+# Story 7.2: Config-Driven Provider Selection
+
+**Status:** in-progress
+**Epic:** 7 — Plugin/Adapter SDK & Registry
+**Depends on:** Story 7.1 (Adapter Registry & Runtime Discovery) ✅ Merged
+
+## User Story
+
+**As a** user with multiple task sources,
+**I want** to configure active backends via `~/.threedoors/config.yaml`,
+**so that** I can choose which task providers are active without code changes.
+
+## Acceptance Criteria
+
+### AC-1: Config parser reads providers section
+**Given** a config.yaml with a `providers:` section
+**When** `LoadProviderConfig()` is called
+**Then** it parses the providers list with per-provider settings
+
+### AC-2: YAML schema supports providers section
+**Given** a config.yaml file
+**When** it contains a `providers:` section
+**Then** each entry has a `name` and provider-specific `settings` map
+**And** the schema is documented with examples
+
+### AC-3: Only configured providers loaded at startup
+**Given** a config.yaml with specific providers listed
+**When** the application starts
+**Then** only those providers are initialized via the registry
+**And** unconfigured providers are not activated
+
+### AC-4: Provider-specific settings passed to adapter factory
+**Given** a provider entry with custom settings (paths, credentials, options)
+**When** the adapter factory is called
+**Then** the settings are accessible to the factory for initialization
+
+### AC-5: Missing config.yaml backward compatible
+**Given** no config.yaml exists
+**When** the application starts
+**Then** it falls back to the text file provider
+**And** behavior is identical to pre-7.2
+
+### AC-6: Sample config generated on first run
+**Given** the application runs for the first time (no config.yaml)
+**When** onboarding completes or first startup finishes
+**Then** a sample config.yaml is generated with commented-out provider examples
+
+## Quality Gate
+
+- [ ] AC-Q1: gofumpt formatted
+- [ ] AC-Q2: golangci-lint zero warnings
+- [ ] AC-Q3: All tests pass
+- [ ] AC-Q4: Rebased on main
+- [ ] AC-Q5: Scope checked — no unrelated changes
+- [ ] AC-Q6: Errors handled with context wrapping (`%w`)
+- [ ] AC-Q7: No panics in user-facing code
+- [ ] AC-Q8: Table-driven tests where applicable
+
+## Tasks
+
+### Task 1: Extend ProviderConfig with providers section
+- Add `Providers []ProviderEntry` field to config struct
+- Define `ProviderEntry` struct with `Name string` and `Settings map[string]string`
+- Update `LoadProviderConfig` to parse the new schema
+- Maintain backward compatibility with existing `provider:` field
+
+### Task 2: Update provider factory to use providers list
+- Modify `NewProviderFromConfig` to iterate configured providers
+- Initialize only configured providers via registry
+- Pass provider-specific settings through to adapter factories
+- Fall back to textfile when no providers configured
+
+### Task 3: Generate sample config on first run
+- Create `GenerateSampleConfig` function
+- Include commented-out examples for all registered providers
+- Integrate with onboarding/first-run flow
+
+### Task 4: Update main.go wiring
+- Wire new config-driven flow into application startup
+- Ensure backward compatibility path works
+
+### Task 5: Tests
+- Unit tests for new config parsing
+- Unit tests for provider selection logic
+- Integration test for backward compatibility
+- Test sample config generation
+
+## Dev Notes
+
+- The `AdapterFactory` signature is `func(config *ProviderConfig) (TaskProvider, error)` — Story 7.2 needs to pass per-provider settings through this
+- Current `ProviderConfig` has flat `Provider` and `NoteTitle` fields — need to extend without breaking
+- `config.yaml` is shared with onboarding (`onboarding_complete`) and values (`values`) — use map merge pattern like `MarkOnboardingComplete`
+- Registry from 7.1: `DefaultRegistry()`, `Register()`, `InitProvider()`, `ListProviders()`

--- a/internal/tasks/provider_config.go
+++ b/internal/tasks/provider_config.go
@@ -2,15 +2,39 @@ package tasks
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
+// ProviderEntry represents a configured provider with its per-provider settings.
+type ProviderEntry struct {
+	Name     string            `yaml:"name"`
+	Settings map[string]string `yaml:"settings,omitempty"`
+}
+
+// GetSetting returns the value for a key, or the fallback if not found.
+func (pe ProviderEntry) GetSetting(key, fallback string) string {
+	if pe.Settings == nil {
+		return fallback
+	}
+	v, ok := pe.Settings[key]
+	if !ok {
+		return fallback
+	}
+	return v
+}
+
 // ProviderConfig holds configuration for which task provider to use.
 type ProviderConfig struct {
-	Provider  string `yaml:"provider"`
-	NoteTitle string `yaml:"note_title"`
+	// Provider is the legacy flat provider name (backward compatible).
+	Provider string `yaml:"provider,omitempty"`
+	// NoteTitle is the legacy Apple Notes title (backward compatible).
+	NoteTitle string `yaml:"note_title,omitempty"`
+	// Providers is the new config-driven list of active providers.
+	Providers []ProviderEntry `yaml:"providers,omitempty"`
 }
 
 // defaultProviderConfig returns the default configuration.
@@ -41,8 +65,8 @@ func LoadProviderConfig(path string) (*ProviderConfig, error) {
 		return nil, err
 	}
 
-	// Ensure defaults for empty fields
-	if cfg.Provider == "" {
+	// Ensure defaults for empty fields (backward compatibility)
+	if cfg.Provider == "" && len(cfg.Providers) == 0 {
 		cfg.Provider = "textfile"
 	}
 	if cfg.NoteTitle == "" {
@@ -50,4 +74,110 @@ func LoadProviderConfig(path string) (*ProviderConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+// ResolveActiveProvider creates a TaskProvider based on the configuration and registry.
+// If the config has a providers list, the first provider is used as the primary.
+// Otherwise, the legacy flat provider field is used for backward compatibility.
+func ResolveActiveProvider(cfg *ProviderConfig, reg *Registry) (TaskProvider, error) {
+	if len(cfg.Providers) > 0 {
+		return resolveFromProvidersList(cfg, reg)
+	}
+	return resolveFromFlatConfig(cfg, reg)
+}
+
+// resolveFromProvidersList initializes the first configured provider as primary.
+func resolveFromProvidersList(cfg *ProviderConfig, reg *Registry) (TaskProvider, error) {
+	primary := cfg.Providers[0]
+
+	if !reg.IsRegistered(primary.Name) {
+		return nil, fmt.Errorf("resolve provider %q: not registered", primary.Name)
+	}
+
+	provider, err := reg.InitProvider(primary.Name, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve provider %q: %w", primary.Name, err)
+	}
+
+	return provider, nil
+}
+
+// resolveFromFlatConfig handles the legacy flat provider field.
+func resolveFromFlatConfig(cfg *ProviderConfig, reg *Registry) (TaskProvider, error) {
+	name := cfg.Provider
+	if name == "" {
+		name = "textfile"
+	}
+
+	if !reg.IsRegistered(name) {
+		return nil, fmt.Errorf("resolve provider %q: not registered", name)
+	}
+
+	provider, err := reg.InitProvider(name, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve provider %q: %w", name, err)
+	}
+
+	return provider, nil
+}
+
+// GenerateSampleConfig writes a sample config.yaml with commented-out provider examples.
+// If the file already exists, it does nothing (preserves user config).
+func GenerateSampleConfig(path string, reg *Registry) error {
+	// Do not overwrite existing config
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+
+	providers := reg.ListProviders()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# ThreeDoors Configuration\n")
+	fmt.Fprintf(&b, "# See docs for available providers and settings.\n\n")
+	fmt.Fprintf(&b, "# Active provider (simple mode — use 'providers:' list for advanced config)\n")
+	fmt.Fprintf(&b, "provider: textfile\n")
+	fmt.Fprintf(&b, "note_title: ThreeDoors Tasks\n\n")
+	fmt.Fprintf(&b, "# Advanced: configure multiple providers with per-provider settings\n")
+	fmt.Fprintf(&b, "# Uncomment and customize the providers list below:\n")
+	fmt.Fprintf(&b, "#\n")
+	fmt.Fprintf(&b, "# providers:\n")
+
+	for _, name := range providers {
+		fmt.Fprintf(&b, "#   - name: %s\n", name)
+		fmt.Fprintf(&b, "#     settings:\n")
+		switch name {
+		case "textfile":
+			fmt.Fprintf(&b, "#       task_file: ~/.threedoors/tasks.yaml\n")
+		case "applenotes":
+			fmt.Fprintf(&b, "#       note_title: ThreeDoors Tasks\n")
+		default:
+			fmt.Fprintf(&b, "#       # Add provider-specific settings here\n")
+		}
+	}
+
+	tmpPath := path + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create sample config: %w", err)
+	}
+
+	if _, err := f.WriteString(b.String()); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write sample config: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("sync sample config: %w", err)
+	}
+	_ = f.Close()
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename sample config: %w", err)
+	}
+
+	return nil
 }

--- a/internal/tasks/provider_config_test.go
+++ b/internal/tasks/provider_config_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -96,5 +97,391 @@ func TestLoadProviderConfig_RoundTrip(t *testing.T) {
 	}
 	if cfg.NoteTitle != "Work Notes" {
 		t.Errorf("NoteTitle = %q, want %q", cfg.NoteTitle, "Work Notes")
+	}
+}
+
+// --- Story 7.2 Tests: Config-Driven Provider Selection ---
+
+func TestLoadProviderConfig_WithProvidersList(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`providers:
+  - name: textfile
+    settings:
+      task_file: ~/custom/tasks.yaml
+  - name: applenotes
+    settings:
+      note_title: Work Tasks
+`)
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := LoadProviderConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadProviderConfig() unexpected error: %v", err)
+	}
+
+	if len(cfg.Providers) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(cfg.Providers))
+	}
+	if cfg.Providers[0].Name != "textfile" {
+		t.Errorf("Providers[0].Name = %q, want %q", cfg.Providers[0].Name, "textfile")
+	}
+	if cfg.Providers[0].Settings["task_file"] != "~/custom/tasks.yaml" {
+		t.Errorf("Providers[0].Settings[task_file] = %q, want %q", cfg.Providers[0].Settings["task_file"], "~/custom/tasks.yaml")
+	}
+	if cfg.Providers[1].Name != "applenotes" {
+		t.Errorf("Providers[1].Name = %q, want %q", cfg.Providers[1].Name, "applenotes")
+	}
+	if cfg.Providers[1].Settings["note_title"] != "Work Tasks" {
+		t.Errorf("Providers[1].Settings[note_title] = %q, want %q", cfg.Providers[1].Settings["note_title"], "Work Tasks")
+	}
+}
+
+func TestLoadProviderConfig_ProvidersListEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte("providers: []\n")
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := LoadProviderConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadProviderConfig() unexpected error: %v", err)
+	}
+
+	if len(cfg.Providers) != 0 {
+		t.Errorf("expected 0 providers, got %d", len(cfg.Providers))
+	}
+}
+
+func TestLoadProviderConfig_BackwardCompatibleFlatProvider(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	// Old-style flat config should still work
+	content := []byte("provider: applenotes\nnote_title: My Tasks\n")
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := LoadProviderConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadProviderConfig() unexpected error: %v", err)
+	}
+
+	// Flat provider field should still be parsed
+	if cfg.Provider != "applenotes" {
+		t.Errorf("Provider = %q, want %q", cfg.Provider, "applenotes")
+	}
+	if cfg.NoteTitle != "My Tasks" {
+		t.Errorf("NoteTitle = %q, want %q", cfg.NoteTitle, "My Tasks")
+	}
+}
+
+func TestLoadProviderConfig_ProviderEntryWithNoSettings(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`providers:
+  - name: textfile
+`)
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := LoadProviderConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadProviderConfig() unexpected error: %v", err)
+	}
+
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(cfg.Providers))
+	}
+	if cfg.Providers[0].Name != "textfile" {
+		t.Errorf("Providers[0].Name = %q, want %q", cfg.Providers[0].Name, "textfile")
+	}
+	if len(cfg.Providers[0].Settings) != 0 {
+		t.Errorf("expected nil or empty settings, got %v", cfg.Providers[0].Settings)
+	}
+}
+
+func TestProviderEntry_GetSetting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entry    ProviderEntry
+		key      string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "existing key",
+			entry:    ProviderEntry{Name: "test", Settings: map[string]string{"key": "value"}},
+			key:      "key",
+			fallback: "default",
+			want:     "value",
+		},
+		{
+			name:     "missing key returns fallback",
+			entry:    ProviderEntry{Name: "test", Settings: map[string]string{"other": "value"}},
+			key:      "key",
+			fallback: "default",
+			want:     "default",
+		},
+		{
+			name:     "nil settings returns fallback",
+			entry:    ProviderEntry{Name: "test"},
+			key:      "key",
+			fallback: "default",
+			want:     "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.entry.GetSetting(tt.key, tt.fallback)
+			if got != tt.want {
+				t.Errorf("GetSetting(%q, %q) = %q, want %q", tt.key, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateSampleConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	reg := NewRegistry()
+	_ = reg.Register("textfile", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+	_ = reg.Register("applenotes", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+
+	err := GenerateSampleConfig(configPath, reg)
+	if err != nil {
+		t.Fatalf("GenerateSampleConfig() unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated config: %v", err)
+	}
+
+	content := string(data)
+
+	// Should contain the active textfile provider
+	if !strings.Contains(content, "textfile") {
+		t.Error("sample config should mention textfile provider")
+	}
+
+	// Should contain commented-out examples
+	if !strings.Contains(content, "#") {
+		t.Error("sample config should contain comments")
+	}
+}
+
+func TestGenerateSampleConfig_DoesNotOverwriteExisting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	existing := []byte("provider: applenotes\n")
+	if err := os.WriteFile(configPath, existing, 0o644); err != nil {
+		t.Fatalf("failed to write existing config: %v", err)
+	}
+
+	reg := NewRegistry()
+	err := GenerateSampleConfig(configPath, reg)
+	if err != nil {
+		t.Fatalf("GenerateSampleConfig() unexpected error: %v", err)
+	}
+
+	// Existing file should not be overwritten
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	if string(data) != string(existing) {
+		t.Errorf("existing config was overwritten: got %q, want %q", string(data), string(existing))
+	}
+}
+
+func TestResolveActiveProvider_WithProvidersList(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	_ = reg.Register("textfile", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+
+	cfg := &ProviderConfig{
+		Providers: []ProviderEntry{
+			{Name: "textfile", Settings: map[string]string{}},
+		},
+	}
+
+	provider, err := ResolveActiveProvider(cfg, reg)
+	if err != nil {
+		t.Fatalf("ResolveActiveProvider() unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("ResolveActiveProvider() returned nil")
+	}
+
+	_, ok := provider.(*TextFileProvider)
+	if !ok {
+		t.Errorf("expected *TextFileProvider, got %T", provider)
+	}
+}
+
+func TestResolveActiveProvider_FallbackToFlatProvider(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	_ = reg.Register("textfile", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+
+	// Old-style config with flat provider field, no providers list
+	cfg := &ProviderConfig{
+		Provider:  "textfile",
+		NoteTitle: "ThreeDoors Tasks",
+	}
+
+	provider, err := ResolveActiveProvider(cfg, reg)
+	if err != nil {
+		t.Fatalf("ResolveActiveProvider() unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("ResolveActiveProvider() returned nil")
+	}
+}
+
+func TestResolveActiveProvider_NoConfig_DefaultsToTextFile(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	_ = reg.Register("textfile", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+
+	// Empty config — should default to textfile
+	cfg := &ProviderConfig{}
+
+	provider, err := ResolveActiveProvider(cfg, reg)
+	if err != nil {
+		t.Fatalf("ResolveActiveProvider() unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("ResolveActiveProvider() returned nil")
+	}
+
+	_, ok := provider.(*TextFileProvider)
+	if !ok {
+		t.Errorf("expected *TextFileProvider, got %T", provider)
+	}
+}
+
+func TestResolveActiveProvider_UnknownProvider_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	_ = reg.Register("textfile", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+
+	cfg := &ProviderConfig{
+		Providers: []ProviderEntry{
+			{Name: "nonexistent"},
+		},
+	}
+
+	_, err := ResolveActiveProvider(cfg, reg)
+	if err == nil {
+		t.Error("ResolveActiveProvider() expected error for unknown provider, got nil")
+	}
+}
+
+func TestResolveActiveProvider_SettingsPassedToFactory(t *testing.T) {
+	t.Parallel()
+
+	var receivedSettings map[string]string
+	reg := NewRegistry()
+	_ = reg.Register("custom", func(config *ProviderConfig) (TaskProvider, error) {
+		if len(config.Providers) > 0 {
+			receivedSettings = config.Providers[0].Settings
+		}
+		return NewTextFileProvider(), nil
+	})
+
+	cfg := &ProviderConfig{
+		Providers: []ProviderEntry{
+			{
+				Name: "custom",
+				Settings: map[string]string{
+					"path":     "/custom/path",
+					"readonly": "true",
+				},
+			},
+		},
+	}
+
+	_, err := ResolveActiveProvider(cfg, reg)
+	if err != nil {
+		t.Fatalf("ResolveActiveProvider() unexpected error: %v", err)
+	}
+
+	if receivedSettings == nil {
+		t.Fatal("factory did not receive settings")
+	}
+	if receivedSettings["path"] != "/custom/path" {
+		t.Errorf("settings[path] = %q, want %q", receivedSettings["path"], "/custom/path")
+	}
+	if receivedSettings["readonly"] != "true" {
+		t.Errorf("settings[readonly] = %q, want %q", receivedSettings["readonly"], "true")
+	}
+}
+
+func TestResolveActiveProvider_FirstProviderUsedAsPrimary(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	_ = reg.Register("textfile", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+	_ = reg.Register("other", func(config *ProviderConfig) (TaskProvider, error) {
+		return NewTextFileProvider(), nil
+	})
+
+	cfg := &ProviderConfig{
+		Providers: []ProviderEntry{
+			{Name: "textfile"},
+			{Name: "other"},
+		},
+	}
+
+	provider, err := ResolveActiveProvider(cfg, reg)
+	if err != nil {
+		t.Fatalf("ResolveActiveProvider() unexpected error: %v", err)
+	}
+
+	// First provider should be the primary
+	_, ok := provider.(*TextFileProvider)
+	if !ok {
+		t.Errorf("expected *TextFileProvider as primary, got %T", provider)
 	}
 }

--- a/internal/tasks/provider_factory.go
+++ b/internal/tasks/provider_factory.go
@@ -6,26 +6,18 @@ import (
 )
 
 // NewProviderFromConfig creates a TaskProvider based on the given configuration.
-// It first attempts to look up the provider in the default registry.
+// It first attempts to use the new providers list (Story 7.2).
+// If no providers list is present, it falls back to the legacy flat provider field.
 // If the registry has a matching factory, it uses that; otherwise it falls back
 // to built-in defaults for backward compatibility.
 func NewProviderFromConfig(config *ProviderConfig) TaskProvider {
 	reg := DefaultRegistry()
 
-	name := config.Provider
-	if name == "" {
-		name = "textfile"
+	provider, err := ResolveActiveProvider(config, reg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v, using textfile\n", err)
+		return NewTextFileProvider()
 	}
 
-	if reg.IsRegistered(name) {
-		provider, err := reg.InitProvider(name, config)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: adapter %q failed to initialize: %v, using textfile\n", name, err)
-			return NewTextFileProvider()
-		}
-		return provider
-	}
-
-	fmt.Fprintf(os.Stderr, "Warning: unknown provider %q, using textfile\n", name)
-	return NewTextFileProvider()
+	return provider
 }


### PR DESCRIPTION
## Summary

- Extends `ProviderConfig` with a `providers:` list supporting per-provider `settings` maps
- Adds `ResolveActiveProvider()` function that uses the registry (from Story 7.1) to initialize only configured providers
- Generates a sample `config.yaml` with commented-out provider examples on first run
- Full backward compatibility — existing flat `provider:` field configs continue to work unchanged
- Simplifies `NewProviderFromConfig()` to delegate to `ResolveActiveProvider`

## Acceptance Criteria Met

- [x] AC-1: Config parser reads `providers:` section from config.yaml
- [x] AC-2: YAML schema supports per-provider settings map
- [x] AC-3: Only configured providers are loaded and activated at startup
- [x] AC-4: Provider-specific settings passed through to adapter factory
- [x] AC-5: Missing config.yaml falls back to text file provider (backward compatible)
- [x] AC-6: Sample config.yaml generated on first run with commented-out examples

## Files Changed

| File | Change |
|---|---|
| `internal/tasks/provider_config.go` | Added `ProviderEntry`, `Providers` field, `ResolveActiveProvider()`, `GenerateSampleConfig()` |
| `internal/tasks/provider_config_test.go` | 13 new tests for providers list parsing, settings, sample config, resolution |
| `internal/tasks/provider_factory.go` | Simplified to delegate to `ResolveActiveProvider` |
| `cmd/threedoors/main.go` | Wire sample config generation at startup |
| `docs/stories/7.2.story.md` | Story specification |

## Quality Gates

- [x] gofumpt formatted
- [x] golangci-lint: 0 issues
- [x] All tests pass (full suite)
- [x] Race detector clean
- [x] Rebased on main (includes Story 7.1)
- [x] Errors handled with context wrapping (`%w`)

## Test Plan

- [x] Config parsing with `providers:` list (multiple entries, empty list, no settings)
- [x] `ProviderEntry.GetSetting()` with existing key, missing key, nil settings
- [x] `GenerateSampleConfig()` creates file with provider examples
- [x] `GenerateSampleConfig()` does not overwrite existing config
- [x] `ResolveActiveProvider()` with providers list, flat config fallback, empty config defaults
- [x] `ResolveActiveProvider()` errors on unknown provider
- [x] Settings passed through to factory function
- [x] Backward compatibility with legacy flat `provider:` field
- [x] All existing tests continue to pass (no regressions)

## Future Opportunities (not in scope)

- Story 7.3: Adapter developer guide & contract tests
- Multi-provider aggregation (using multiple providers simultaneously)
- Config file validation CLI command