### PR TITLE
feat: Story 8.4 - Obsidian Daily Note Integration enhancements

### DIFF
--- a/internal/tasks/obsidian_daily.go
+++ b/internal/tasks/obsidian_daily.go
@@ -53,6 +53,14 @@ func sanitizeDailyNotePath(name string) (string, error) {
 	return cleaned, nil
 }
 
+// buildDailyNotePath joins a sanitized relative path with the vault and optional folder.
+func (a *ObsidianAdapter) buildDailyNotePath(sanitized string) string {
+	if a.dailyNotes.Folder == "" {
+		return filepath.Join(a.vaultPath, sanitized)
+	}
+	return filepath.Join(a.vaultPath, a.dailyNotes.Folder, sanitized)
+}
+
 // dailyNotePath computes the absolute path to a daily note for the given date.
 func (a *ObsidianAdapter) dailyNotePath(date time.Time) (string, error) {
 	if a.dailyNotes == nil || !a.dailyNotes.Enabled {
@@ -70,18 +78,60 @@ func (a *ObsidianAdapter) dailyNotePath(date time.Time) (string, error) {
 		return "", fmt.Errorf("daily note path: %w", err)
 	}
 
-	folder := a.dailyNotes.Folder
-	if folder == "" {
-		return filepath.Join(a.vaultPath, sanitized), nil
-	}
+	return a.buildDailyNotePath(sanitized), nil
+}
 
-	return filepath.Join(a.vaultPath, folder, sanitized), nil
+// findHeadingIndex returns the index of the first line matching the heading, or -1.
+func findHeadingIndex(lines []string, heading string) int {
+	trimmedHeading := strings.TrimSpace(heading)
+	for i, line := range lines {
+		if strings.TrimSpace(line) == trimmedHeading {
+			return i
+		}
+	}
+	return -1
+}
+
+// commonDateFormats lists common date formats to try when auto-detecting daily notes.
+// The first match wins. These use Go's reference time: Mon Jan 2 15:04:05 MST 2006.
+var commonDateFormats = []string{
+	"2006-01-02.md",  // YYYY-MM-DD.md (ISO 8601, Obsidian default)
+	"01-02-2006.md",  // MM-DD-YYYY.md (US format)
+	"02-01-2006.md",  // DD-MM-YYYY.md (European format)
+	"2006.01.02.md",  // YYYY.MM.DD.md (dot separator)
+	"2006_01_02.md",  // YYYY_MM_DD.md (underscore separator)
+	"20060102.md",    // YYYYMMDD.md (compact)
+	"2006/01/02.md",  // YYYY/MM/DD.md (subdirectory structure)
+	"2006/01-02.md",  // YYYY/MM-DD.md (year subfolder)
+	"Jan 2, 2006.md", // Month Day, Year.md (long format)
+	"2 Jan 2006.md",  // Day Month Year.md (UK long format)
+}
+
+// ValidateDateFormat checks whether a date format string produces a valid filename.
+// Returns an error if the format is empty, contains path traversal, or produces
+// a filename with null bytes.
+func ValidateDateFormat(format string) error {
+	if format == "" {
+		return fmt.Errorf("date format is empty")
+	}
+	// Test with a reference date to see if the format produces a sane filename
+	testDate := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	filename := testDate.Format(format)
+	_, err := sanitizeDailyNotePath(filename)
+	if err != nil {
+		return fmt.Errorf("date format %q produces invalid path: %w", format, err)
+	}
+	if !strings.HasSuffix(filename, ".md") {
+		return fmt.Errorf("date format %q does not end with .md", format)
+	}
+	return nil
 }
 
 // loadDailyNoteTasks reads tasks from the daily note for the given date.
+// Only tasks under the configured heading section are returned.
 // Returns an empty slice (not an error) if the daily note file does not exist.
 func (a *ObsidianAdapter) loadDailyNoteTasks(date time.Time) ([]*Task, error) {
-	path, err := a.dailyNotePath(date)
+	path, err := a.resolveDailyNotePath(date)
 	if err != nil {
 		return nil, err
 	}
@@ -94,11 +144,43 @@ func (a *ObsidianAdapter) loadDailyNoteTasks(date time.Time) ([]*Task, error) {
 		return nil, fmt.Errorf("read daily note %q: %w", filepath.Base(path), err)
 	}
 
+	heading := a.dailyNotes.Heading
+	if heading == "" {
+		heading = defaultDailyNotesHeading
+	}
+
 	now := time.Now().UTC()
 	lines := strings.Split(string(data), "\n")
-	var tasks []*Task
+	tasks := a.parseTasksUnderHeading(lines, heading, now)
 
-	for _, line := range lines {
+	return tasks, nil
+}
+
+// parseTasksUnderHeading extracts checkbox tasks from lines that fall under
+// the specified heading section. If no heading is found, returns an empty slice.
+func (a *ObsidianAdapter) parseTasksUnderHeading(lines []string, heading string, now time.Time) []*Task {
+	headingIdx := findHeadingIndex(lines, heading)
+	if headingIdx == -1 {
+		// No heading found — no tasks to extract
+		return nil
+	}
+
+	// Determine heading level to know when the section ends
+	headingLevel := headingMarkdownLevel(heading)
+
+	var tasks []*Task
+	for i := headingIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		// Stop at next heading of same or higher level
+		if strings.HasPrefix(trimmed, "#") {
+			level := headingMarkdownLevel(trimmed)
+			if level > 0 && level <= headingLevel {
+				break
+			}
+		}
+
 		text, status, embeddedID, isCheckbox := parseCheckboxLineObsidian(line)
 		if !isCheckbox {
 			continue
@@ -135,7 +217,80 @@ func (a *ObsidianAdapter) loadDailyNoteTasks(date time.Time) ([]*Task, error) {
 		tasks = append(tasks, task)
 	}
 
-	return tasks, nil
+	return tasks
+}
+
+// headingMarkdownLevel returns the heading level (1-6) for a markdown heading,
+// or 0 if the line is not a heading.
+func headingMarkdownLevel(line string) int {
+	trimmed := strings.TrimSpace(line)
+	level := 0
+	for _, ch := range trimmed {
+		if ch == '#' {
+			level++
+		} else {
+			break
+		}
+	}
+	if level > 0 && level <= 6 && len(trimmed) > level && trimmed[level] == ' ' {
+		return level
+	}
+	return 0
+}
+
+// resolveDailyNotePath finds the daily note file for the given date.
+// It first tries the configured format, then falls back to common date formats.
+// Returns the path from dailyNotePath() if no auto-detection is needed.
+func (a *ObsidianAdapter) resolveDailyNotePath(date time.Time) (string, error) {
+	// Try the configured (or default) format first
+	path, err := a.dailyNotePath(date)
+	if err != nil {
+		return "", err
+	}
+
+	if _, statErr := os.Stat(path); statErr == nil {
+		return path, nil
+	}
+
+	// File not found with configured format — try common formats
+	for _, format := range commonDateFormats {
+		filename := date.Format(format)
+		sanitized, sanitizeErr := sanitizeDailyNotePath(filename)
+		if sanitizeErr != nil {
+			continue
+		}
+
+		candidate := a.buildDailyNotePath(sanitized)
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return candidate, nil
+		}
+	}
+
+	// No file found with any format — return the configured path
+	// so callers get the expected "not found" behavior
+	return path, nil
+}
+
+// QuickAddToDailyNote creates a new task from text and appends it to today's daily note
+// under the configured heading. Returns the created task.
+func (a *ObsidianAdapter) QuickAddToDailyNote(text string) (*Task, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.dailyNotes == nil || !a.dailyNotes.Enabled {
+		return nil, fmt.Errorf("daily notes not enabled")
+	}
+
+	if strings.TrimSpace(text) == "" {
+		return nil, fmt.Errorf("task text is empty")
+	}
+
+	task := NewTask(text)
+	if err := a.appendTaskToDailyNote(task, time.Now().UTC()); err != nil {
+		return nil, fmt.Errorf("quick add to daily note: %w", err)
+	}
+
+	return task, nil
 }
 
 // appendTaskToDailyNote appends a task under the configured heading in today's daily note.
@@ -172,14 +327,7 @@ func (a *ObsidianAdapter) appendTaskToDailyNote(task *Task, date time.Time) erro
 	content := string(data)
 	lines := strings.Split(content, "\n")
 
-	// Find the heading line
-	headingIdx := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == strings.TrimSpace(heading) {
-			headingIdx = i
-			break
-		}
-	}
+	headingIdx := findHeadingIndex(lines, heading)
 
 	if headingIdx == -1 {
 		// Heading not found — append heading + task at end

--- a/internal/tasks/obsidian_daily_test.go
+++ b/internal/tasks/obsidian_daily_test.go
@@ -124,6 +124,122 @@ Some notes here.
 	}
 }
 
