### PR TITLE
feat: Story 8.4 - Obsidian Daily Note Integration

### DIFF
--- a/internal/tasks/adapters.go
+++ b/internal/tasks/adapters.go
@@ -26,11 +26,19 @@ func RegisterBuiltinAdapters(reg *Registry) {
 		vaultPath := ""
 		tasksFolder := ""
 		filePattern := ""
+		dailyNotesEnabled := ""
+		dailyNotesFolder := ""
+		dailyNotesHeading := ""
+		dailyNotesFormat := ""
 		for _, p := range config.Providers {
 			if p.Name == "obsidian" {
 				vaultPath = p.GetSetting("vault_path", "")
 				tasksFolder = p.GetSetting("tasks_folder", "")
 				filePattern = p.GetSetting("file_pattern", "")
+				dailyNotesEnabled = p.GetSetting("daily_notes", "")
+				dailyNotesFolder = p.GetSetting("daily_notes_folder", "")
+				dailyNotesHeading = p.GetSetting("daily_notes_heading", "")
+				dailyNotesFormat = p.GetSetting("daily_notes_format", "")
 				break
 			}
 		}
@@ -38,13 +46,24 @@ func RegisterBuiltinAdapters(reg *Registry) {
 			return nil, fmt.Errorf("obsidian adapter requires vault_path setting")
 		}
 
-		if err := ValidateVaultPath(vaultPath); err != nil {
-			primary := NewObsidianAdapter(vaultPath, tasksFolder, filePattern)
-			fallback := NewTextFileProvider()
-			fmt.Fprintf(os.Stderr, "Warning: %v. Falling back to text file provider.\n", err)
-			return NewFallbackProvider(primary, fallback), nil
+		adapter := NewObsidianAdapter(vaultPath, tasksFolder, filePattern)
+
+		// Configure daily notes if enabled
+		if dailyNotesEnabled == "true" {
+			adapter.SetDailyNotes(&DailyNotesConfig{
+				Enabled:    true,
+				Folder:     dailyNotesFolder,
+				Heading:    dailyNotesHeading,
+				DateFormat: dailyNotesFormat,
+			})
 		}
 
-		return NewObsidianAdapter(vaultPath, tasksFolder, filePattern), nil
+		if err := ValidateVaultPath(vaultPath); err != nil {
+			fallback := NewTextFileProvider()
+			fmt.Fprintf(os.Stderr, "Warning: %v. Falling back to text file provider.\n", err)
+			return NewFallbackProvider(adapter, fallback), nil
+		}
+
+		return adapter, nil
 	})
 }

--- a/internal/tasks/obsidian_adapter.go
+++ b/internal/tasks/obsidian_adapter.go
@@ -19,6 +19,7 @@ type ObsidianAdapter struct {
 	vaultPath   string
 	tasksFolder string
 	filePattern string
+	dailyNotes  *DailyNotesConfig
 	mu          sync.Mutex
 }
 
@@ -66,6 +67,11 @@ func ValidateVaultPath(vaultPath string) error {
 	_ = os.Remove(tmpFile)
 
 	return nil
+}
+
+// SetDailyNotes configures daily note integration for the adapter.
+func (a *ObsidianAdapter) SetDailyNotes(config *DailyNotesConfig) {
+	a.dailyNotes = config
 }
 
 // taskDir returns the absolute path to the directory containing task files.
@@ -198,6 +204,24 @@ func (a *ObsidianAdapter) loadTasksLocked() ([]*Task, error) {
 		tasks = append(tasks, fileTasks...)
 	}
 
+	// Include tasks from today's daily note when enabled
+	if a.dailyNotes != nil && a.dailyNotes.Enabled {
+		dailyTasks, err := a.loadDailyNoteTasks(now)
+		if err != nil {
+			return nil, fmt.Errorf("obsidian daily notes: %w", err)
+		}
+		// Deduplicate: skip daily note tasks whose IDs already appear in vault tasks
+		seen := make(map[string]bool, len(tasks))
+		for _, t := range tasks {
+			seen[t.ID] = true
+		}
+		for _, dt := range dailyTasks {
+			if !seen[dt.ID] {
+				tasks = append(tasks, dt)
+			}
+		}
+	}
+
 	return tasks, nil
 }
 
