### PR TITLE
fix: increase notarization timeout to 1 hour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
               --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
               --password "$APPLE_NOTARIZATION_PASSWORD" \
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
-              --wait --timeout 1800
+              --wait --timeout 3600
             rm "${BINARY}.zip"
           done
 
@@ -180,7 +180,7 @@ jobs:
               --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
               --password "$APPLE_NOTARIZATION_PASSWORD" \
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
-              --wait --timeout 1800
+              --wait --timeout 3600
             xcrun stapler staple "$PKG"
           done
 


### PR DESCRIPTION
## Summary

- Bumps notarization timeout from 1800s to 3600s (1 hour) for both binary and pkg notarization steps

## Why

PR #67 bumped from 900s to 1800s but the first submission already took 15+ minutes. Early submissions from a new Apple Developer account may need more headroom. A full hour gives plenty of margin while we establish a baseline.

## Test plan

- [ ] Merge and verify `sign-and-notarize` job completes without timeout