+func TestLoadDailyNoteTasks_HeadingScopedReading(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	content := `# 2026-03-15
+
+## Meetings
+
+- [ ] Meeting task outside heading <!-- td:mt-1 -->
+
+## Tasks
+
+- [ ] Under heading task <!-- td:ht-1 -->
+- [x] Another heading task <!-- td:ht-2 -->
+
+## Notes
+
+- [ ] Stray checkbox in notes <!-- td:nt-1 -->
+`
+	if err := os.WriteFile(filepath.Join(dir, "2026-03-15.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	tasks, err := adapter.loadDailyNoteTasks(date)
+	if err != nil {
+		t.Fatalf("loadDailyNoteTasks() error: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2 (only under ## Tasks)", len(tasks))
+	}
+	if tasks[0].ID != "ht-1" {
+		t.Errorf("task 0 ID = %q, want %q", tasks[0].ID, "ht-1")
+	}
+	if tasks[1].ID != "ht-2" {
+		t.Errorf("task 1 ID = %q, want %q", tasks[1].ID, "ht-2")
+	}
+}
+
+func TestLoadDailyNoteTasks_NoHeadingReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	content := `# 2026-03-15
+
+- [ ] Task with no heading section <!-- td:nh-1 -->
+`
+	if err := os.WriteFile(filepath.Join(dir, "2026-03-15.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	tasks, err := adapter.loadDailyNoteTasks(date)
+	if err != nil {
+		t.Fatalf("loadDailyNoteTasks() error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("got %d tasks, want 0 when heading not present", len(tasks))
+	}
+}
+
+func TestLoadDailyNoteTasks_SubheadingIncluded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	// ### subheading (level 3) under ## Tasks (level 2) should be included
+	content := `## Tasks
+
+- [ ] Top level task <!-- td:tl-1 -->
+
+### Subtasks
+
+- [ ] Subtask under heading <!-- td:st-1 -->
+
+## Notes
+
+- [ ] Not included <!-- td:ni-1 -->
+`
+	if err := os.WriteFile(filepath.Join(dir, "2026-03-15.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	tasks, err := adapter.loadDailyNoteTasks(date)
+	if err != nil {
+		t.Fatalf("loadDailyNoteTasks() error: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2 (includes subheading tasks)", len(tasks))
+	}
+	if tasks[0].ID != "tl-1" {
+		t.Errorf("task 0 ID = %q, want %q", tasks[0].ID, "tl-1")
+	}
+	if tasks[1].ID != "st-1" {
+		t.Errorf("task 1 ID = %q, want %q", tasks[1].ID, "st-1")
+	}
+}
+
 func TestLoadDailyNoteTasks_WithFolder(t *testing.T) {
 	t.Parallel()
 
@@ -134,7 +250,7 @@ func TestLoadDailyNoteTasks_WithFolder(t *testing.T) {
 	}
 
 	date := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
-	content := "- [ ] Daily task <!-- td:df-1 -->\n"
+	content := "## Tasks\n\n- [ ] Daily task <!-- td:df-1 -->\n"
 	if err := os.WriteFile(filepath.Join(dailyDir, "2026-01-05.md"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -315,10 +431,10 @@ func TestLoadTasks_IncludesDailyNotes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create today's daily note
+	// Create today's daily note with heading
 	today := time.Now().UTC()
 	dailyFilename := today.Format("2006-01-02.md")
-	dailyContent := "- [ ] Daily task <!-- td:dt-1 -->\n"
+	dailyContent := "## Tasks\n\n- [ ] Daily task <!-- td:dt-1 -->\n"
 	if err := os.WriteFile(filepath.Join(dir, dailyFilename), []byte(dailyContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +474,7 @@ func TestLoadTasks_DeduplicatesDailyNotes(t *testing.T) {
 	// Same task ID in both vault and daily note (daily note is in vault dir)
 	today := time.Now().UTC()
 	dailyFilename := today.Format("2006-01-02.md")
-	content := "- [ ] Duplicate task <!-- td:dup-1 -->\n"
+	content := "## Tasks\n\n- [ ] Duplicate task <!-- td:dup-1 -->\n"
 	if err := os.WriteFile(filepath.Join(dir, dailyFilename), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -575,5 +691,333 @@ func TestAppendTaskToDailyNote_DefaultHeading(t *testing.T) {
 
 	if !strings.Contains(string(data), defaultDailyNotesHeading) {
 		t.Errorf("should use default heading %q", defaultDailyNotesHeading)
+	}
+}
+
+// Story 8.4: Common date format auto-detection tests
+
+func TestResolveDailyNotePath_AutoDetectsFormat(t *testing.T) {
+	t.Parallel()
+
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		configFormat   string
+		actualFilename string
+	}{
+		{"US format detected", "2006-01-02.md", "03-15-2026.md"},
+		{"dot separator detected", "2006-01-02.md", "2026.03.15.md"},
+		{"underscore detected", "2006-01-02.md", "2026_03_15.md"},
+		{"compact detected", "2006-01-02.md", "20260315.md"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+
+			// Create file with non-configured format
+			content := "## Tasks\n\n- [ ] Auto-detected task <!-- td:ad-1 -->\n"
+			if err := os.WriteFile(filepath.Join(dir, tt.actualFilename), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			adapter := NewObsidianAdapter(dir, "", "")
+			adapter.SetDailyNotes(&DailyNotesConfig{
+				Enabled:    true,
+				DateFormat: tt.configFormat,
+			})
+
+			path, err := adapter.resolveDailyNotePath(date)
+			if err != nil {
+				t.Fatalf("resolveDailyNotePath() error: %v", err)
+			}
+
+			if filepath.Base(path) != tt.actualFilename {
+				t.Errorf("resolved to %q, want filename %q", filepath.Base(path), tt.actualFilename)
+			}
+		})
+	}
+}
+
+func TestResolveDailyNotePath_PrefersConfiguredFormat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	// Create files in both configured and auto-detected formats
+	content := "## Tasks\n\n- [ ] Task <!-- td:t-1 -->\n"
+	if err := os.WriteFile(filepath.Join(dir, "03-15-2026.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "2026-03-15.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled:    true,
+		DateFormat: "2006-01-02.md",
+	})
+
+	path, err := adapter.resolveDailyNotePath(date)
+	if err != nil {
+		t.Fatalf("resolveDailyNotePath() error: %v", err)
+	}
+
+	if filepath.Base(path) != "2026-03-15.md" {
+		t.Errorf("should prefer configured format, got %q", filepath.Base(path))
+	}
+}
+
+func TestResolveDailyNotePath_WithFolder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	// Create daily note in folder with non-default format
+	dailyDir := filepath.Join(dir, "Daily")
+	if err := os.MkdirAll(dailyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "## Tasks\n\n- [ ] Task <!-- td:t-1 -->\n"
+	if err := os.WriteFile(filepath.Join(dailyDir, "03-15-2026.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled:    true,
+		Folder:     "Daily",
+		DateFormat: "2006-01-02.md",
+	})
+
+	path, err := adapter.resolveDailyNotePath(date)
+	if err != nil {
+		t.Fatalf("resolveDailyNotePath() error: %v", err)
+	}
+
+	if filepath.Base(path) != "03-15-2026.md" {
+		t.Errorf("should auto-detect format in folder, got %q", filepath.Base(path))
+	}
+}
+
+func TestResolveDailyNotePath_NoFileReturnsConfiguredPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	date := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled:    true,
+		DateFormat: "2006-01-02.md",
+	})
+
+	path, err := adapter.resolveDailyNotePath(date)
+	if err != nil {
+		t.Fatalf("resolveDailyNotePath() error: %v", err)
+	}
+
+	if filepath.Base(path) != "2026-03-15.md" {
+		t.Errorf("should return configured format path, got %q", filepath.Base(path))
+	}
+}
+
+// Story 8.4: ValidateDateFormat tests
+
+func TestValidateDateFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		format  string
+		wantErr bool
+	}{
+		{"standard ISO", "2006-01-02.md", false},
+		{"US format", "01-02-2006.md", false},
+		{"dot separator", "2006.01.02.md", false},
+		{"underscore", "2006_01_02.md", false},
+		{"compact", "20060102.md", false},
+		{"subdirectory", "2006/01/02.md", false},
+		{"long month", "Jan 2, 2006.md", false},
+		{"empty string", "", true},
+		{"no .md extension", "2006-01-02", true},
+		{"no .md extension txt", "2006-01-02.txt", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDateFormat(tt.format)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDateFormat(%q) error = %v, wantErr %v", tt.format, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Story 8.4: QuickAddToDailyNote tests
+
+func TestQuickAddToDailyNote(t *testing.T) {
+	dir := t.TempDir()
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	task, err := adapter.QuickAddToDailyNote("Buy groceries")
+	if err != nil {
+		t.Fatalf("QuickAddToDailyNote() error: %v", err)
+	}
+
+	if task == nil {
+		t.Fatal("expected non-nil task")
+	}
+	if task.Text != "Buy groceries" {
+		t.Errorf("task text = %q, want %q", task.Text, "Buy groceries")
+	}
+	if task.ID == "" {
+		t.Error("task should have an ID")
+	}
+
+	// Verify it was written to today's daily note
+	today := time.Now().UTC()
+	dailyFilename := today.Format("2006-01-02.md")
+	data, err := os.ReadFile(filepath.Join(dir, dailyFilename))
+	if err != nil {
+		t.Fatalf("daily note should exist: %v", err)
+	}
+	if !strings.Contains(string(data), "Buy groceries") {
+		t.Error("daily note should contain task")
+	}
+	if !strings.Contains(string(data), "## Tasks") {
+		t.Error("daily note should contain heading")
+	}
+}
+
+func TestQuickAddToDailyNote_DisabledReturnsError(t *testing.T) {
+	t.Parallel()
+	adapter := NewObsidianAdapter(t.TempDir(), "", "")
+	_, err := adapter.QuickAddToDailyNote("some task")
+	if err == nil {
+		t.Error("expected error when daily notes not enabled")
+	}
+}
+
+func TestQuickAddToDailyNote_EmptyTextReturnsError(t *testing.T) {
+	adapter := NewObsidianAdapter(t.TempDir(), "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+	})
+
+	_, err := adapter.QuickAddToDailyNote("")
+	if err == nil {
+		t.Error("expected error for empty text")
+	}
+	_, err = adapter.QuickAddToDailyNote("   ")
+	if err == nil {
+		t.Error("expected error for whitespace-only text")
+	}
+}
+
+func TestQuickAddToDailyNote_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	adapter := NewObsidianAdapter(dir, "", "")
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+		Heading: "## Tasks",
+	})
+
+	// Quick-add three tasks
+	task1, err := adapter.QuickAddToDailyNote("First task")
+	if err != nil {
+		t.Fatalf("QuickAddToDailyNote() error: %v", err)
+	}
+	task2, err := adapter.QuickAddToDailyNote("Second task")
+	if err != nil {
+		t.Fatalf("QuickAddToDailyNote() error: %v", err)
+	}
+
+	// Load them back
+	tasks, err := adapter.loadDailyNoteTasks(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("loadDailyNoteTasks() error: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2", len(tasks))
+	}
+
+	if tasks[0].ID != task1.ID {
+		t.Errorf("task 0 ID = %q, want %q", tasks[0].ID, task1.ID)
+	}
+	if tasks[1].ID != task2.ID {
+		t.Errorf("task 1 ID = %q, want %q", tasks[1].ID, task2.ID)
+	}
+}
+
+// Story 8.4: headingMarkdownLevel tests
+
+func TestHeadingMarkdownLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		line  string
+		level int
+	}{
+		{"h1", "# Title", 1},
+		{"h2", "## Subtitle", 2},
+		{"h3", "### Sub-subtitle", 3},
+		{"h4", "#### Level 4", 4},
+		{"h5", "##### Level 5", 5},
+		{"h6", "###### Level 6", 6},
+		{"not heading no space", "#NoSpace", 0},
+		{"not heading empty", "", 0},
+		{"not heading text", "Just text", 0},
+		{"too many hashes", "####### Seven", 0},
+		{"hash only", "#", 0},
+		{"with leading whitespace", "  ## Tasks", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := headingMarkdownLevel(tt.line)
+			if got != tt.level {
+				t.Errorf("headingMarkdownLevel(%q) = %d, want %d", tt.line, got, tt.level)
+			}
+		})
+	}
+}
+
+// AC-Q6: Additional input sanitization for daily note paths and headings
+
+func TestDailyNotes_PathTraversalInDateFormat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	adapter := NewObsidianAdapter(dir, "", "")
+
+	// Attempt to use a date format that would produce path traversal
+	adapter.SetDailyNotes(&DailyNotesConfig{
+		Enabled: true,
+	})
+
+	// sanitizeDailyNotePath catches path traversal attempts
+	_, err := sanitizeDailyNotePath("../../../etc/passwd")
+	if err == nil {
+		t.Error("expected error for path traversal in daily note path")
+	}
+
+	_, err = sanitizeDailyNotePath("valid/2026-03-15.md")
+	if err != nil {
+		t.Errorf("should allow valid subdirectory path: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Enhances Story 8.4 (Obsidian Daily Note Integration) with missing acceptance criteria coverage:

- **Heading-scoped reading**: `loadDailyNoteTasks` now only parses tasks under the configured heading section (e.g. `## Tasks`), matching the write behavior of `appendTaskToDailyNote`. Tasks in other sections like `## Meetings` or `## Notes` are correctly excluded.
- **Common date format auto-detection**: When the configured date format doesn't find a daily note file, automatically tries 10 common formats (ISO 8601, US MM-DD-YYYY, EU DD-MM-YYYY, compact YYYYMMDD, dot/underscore separators, subdirectory structures, long month names).
- **`ValidateDateFormat()`**: New function to validate date format strings produce valid `.md` file paths.
- **`QuickAddToDailyNote()`**: New public API method for quick-adding tasks to today's daily note under the configured heading. Returns the created task with ID.
- **Code quality**: Extracted `buildDailyNotePath()` and `findHeadingIndex()` helpers to eliminate path-building and heading-search duplication (from /simplify review).

## Acceptance Criteria Coverage

| AC | Status |
|----|--------|
| Daily notes enabled in config → reads tasks from today's daily note | ✅ Enhanced: now heading-scoped |
| Quick-add tasks appended under configurable heading | ✅ New public `QuickAddToDailyNote()` API |
| Supports common date formats (YYYY-MM-DD.md, etc.) | ✅ Auto-detection of 10 formats |
| Missing daily note handled gracefully | ✅ Returns empty slice |
| AC-Q6: Input sanitization for paths and headings | ✅ Tests for special chars, unicode, emoji, path traversal |

## Quality Gate

- [x] `gofumpt` — formatted
- [x] `golangci-lint` — 0 issues
- [x] All tests pass
- [x] Race detector clean
- [x] `/simplify` review applied
- [x] Rebased on upstream/main

## Test plan

- [x] `TestLoadDailyNoteTasks_HeadingScopedReading` — only tasks under heading returned
- [x] `TestLoadDailyNoteTasks_NoHeadingReturnsEmpty` — no heading = no tasks
- [x] `TestLoadDailyNoteTasks_SubheadingIncluded` — sub-sections included
- [x] `TestResolveDailyNotePath_AutoDetectsFormat` — 4 format variants
- [x] `TestResolveDailyNotePath_PrefersConfiguredFormat` — configured wins
- [x] `TestValidateDateFormat` — 10 valid/invalid cases
- [x] `TestQuickAddToDailyNote` — basic flow
- [x] `TestQuickAddToDailyNote_RoundTrip` — write then read
- [x] `TestQuickAddToDailyNote_EmptyTextReturnsError` — validation
- [x] `TestHeadingMarkdownLevel` — 12 cases including edge cases
- [x] `TestDailyNotes_PathTraversalInDateFormat` — AC-Q6 sanitization