@@ -295,7 +319,11 @@ func (a *ObsidianAdapter) SaveTask(task *Task) error {
 		}
 	}
 
-	// Task not found — append to first file, or create tasks.md
+	// Task not found — route to daily note if enabled, otherwise to tasks folder
+	if a.dailyNotes != nil && a.dailyNotes.Enabled {
+		return a.appendTaskToDailyNote(task, time.Now().UTC())
+	}
+
 	targetFile := filepath.Join(dir, "tasks.md")
 	if len(files) > 0 {
 		targetFile = files[0]

--- a/internal/tasks/obsidian_daily.go
+++ b/internal/tasks/obsidian_daily.go
@@ -1,0 +1,224 @@
+package tasks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DailyNotesConfig holds configuration for Obsidian daily note integration.
+type DailyNotesConfig struct {
+	// Enabled activates daily note reading/writing.
+	Enabled bool
+	// Folder is the daily notes folder relative to vault root (e.g. "Daily").
+	Folder string
+	// Heading is the Markdown heading under which tasks are appended (e.g. "## Tasks").
+	Heading string
+	// DateFormat is a Go time format for the daily note filename (default "2006-01-02.md").
+	DateFormat string
+}
+
+// defaultDailyNotesDateFormat is the Go time layout for YYYY-MM-DD.md.
+const defaultDailyNotesDateFormat = "2006-01-02.md"
+
+// defaultDailyNotesHeading is the default heading under which tasks are appended.
+const defaultDailyNotesHeading = "## Tasks"
+
+// sanitizeDailyNotePath validates and sanitizes a date-formatted path.
+// It allows subdirectory structures (e.g. "2026/03/15.md") but rejects
+// path traversal attempts (..) and null bytes.
+func sanitizeDailyNotePath(name string) (string, error) {
+	if strings.ContainsAny(name, "\x00") {
+		return "", fmt.Errorf("daily note path contains null byte")
+	}
+	// Clean the path to normalize separators
+	cleaned := filepath.Clean(name)
+	if cleaned == "." || cleaned == ".." {
+		return "", fmt.Errorf("daily note path %q is invalid", name)
+	}
+	// Reject path traversal: no component should be ".."
+	for _, part := range strings.Split(cleaned, string(filepath.Separator)) {
+		if part == ".." {
+			return "", fmt.Errorf("daily note path %q contains path traversal", name)
+		}
+	}
+	// Reject absolute paths
+	if filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("daily note path %q is absolute", name)
+	}
+	return cleaned, nil
+}
+
+// dailyNotePath computes the absolute path to a daily note for the given date.
+func (a *ObsidianAdapter) dailyNotePath(date time.Time) (string, error) {
+	if a.dailyNotes == nil || !a.dailyNotes.Enabled {
+		return "", fmt.Errorf("daily notes not enabled")
+	}
+
+	dateFormat := a.dailyNotes.DateFormat
+	if dateFormat == "" {
+		dateFormat = defaultDailyNotesDateFormat
+	}
+
+	filename := date.Format(dateFormat)
+	sanitized, err := sanitizeDailyNotePath(filename)
+	if err != nil {
+		return "", fmt.Errorf("daily note path: %w", err)
+	}
+
+	folder := a.dailyNotes.Folder
+	if folder == "" {
+		return filepath.Join(a.vaultPath, sanitized), nil
+	}
+
+	return filepath.Join(a.vaultPath, folder, sanitized), nil
+}
+
+// loadDailyNoteTasks reads tasks from the daily note for the given date.
+// Returns an empty slice (not an error) if the daily note file does not exist.
+func (a *ObsidianAdapter) loadDailyNoteTasks(date time.Time) ([]*Task, error) {
+	path, err := a.dailyNotePath(date)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []*Task{}, nil
+		}
+		return nil, fmt.Errorf("read daily note %q: %w", filepath.Base(path), err)
+	}
+
+	now := time.Now().UTC()
+	lines := strings.Split(string(data), "\n")
+	var tasks []*Task
+
+	for _, line := range lines {
+		text, status, embeddedID, isCheckbox := parseCheckboxLineObsidian(line)
+		if !isCheckbox {
+			continue
+		}
+
+		cleaned, tags, _, effort := extractMetadata(text)
+		if cleaned == "" {
+			continue
+		}
+
+		id := embeddedID
+		if id == "" {
+			id = uuid.New().String()
+		}
+
+		task := &Task{
+			ID:        id,
+			Text:      cleaned,
+			Status:    status,
+			Effort:    effort,
+			Notes:     []TaskNote{},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+
+		if len(tags) > 0 {
+			task.Context = strings.Join(tags, ", ")
+		}
+
+		if status == StatusComplete {
+			task.CompletedAt = &now
+		}
+
+		tasks = append(tasks, task)
+	}
+
+	return tasks, nil
+}
+
+// appendTaskToDailyNote appends a task under the configured heading in today's daily note.
+// Creates the file and heading if they don't exist.
+func (a *ObsidianAdapter) appendTaskToDailyNote(task *Task, date time.Time) error {
+	path, err := a.dailyNotePath(date)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create daily notes dir: %w", err)
+	}
+
+	heading := a.dailyNotes.Heading
+	if heading == "" {
+		heading = defaultDailyNotesHeading
+	}
+
+	taskLine := taskToObsidianLine(task)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read daily note %q: %w", filepath.Base(path), err)
+		}
+		// File doesn't exist — create with heading and task
+		content := heading + "\n\n" + taskLine + "\n"
+		return atomicWriteFile(path, content)
+	}
+
+	content := string(data)
+	lines := strings.Split(content, "\n")
+
+	// Find the heading line
+	headingIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == strings.TrimSpace(heading) {
+			headingIdx = i
+			break
+		}
+	}
+
+	if headingIdx == -1 {
+		// Heading not found — append heading + task at end
+		if content != "" && !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += "\n" + heading + "\n\n" + taskLine + "\n"
+		return atomicWriteFile(path, content)
+	}
+
+	// Insert task after the heading section: find the right insertion point.
+	// Skip blank lines after heading, then insert after the last checkbox line
+	// in this section (or right after the heading if no checkboxes yet).
+	insertIdx := headingIdx + 1
+
+	// Skip blank lines after heading
+	for insertIdx < len(lines) && strings.TrimSpace(lines[insertIdx]) == "" {
+		insertIdx++
+	}
+
+	// Find the end of checkbox block under this heading
+	for insertIdx < len(lines) {
+		trimmed := strings.TrimSpace(lines[insertIdx])
+		// Stop at next heading or non-checkbox, non-blank content
+		if strings.HasPrefix(trimmed, "#") {
+			break
+		}
+		_, _, _, isCheckbox := parseCheckboxLineObsidian(lines[insertIdx])
+		if !isCheckbox && trimmed != "" {
+			break
+		}
+		insertIdx++
+	}
+
+	// Insert the task line
+	newLines := make([]string, 0, len(lines)+1)
+	newLines = append(newLines, lines[:insertIdx]...)
+	newLines = append(newLines, taskLine)
+	newLines = append(newLines, lines[insertIdx:]...)
+
+	return atomicWriteFile(path, strings.Join(newLines, "\n"))
+}

--- a/internal/tasks/obsidian_daily_test.go
+++ b/internal/tasks/obsidian_daily_test.go
@@ -1,0 +1,579 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDailyNotePath(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		folder     string
+		dateFormat string
+		wantSuffix string
+	}{
+		{"default format", "", "", filepath.Join("2026-03-15.md")},
+		{"custom folder", "Daily", "", filepath.Join("Daily", "2026-03-15.md")},
+		{"custom format", "", "01-02-2006.md", "03-15-2026.md"},
+		{"folder and format", "Notes/Daily", "2006-01-02.md", filepath.Join("Notes/Daily", "2026-03-15.md")},
+		{"year-month subfolder format", "Daily", "2006/01/02.md", filepath.Join("Daily", "2026/03/15.md")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			adapter := NewObsidianAdapter(dir, "", "")
+			adapter.SetDailyNotes(&DailyNotesConfig{
+				Enabled:    true,
+				Folder:     tt.folder,
+				DateFormat: tt.dateFormat,
+			})
+
+			got, err := adapter.dailyNotePath(date)
+			if err != nil {
+				t.Fatalf("dailyNotePath() error: %v", err)
+			}
+			if !strings.HasSuffix(got, tt.wantSuffix) {
+				t.Errorf("dailyNotePath() = %q, want suffix %q", got, tt.wantSuffix)
+			}
+			if !strings.HasPrefix(got, dir) {
+				t.Errorf("dailyNotePath() = %q, should start with vault path %q", got, dir)
+			}
+		})
+	}
+}
+
+func TestDailyNotePath_DisabledReturnsError(t *testing.T) {
+	t.Parallel()
+	adapter := NewObsidianAdapter(t.TempDir(), "", "")
+	_, err := adapter.dailyNotePath(time.Now().UTC())
+	if err == nil {
+		t.Error("expected error when daily notes not enabled")
+	}
+}
+
+func TestLoadDailyNoteTasks_MissingFileReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+	})
+
+	tasks, err := adapter.loadDailyNoteTasks(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("loadDailyNoteTasks() error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("got %d tasks, want 0 for missing daily note", len(tasks))
+	}
+}
+
+func TestLoadDailyNoteTasks_ParsesTasks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	content := `# 2026-03-15
+
+## Tasks
+
+- [ ] Morning standup <!-- td:dn-1 -->
+- [x] Code review <!-- td:dn-2 -->
+- [/] Write docs <!-- td:dn-3 -->
+
+## Notes
+
+Some notes here.
+`
+	if err := os.WriteFile(filepath.Join(dir, "2026-03-15.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+	})
+
+	tasks, err := adapter.loadDailyNoteTasks(date)
+	if err != nil {
+		t.Fatalf("loadDailyNoteTasks() error: %v", err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("got %d tasks, want 3", len(tasks))
+	}
+
+	wantStatuses := []TaskStatus{StatusTodo, StatusComplete, StatusInProgress}
+	wantIDs := []string{"dn-1", "dn-2", "dn-3"}
+	for i, task := range tasks {
+		if task.Status != wantStatuses[i] {
+			t.Errorf("task %d status = %q, want %q", i, task.Status, wantStatuses[i])
+		}
+		if task.ID != wantIDs[i] {
+			t.Errorf("task %d ID = %q, want %q", i, task.ID, wantIDs[i])
+		}
+	}
+}
+
+func TestLoadDailyNoteTasks_WithFolder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dailyDir := filepath.Join(dir, "Daily")
+	if err := os.MkdirAll(dailyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	date := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	content := "- [ ] Daily task <!-- td:df-1 -->\n"
+	if err := os.WriteFile(filepath.Join(dailyDir, "2026-01-05.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Folder:  "Daily",
+	})
+
+	tasks, err := adapter.loadDailyNoteTasks(date)
+	if err != nil {
+		t.Fatalf("loadDailyNoteTasks() error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(tasks))
+	}
+	if tasks[0].ID != "df-1" {
+		t.Errorf("task ID = %q, want %q", tasks[0].ID, "df-1")
+	}
+}
+
+func TestAppendTaskToDailyNote_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	task := NewTask("New daily task")
+	if err := adapter.appendTaskToDailyNote(task, date); err != nil {
+		t.Fatalf("appendTaskToDailyNote() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "2026-03-15.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(data)
+	if !strings.Contains(got, "## Tasks") {
+		t.Error("file should contain heading")
+	}
+	if !strings.Contains(got, "New daily task") {
+		t.Error("file should contain task text")
+	}
+	if !strings.Contains(got, "<!-- td:") {
+		t.Error("file should contain embedded task ID")
+	}
+}
+
+func TestAppendTaskToDailyNote_AppendsUnderHeading(t *testing.T) {
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	existing := `# 2026-03-15
+
+## Tasks
+
+- [ ] Existing task <!-- td:ex-1 -->
+
+## Notes
+
+Some notes.
+`
+	if err := os.WriteFile(filepath.Join(dir, "2026-03-15.md"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	task := NewTask("Appended task")
+	if err := adapter.appendTaskToDailyNote(task, date); err != nil {
+		t.Fatalf("appendTaskToDailyNote() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "2026-03-15.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+
+	// Should contain both tasks
+	if !strings.Contains(got, "Existing task") {
+		t.Error("should preserve existing task")
+	}
+	if !strings.Contains(got, "Appended task") {
+		t.Error("should contain appended task")
+	}
+
+	// Notes section should still be present
+	if !strings.Contains(got, "## Notes") {
+		t.Error("should preserve other sections")
+	}
+	if !strings.Contains(got, "Some notes.") {
+		t.Error("should preserve notes content")
+	}
+
+	// Appended task should appear before ## Notes
+	taskIdx := strings.Index(got, "Appended task")
+	notesIdx := strings.Index(got, "## Notes")
+	if taskIdx > notesIdx {
+		t.Error("appended task should appear before ## Notes section")
+	}
+}
+
+func TestAppendTaskToDailyNote_NoHeadingInFile(t *testing.T) {
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	existing := "# 2026-03-15\n\nSome notes here.\n"
+	if err := os.WriteFile(filepath.Join(dir, "2026-03-15.md"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	task := NewTask("New task")
+	if err := adapter.appendTaskToDailyNote(task, date); err != nil {
+		t.Fatalf("appendTaskToDailyNote() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "2026-03-15.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, "## Tasks") {
+		t.Error("should add heading when not present")
+	}
+	if !strings.Contains(got, "New task") {
+		t.Error("should add task")
+	}
+	if !strings.Contains(got, "Some notes here.") {
+		t.Error("should preserve existing content")
+	}
+}
+
+func TestAppendTaskToDailyNote_CreatesDirAndFile(t *testing.T) {
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Folder:  "Daily",
+	})
+
+	task := NewTask("Task in new dir")
+	if err := adapter.appendTaskToDailyNote(task, date); err != nil {
+		t.Fatalf("appendTaskToDailyNote() error: %v", err)
+	}
+
+	path := filepath.Join(dir, "Daily", "2026-03-15.md")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("daily note file should be created")
+	}
+}
+
+func TestLoadTasks_IncludesDailyNotes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create regular tasks file
+	tasksContent := "- [ ] Vault task <!-- td:vt-1 -->\n"
+	if err := os.WriteFile(filepath.Join(dir, "tasks.md"), []byte(tasksContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create today's daily note
+	today := time.Now().UTC()
+	dailyFilename := today.Format("2006-01-02.md")
+	dailyContent := "- [ ] Daily task <!-- td:dt-1 -->\n"
+	if err := os.WriteFile(filepath.Join(dir, dailyFilename), []byte(dailyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+	})
+
+	tasks, err := adapter.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() error: %v", err)
+	}
+
+	foundVault := false
+	foundDaily := false
+	for _, task := range tasks {
+		if task.ID == "vt-1" {
+			foundVault = true
+		}
+		if task.ID == "dt-1" {
+			foundDaily = true
+		}
+	}
+
+	if !foundVault {
+		t.Error("should include vault tasks")
+	}
+	if !foundDaily {
+		t.Error("should include daily note tasks")
+	}
+}
+
+func TestLoadTasks_DeduplicatesDailyNotes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Same task ID in both vault and daily note (daily note is in vault dir)
+	today := time.Now().UTC()
+	dailyFilename := today.Format("2006-01-02.md")
+	content := "- [ ] Duplicate task <!-- td:dup-1 -->\n"
+	if err := os.WriteFile(filepath.Join(dir, dailyFilename), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+	})
+
+	tasks, err := adapter.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() error: %v", err)
+	}
+
+	// When daily note is in the same folder as vault, the task appears in vault load.
+	// Dedup should ensure it only appears once.
+	count := 0
+	for _, task := range tasks {
+		if task.ID == "dup-1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("duplicate task appeared %d times, want 1", count)
+	}
+}
+
+func TestSaveTask_RoutesToDailyNote(t *testing.T) {
+	dir := t.TempDir()
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	task := NewTask("Quick add task")
+	if err := adapter.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask() error: %v", err)
+	}
+
+	// Task should be in today's daily note, not tasks.md
+	today := time.Now().UTC()
+	dailyFilename := today.Format("2006-01-02.md")
+	data, err := os.ReadFile(filepath.Join(dir, dailyFilename))
+	if err != nil {
+		t.Fatalf("daily note should exist: %v", err)
+	}
+	if !strings.Contains(string(data), "Quick add task") {
+		t.Error("task should be in daily note")
+	}
+
+	// tasks.md should not exist
+	if _, err := os.Stat(filepath.Join(dir, "tasks.md")); !os.IsNotExist(err) {
+		t.Error("tasks.md should not be created when daily notes enabled")
+	}
+}
+
+func TestSanitizeDailyNotePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"normal date", "2026-03-15.md", "2026-03-15.md", false},
+		{"with spaces", "2026 03 15.md", "2026 03 15.md", false},
+		{"null byte", "2026\x00-03-15.md", "", true},
+		{"path traversal dots", "../evil.md", "", true},
+		{"subdirectory allowed", "2026/03/15.md", "2026/03/15.md", false},
+		{"just dot", ".", "", true},
+		{"double dot", "..", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := sanitizeDailyNotePath(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sanitizeDailyNotePath(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("sanitizeDailyNotePath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// AC-Q6: Input sanitization tests for special characters in date formats and heading names.
+func TestDailyNotes_InputSanitization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		heading    string
+		dateFormat string
+		taskText   string
+	}{
+		{
+			name:       "unicode heading",
+			heading:    "## 任务列表",
+			dateFormat: "2006-01-02.md",
+			taskText:   "Normal task",
+		},
+		{
+			name:       "heading with special chars",
+			heading:    "## Tasks & Notes (Daily)",
+			dateFormat: "2006-01-02.md",
+			taskText:   "Task with 'quotes' & \"doubles\"",
+		},
+		{
+			name:       "emoji heading",
+			heading:    "## 📋 Tasks",
+			dateFormat: "2006-01-02.md",
+			taskText:   "🚀 Launch prep",
+		},
+		{
+			name:       "heading with angle brackets",
+			heading:    "## Tasks <important>",
+			dateFormat: "2006-01-02.md",
+			taskText:   "Task with <html> entities",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+			adapter := NewObsidianAdapter(dir, "", "")
+			adapter.SetDailyNotes(&DailyNotesConfig{
+				Enabled:    true,
+				Heading:    tt.heading,
+				DateFormat: tt.dateFormat,
+			})
+
+			task := NewTask(tt.taskText)
+			if err := adapter.appendTaskToDailyNote(task, date); err != nil {
+				t.Fatalf("appendTaskToDailyNote() error: %v", err)
+			}
+
+			// Verify round-trip: load tasks back
+			tasks, err := adapter.loadDailyNoteTasks(date)
+			if err != nil {
+				t.Fatalf("loadDailyNoteTasks() error: %v", err)
+			}
+			if len(tasks) == 0 {
+				t.Fatal("expected at least one task after round-trip")
+			}
+			if tasks[0].ID != task.ID {
+				t.Errorf("ID mismatch: got %q, want %q", tasks[0].ID, task.ID)
+			}
+		})
+	}
+}
+
+func TestDailyNotes_DateFormatSanitization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dateFormat string
+		wantErr    bool
+	}{
+		{"standard YYYY-MM-DD", "2006-01-02.md", false},
+		{"US format MM-DD-YYYY", "01-02-2006.md", false},
+		{"dot separator", "2006.01.02.md", false},
+		{"underscore separator", "2006_01_02.md", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+			adapter := NewObsidianAdapter(dir, "", "")
+			adapter.SetDailyNotes(&DailyNotesConfig{
+				Enabled:    true,
+				DateFormat: tt.dateFormat,
+			})
+
+			_, err := adapter.dailyNotePath(date)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("dailyNotePath() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAppendTaskToDailyNote_DefaultHeading(t *testing.T) {
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		// Heading left empty — should use default
+	})
+
+	task := NewTask("Default heading task")
+	if err := adapter.appendTaskToDailyNote(task, date); err != nil {
+		t.Fatalf("appendTaskToDailyNote() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "2026-03-15.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(data), defaultDailyNotesHeading) {
+		t.Errorf("should use default heading %q", defaultDailyNotesHeading)
+	}
+}

--- a/internal/tasks/provider_config.go
+++ b/internal/tasks/provider_config.go
@@ -154,6 +154,10 @@ func GenerateSampleConfig(path string, reg *Registry) error {
 			fmt.Fprintf(&b, "#       vault_path: /path/to/your/vault\n")
 			fmt.Fprintf(&b, "#       tasks_folder: tasks  # Optional: subfolder within vault\n")
 			fmt.Fprintf(&b, "#       file_pattern: \"*.md\"  # Optional: glob pattern for task files\n")
+			fmt.Fprintf(&b, "#       daily_notes: true  # Optional: enable daily note integration\n")
+			fmt.Fprintf(&b, "#       daily_notes_folder: Daily  # Optional: daily notes folder\n")
+			fmt.Fprintf(&b, "#       daily_notes_heading: \"## Tasks\"  # Optional: heading for tasks\n")
+			fmt.Fprintf(&b, "#       daily_notes_format: \"2006-01-02.md\"  # Optional: Go date format\n")
 		default:
 			fmt.Fprintf(&b, "#       # Add provider-specific settings here\n")
 		}


### PR DESCRIPTION
## Summary

- Adds daily note integration to the Obsidian adapter, completing Epic 8 (Obsidian Integration)
- Tasks can be read from today's daily note and quick-add tasks are appended under a configurable heading
- Supports configurable date format, daily notes folder, and heading with path sanitization (AC-Q6)

### New files
- `internal/tasks/obsidian_daily.go` — Core daily note logic: path resolution, load, append, sanitization
- `internal/tasks/obsidian_daily_test.go` — 20 table-driven tests including AC-Q6 input sanitization

### Modified files
- `internal/tasks/obsidian_adapter.go` — Added `dailyNotes` field, `SetDailyNotes()`, integrated into `LoadTasks` (with dedup) and `SaveTask` (routes new tasks to daily note)
- `internal/tasks/adapters.go` — Extracts `daily_notes`, `daily_notes_folder`, `daily_notes_heading`, `daily_notes_format` from config
- `internal/tasks/provider_config.go` — Added daily note settings to sample config

### Config settings
```yaml
providers:
  - name: obsidian
    settings:
      vault_path: ~/Documents/ObsidianVault
      daily_notes: true
      daily_notes_folder: Daily
      daily_notes_heading: "## Tasks"
      daily_notes_format: "2006-01-02.md"
```

### Acceptance Criteria
- [x] Daily notes enabled in config → reads tasks from today's daily note
- [x] Quick-add tasks appended under configurable heading
- [x] Supports common date formats (YYYY-MM-DD.md, etc.)
- [x] Missing daily note handled gracefully (returns empty, no error)
- [x] AC-Q6: Path sanitization with special characters in date formats and heading names

### Quality Gate
- [x] gofumpt formatted
- [x] golangci-lint: 0 issues
- [x] All tests pass (including contract tests)
- [x] Rebased on main

## Test plan
- [ ] Verify daily note tasks load alongside vault tasks
- [ ] Verify deduplication when daily note is in vault folder
- [ ] Verify new tasks route to daily note when enabled
- [ ] Verify missing daily note returns empty (no error)
- [ ] Verify path traversal attempts are rejected
- [ ] Verify special characters in headings work correctly

Closes Story 8.4. Completes Epic 8 (Obsidian Integration).
Builds on PR #75 (Stories 8.2 & 8.3).