### PR TITLE
feat: Story 12.2 — Time-Contextual Door Selection

### DIFF
--- a/docs/stories/12.2.story.md
+++ b/docs/stories/12.2.story.md
@@ -1,0 +1,139 @@
+# Story 12.2: Time-Contextual Door Selection
+
+## Story
+
+As a user with calendar awareness,
+I want doors to suggest time-appropriate tasks,
+So that I'm not shown deep-work when I have a meeting in 15 minutes.
+
+## Status
+
+ready-for-dev
+
+## Prerequisites
+
+- Story 12.1 - Local Calendar Source Reader (provides CalendarReader interface, GetFreeBlocks, CalendarEvent, TimeBlock types)
+- Epic 4 - COMPLETE (intelligent door selection via DiversityScore in door_selector.go)
+
+## Acceptance Criteria
+
+### AC1: Door selection considers next event time
+**Given** calendar events are available from configured sources
+**When** doors are selected via SelectDoors
+**Then** the selection algorithm factors in time until the next calendar event
+**And** tasks whose effort level fits the available time block are preferred
+
+### AC2: Short time blocks prefer quick tasks
+**Given** the next calendar event is within 30 minutes
+**When** doors are selected
+**Then** tasks with effort "quick-win" are strongly preferred
+**And** tasks with effort "deep-work" are deprioritized
+**And** tasks with effort "medium" are moderately preferred
+
+### AC3: No calendar data falls back to standard selection
+**Given** no calendar sources are configured or calendar read fails
+**When** doors are selected
+**Then** standard diversity-based selection is used (existing behavior)
+**And** no error is shown to the user
+
+### AC4: Time context shown in TUI
+**Given** calendar events are available
+**When** the doors view is rendered
+**Then** a time context line is displayed (e.g., "Next event in 45 min")
+**And** if no events exist in the next 4 hours, no time context is shown
+
+### AC5: Effort-to-time mapping is configurable via thresholds
+**Given** the time-contextual selector
+**When** determining effort appropriateness
+**Then** the following default thresholds apply:
+- quick-win: ≤ 30 min available
+- medium: 30–90 min available
+- deep-work: > 90 min available
+**And** uncategorized effort tasks are always eligible (no penalty)
+
+### AC6: Graceful degradation on calendar errors
+**Given** a calendar reader returns an error
+**When** doors are selected
+**Then** time-contextual scoring is skipped silently
+**And** standard diversity selection is used as fallback
+
+## Technical Design
+
+### Architecture
+
+Extend the existing door selection algorithm in `internal/tasks/door_selector.go` to incorporate time context from the calendar package. The key change: add a **time-context scoring bonus** to the existing diversity-based multi-candidate selection.
+
+### New Types
+
+```go
+// TimeContext holds calendar-derived time information for door selection.
+type TimeContext struct {
+    NextEventIn   time.Duration // Duration until next calendar event
+    AvailableTime time.Duration // Duration of current free block
+    NextEventName string        // Title of next event (for TUI display)
+    HasCalendar   bool          // Whether calendar data is available
+}
+
+// TimeContextProvider supplies time context for door selection.
+type TimeContextProvider interface {
+    GetTimeContext(ctx context.Context) (*TimeContext, error)
+}
+```
+
+### Scoring Changes
+
+The candidate scoring in `selectDoorsWithRand` will be extended:
+- Current: `score = DiversityScore(candidate)`
+- New: `score = DiversityScore(candidate) + TimeContextScore(candidate, timeCtx)`
+
+`TimeContextScore` adds bonus points for effort-appropriate tasks:
+- If available time ≤ 30 min: +2 per quick-win, +1 per medium, +0 per deep-work
+- If available time 30–90 min: +1 per quick-win, +2 per medium, +0 per deep-work
+- If available time > 90 min: +0 per quick-win, +1 per medium, +2 per deep-work
+- Uncategorized effort: +1 always (neutral)
+- No calendar data: +0 for all (no effect)
+
+### New Files
+
+- `internal/tasks/time_context.go` — TimeContext, TimeContextProvider, TimeContextScore function
+- `internal/tasks/time_context_test.go` — tests for time-contextual scoring
+- `internal/calendar/time_context_provider.go` — calendar-based TimeContextProvider implementation
+- `internal/calendar/time_context_provider_test.go` — tests for calendar time context
+
+### Modified Files
+
+- `internal/tasks/door_selector.go` — extend SelectDoors to accept optional TimeContext, add TimeContextScore to candidate scoring
+- `internal/tasks/door_selector_test.go` — tests for time-contextual door selection
+- `internal/tui/doors_view.go` — add time context display line, accept TimeContextProvider
+- `internal/tui/doors_view_test.go` — test time context rendering
+
+## Tasks
+
+1. Define TimeContext struct and TimeContextProvider interface in `internal/tasks/time_context.go`
+2. Implement TimeContextScore function with effort-to-time mapping
+3. Implement calendar-based TimeContextProvider in `internal/calendar/time_context_provider.go`
+4. Extend SelectDoors/selectDoorsWithRand to incorporate TimeContextScore
+5. Add time context display ("Next event in X min") to DoorsView
+6. Write comprehensive tests for all new functionality
+7. Verify graceful fallback when calendar is unavailable
+
+## Dev Notes
+
+- `SelectDoors` currently takes `(pool *TaskPool, count int)`. Add a new function `SelectDoorsWithTimeContext(pool *TaskPool, count int, timeCtx *TimeContext)` to avoid breaking existing callers. `SelectDoors` delegates with nil TimeContext.
+- The DiversityScore max is 9 (3 dimensions × 3 unique values). TimeContextScore max would be 6 (3 tasks × 2 points). This ensures time context influences but doesn't dominate diversity.
+- All time comparisons must use `time.Now().UTC()`.
+- The TUI time context line should use `lipgloss` styling consistent with existing badge/greeting styles.
+- Calendar errors should be logged but never surface to the user as error messages.
+
+## Quality Gate
+
+- gofumpt formatted
+- golangci-lint passes
+- All tests pass
+- Table-driven tests for >2 cases
+- stdlib testing only (no testify)
+- t.Helper() in helpers, t.Cleanup() for cleanup
+- context.Context as first parameter
+- Errors wrapped with %w
+- time.Now().UTC() used consistently
+- No panics in TUI code paths

--- a/internal/calendar/time_context_provider.go
+++ b/internal/calendar/time_context_provider.go
@@ -1,0 +1,72 @@
+package calendar
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/arcaven/ThreeDoors/internal/tasks"
+)
+
+// CalendarTimeContextProvider implements tasks.TimeContextProvider using a CalendarReader.
+type CalendarTimeContextProvider struct {
+	reader    CalendarReader
+	lookAhead time.Duration
+}
+
+// NewCalendarTimeContextProvider creates a TimeContextProvider backed by a CalendarReader.
+// lookAhead controls how far into the future to scan for events (default: 4 hours).
+func NewCalendarTimeContextProvider(reader CalendarReader, lookAhead time.Duration) *CalendarTimeContextProvider {
+	if lookAhead <= 0 {
+		lookAhead = 4 * time.Hour
+	}
+	return &CalendarTimeContextProvider{
+		reader:    reader,
+		lookAhead: lookAhead,
+	}
+}
+
+// GetTimeContext reads upcoming calendar events and computes the current time context.
+func (p *CalendarTimeContextProvider) GetTimeContext(ctx context.Context) (*tasks.TimeContext, error) {
+	now := time.Now().UTC()
+	end := now.Add(p.lookAhead)
+
+	events, err := p.reader.GetEvents(ctx, now, end)
+	if err != nil {
+		return &tasks.TimeContext{HasCalendar: false}, nil
+	}
+
+	// Filter to non-all-day future events and sort by start time.
+	var upcoming []CalendarEvent
+	for _, e := range events {
+		if e.AllDay {
+			continue
+		}
+		if e.Start.After(now) {
+			upcoming = append(upcoming, e)
+		}
+	}
+
+	if len(upcoming) == 0 {
+		// No upcoming events — large available block
+		return &tasks.TimeContext{
+			HasCalendar:   true,
+			AvailableTime: p.lookAhead,
+			NextEventIn:   0,
+		}, nil
+	}
+
+	sort.Slice(upcoming, func(i, j int) bool {
+		return upcoming[i].Start.Before(upcoming[j].Start)
+	})
+
+	next := upcoming[0]
+	timeUntil := next.Start.Sub(now)
+
+	return &tasks.TimeContext{
+		HasCalendar:   true,
+		NextEventIn:   timeUntil,
+		AvailableTime: timeUntil,
+		NextEventName: next.Title,
+	}, nil
+}

--- a/internal/calendar/time_context_provider_test.go
+++ b/internal/calendar/time_context_provider_test.go
@@ -1,0 +1,166 @@
+package calendar
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCalendarTimeContextProvider_ReaderError(t *testing.T) {
+	t.Parallel()
+	reader := &mockReader{err: errors.New("calendar unavailable")}
+	provider := NewCalendarTimeContextProvider(reader, 4*time.Hour)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tc.HasCalendar {
+		t.Error("expected HasCalendar=false on reader error")
+	}
+}
+
+func TestCalendarTimeContextProvider_NoEvents(t *testing.T) {
+	t.Parallel()
+	reader := &mockReader{events: nil}
+	provider := NewCalendarTimeContextProvider(reader, 4*time.Hour)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tc.HasCalendar {
+		t.Error("expected HasCalendar=true when reader succeeds")
+	}
+	if tc.NextEventIn != 0 {
+		t.Errorf("NextEventIn = %v, want 0 (no events)", tc.NextEventIn)
+	}
+	if tc.AvailableTime != 4*time.Hour {
+		t.Errorf("AvailableTime = %v, want 4h (full lookahead)", tc.AvailableTime)
+	}
+}
+
+func TestCalendarTimeContextProvider_UpcomingEvent(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	reader := &mockReader{
+		events: []CalendarEvent{
+			{Title: "Team Standup", Start: now.Add(45 * time.Minute), End: now.Add(75 * time.Minute)},
+		},
+	}
+	provider := NewCalendarTimeContextProvider(reader, 4*time.Hour)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tc.HasCalendar {
+		t.Error("expected HasCalendar=true")
+	}
+	if tc.NextEventName != "Team Standup" {
+		t.Errorf("NextEventName = %q, want %q", tc.NextEventName, "Team Standup")
+	}
+	// Allow some tolerance for test execution time
+	if tc.NextEventIn < 44*time.Minute || tc.NextEventIn > 46*time.Minute {
+		t.Errorf("NextEventIn = %v, want ~45min", tc.NextEventIn)
+	}
+}
+
+func TestCalendarTimeContextProvider_SkipsAllDayEvents(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	reader := &mockReader{
+		events: []CalendarEvent{
+			{Title: "Holiday", Start: now, End: now.Add(24 * time.Hour), AllDay: true},
+			{Title: "Meeting", Start: now.Add(30 * time.Minute), End: now.Add(60 * time.Minute)},
+		},
+	}
+	provider := NewCalendarTimeContextProvider(reader, 4*time.Hour)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tc.NextEventName != "Meeting" {
+		t.Errorf("NextEventName = %q, want %q (should skip all-day)", tc.NextEventName, "Meeting")
+	}
+}
+
+func TestCalendarTimeContextProvider_PicksEarliestEvent(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	reader := &mockReader{
+		events: []CalendarEvent{
+			{Title: "Later Meeting", Start: now.Add(2 * time.Hour), End: now.Add(3 * time.Hour)},
+			{Title: "Soon Meeting", Start: now.Add(20 * time.Minute), End: now.Add(40 * time.Minute)},
+		},
+	}
+	provider := NewCalendarTimeContextProvider(reader, 4*time.Hour)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tc.NextEventName != "Soon Meeting" {
+		t.Errorf("NextEventName = %q, want %q", tc.NextEventName, "Soon Meeting")
+	}
+}
+
+func TestCalendarTimeContextProvider_SkipsPastEvents(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	reader := &mockReader{
+		events: []CalendarEvent{
+			{Title: "Past", Start: now.Add(-30 * time.Minute), End: now.Add(-10 * time.Minute)},
+			{Title: "Current", Start: now.Add(-5 * time.Minute), End: now.Add(25 * time.Minute)},
+			{Title: "Future", Start: now.Add(60 * time.Minute), End: now.Add(90 * time.Minute)},
+		},
+	}
+	provider := NewCalendarTimeContextProvider(reader, 4*time.Hour)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "Current" started in the past so Start is not After(now); "Future" is the next upcoming
+	if tc.NextEventName != "Future" {
+		t.Errorf("NextEventName = %q, want %q (should skip past/current)", tc.NextEventName, "Future")
+	}
+}
+
+func TestCalendarTimeContextProvider_DefaultLookAhead(t *testing.T) {
+	t.Parallel()
+	reader := &mockReader{events: nil}
+	provider := NewCalendarTimeContextProvider(reader, 0)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tc.AvailableTime != 4*time.Hour {
+		t.Errorf("AvailableTime = %v, want 4h (default lookahead)", tc.AvailableTime)
+	}
+}
+
+func TestCalendarTimeContextProvider_OnlyAllDayEvents(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	reader := &mockReader{
+		events: []CalendarEvent{
+			{Title: "Holiday", Start: now, End: now.Add(24 * time.Hour), AllDay: true},
+		},
+	}
+	provider := NewCalendarTimeContextProvider(reader, 4*time.Hour)
+
+	tc, err := provider.GetTimeContext(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tc.HasCalendar {
+		t.Error("expected HasCalendar=true")
+	}
+	if tc.NextEventIn != 0 {
+		t.Errorf("NextEventIn = %v, want 0 (no timed events)", tc.NextEventIn)
+	}
+}

--- a/internal/tasks/time_context.go
+++ b/internal/tasks/time_context.go
@@ -1,0 +1,177 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"time"
+)
+
+// TimeContext holds calendar-derived time information for door selection.
+// A nil or zero-value TimeContext means no calendar data is available.
+type TimeContext struct {
+	NextEventIn   time.Duration // Duration until next calendar event
+	AvailableTime time.Duration // Duration of current free block
+	NextEventName string        // Title of next event (for TUI display)
+	HasCalendar   bool          // Whether calendar data is available
+}
+
+// TimeContextProvider supplies time context for door selection.
+type TimeContextProvider interface {
+	GetTimeContext(ctx context.Context) (*TimeContext, error)
+}
+
+// Default effort-to-time thresholds.
+const (
+	QuickWinThreshold = 30 * time.Minute
+	MediumThreshold   = 90 * time.Minute
+)
+
+// TimeContextScore scores a set of tasks based on how well their effort levels
+// match the available time block. Returns 0 when no calendar data is available.
+//
+// Scoring per task:
+//   - Available ≤ 30 min: quick-win +2, medium +1, deep-work +0
+//   - Available 30–90 min: quick-win +1, medium +2, deep-work +0
+//   - Available > 90 min: quick-win +0, medium +1, deep-work +2
+//   - Uncategorized effort: +1 always (neutral)
+func TimeContextScore(tasks []*Task, timeCtx *TimeContext) int {
+	if timeCtx == nil || !timeCtx.HasCalendar {
+		return 0
+	}
+
+	score := 0
+	for _, t := range tasks {
+		score += effortTimeScore(t.Effort, timeCtx.AvailableTime)
+	}
+	return score
+}
+
+// SelectDoorsWithTimeContext picks up to count tasks from the pool, considering
+// time context from calendar data in addition to diversity.
+// Falls back to diversity-only selection when timeCtx is nil or has no calendar data.
+func SelectDoorsWithTimeContext(pool *TaskPool, count int, timeCtx *TimeContext) []*Task {
+	rng := rand.New(rand.NewPCG(uint64(time.Now().UTC().UnixNano()), 0))
+	return selectDoorsWithTimeContextAndRand(pool, count, timeCtx, rng)
+}
+
+// selectDoorsWithTimeContextAndRand picks tasks with time awareness using a deterministic RNG.
+func selectDoorsWithTimeContextAndRand(pool *TaskPool, count int, timeCtx *TimeContext, rng *rand.Rand) []*Task {
+	// Fallback: no calendar data → standard diversity selection
+	if timeCtx == nil || !timeCtx.HasCalendar {
+		return selectDoorsWithRand(pool, count, rng)
+	}
+
+	available := pool.GetAvailableForDoors()
+	if len(available) == 0 {
+		return nil
+	}
+	if len(available) <= count {
+		for _, t := range available {
+			pool.MarkRecentlyShown(t.ID)
+		}
+		return available
+	}
+
+	const numCandidates = 10
+
+	bestScore := -1
+	var bestSet []*Task
+
+	for i := range numCandidates {
+		perm := make([]*Task, len(available))
+		copy(perm, available)
+		for j := range count {
+			k := j + rng.IntN(len(perm)-j)
+			perm[j], perm[k] = perm[k], perm[j]
+		}
+		candidate := perm[:count]
+
+		// Combined score: diversity + time context
+		score := DiversityScore(candidate) + TimeContextScore(candidate, timeCtx)
+
+		if score > bestScore {
+			bestScore = score
+			bestSet = make([]*Task, count)
+			copy(bestSet, candidate)
+		} else if score == bestScore && rng.IntN(i+1) == 0 {
+			bestSet = make([]*Task, count)
+			copy(bestSet, candidate)
+		}
+	}
+
+	for _, t := range bestSet {
+		pool.MarkRecentlyShown(t.ID)
+	}
+	return bestSet
+}
+
+// FormatTimeContext returns a human-readable string for TUI display.
+// Returns empty string when no calendar data or event is more than 4 hours away.
+func FormatTimeContext(ctx *TimeContext) string {
+	if ctx == nil || !ctx.HasCalendar || ctx.NextEventIn <= 0 {
+		return ""
+	}
+
+	const maxDisplayDuration = 4 * time.Hour
+	if ctx.NextEventIn > maxDisplayDuration {
+		return ""
+	}
+
+	minutes := int(ctx.NextEventIn.Minutes())
+	var timeStr string
+	if minutes < 60 {
+		timeStr = fmt.Sprintf("%d min", minutes)
+	} else {
+		h := minutes / 60
+		m := minutes % 60
+		timeStr = fmt.Sprintf("%dh %dmin", h, m)
+	}
+
+	if ctx.NextEventName != "" {
+		return fmt.Sprintf("Next event in %s — %s", timeStr, ctx.NextEventName)
+	}
+	return fmt.Sprintf("Next event in %s", timeStr)
+}
+
+// effortTimeScore returns the score for a single task's effort given available time.
+func effortTimeScore(effort TaskEffort, available time.Duration) int {
+	switch {
+	case available <= QuickWinThreshold:
+		// Short block: prefer quick-win
+		switch effort {
+		case EffortQuickWin:
+			return 2
+		case EffortMedium:
+			return 1
+		case EffortDeepWork:
+			return 0
+		default:
+			return 1
+		}
+	case available <= MediumThreshold:
+		// Medium block: prefer medium
+		switch effort {
+		case EffortQuickWin:
+			return 1
+		case EffortMedium:
+			return 2
+		case EffortDeepWork:
+			return 0
+		default:
+			return 1
+		}
+	default:
+		// Long block: prefer deep-work
+		switch effort {
+		case EffortQuickWin:
+			return 0
+		case EffortMedium:
+			return 1
+		case EffortDeepWork:
+			return 2
+		default:
+			return 1
+		}
+	}
+}

--- a/internal/tasks/time_context_test.go
+++ b/internal/tasks/time_context_test.go
@@ -1,0 +1,397 @@
+package tasks
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+	"time"
+)
+
+func TestTimeContextScore_NilContext(t *testing.T) {
+	t.Parallel()
+	tasks := []*Task{{Effort: EffortQuickWin}}
+	got := TimeContextScore(tasks, nil)
+	if got != 0 {
+		t.Errorf("TimeContextScore with nil context = %d, want 0", got)
+	}
+}
+
+func TestTimeContextScore_NoCalendar(t *testing.T) {
+	t.Parallel()
+	tasks := []*Task{{Effort: EffortQuickWin}}
+	ctx := &TimeContext{HasCalendar: false, AvailableTime: 10 * time.Minute}
+	got := TimeContextScore(tasks, ctx)
+	if got != 0 {
+		t.Errorf("TimeContextScore with HasCalendar=false = %d, want 0", got)
+	}
+}
+
+func TestTimeContextScore_EmptyTasks(t *testing.T) {
+	t.Parallel()
+	ctx := &TimeContext{HasCalendar: true, AvailableTime: 10 * time.Minute}
+	got := TimeContextScore(nil, ctx)
+	if got != 0 {
+		t.Errorf("TimeContextScore with nil tasks = %d, want 0", got)
+	}
+}
+
+func TestTimeContextScore_ShortBlock(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		effort TaskEffort
+		want   int
+	}{
+		{"quick-win preferred", EffortQuickWin, 2},
+		{"medium moderate", EffortMedium, 1},
+		{"deep-work deprioritized", EffortDeepWork, 0},
+		{"uncategorized neutral", "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &TimeContext{HasCalendar: true, AvailableTime: 15 * time.Minute}
+			tasks := []*Task{{Effort: tt.effort}}
+			got := TimeContextScore(tasks, ctx)
+			if got != tt.want {
+				t.Errorf("TimeContextScore(short block, %q) = %d, want %d", tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeContextScore_MediumBlock(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		effort TaskEffort
+		want   int
+	}{
+		{"quick-win moderate", EffortQuickWin, 1},
+		{"medium preferred", EffortMedium, 2},
+		{"deep-work deprioritized", EffortDeepWork, 0},
+		{"uncategorized neutral", "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &TimeContext{HasCalendar: true, AvailableTime: 60 * time.Minute}
+			tasks := []*Task{{Effort: tt.effort}}
+			got := TimeContextScore(tasks, ctx)
+			if got != tt.want {
+				t.Errorf("TimeContextScore(medium block, %q) = %d, want %d", tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeContextScore_LongBlock(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		effort TaskEffort
+		want   int
+	}{
+		{"quick-win deprioritized", EffortQuickWin, 0},
+		{"medium moderate", EffortMedium, 1},
+		{"deep-work preferred", EffortDeepWork, 2},
+		{"uncategorized neutral", "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &TimeContext{HasCalendar: true, AvailableTime: 120 * time.Minute}
+			tasks := []*Task{{Effort: tt.effort}}
+			got := TimeContextScore(tasks, ctx)
+			if got != tt.want {
+				t.Errorf("TimeContextScore(long block, %q) = %d, want %d", tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeContextScore_MultipleTasks(t *testing.T) {
+	t.Parallel()
+	ctx := &TimeContext{HasCalendar: true, AvailableTime: 20 * time.Minute}
+	tasks := []*Task{
+		{Effort: EffortQuickWin}, // +2
+		{Effort: EffortMedium},   // +1
+		{Effort: EffortDeepWork}, // +0
+	}
+	got := TimeContextScore(tasks, ctx)
+	if got != 3 {
+		t.Errorf("TimeContextScore(short block, mixed) = %d, want 3", got)
+	}
+}
+
+func TestTimeContextScore_BoundaryValues(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		available time.Duration
+		effort    TaskEffort
+		want      int
+	}{
+		{"exactly 30min quick-win", 30 * time.Minute, EffortQuickWin, 2},
+		{"exactly 30min medium", 30 * time.Minute, EffortMedium, 1},
+		{"31min quick-win", 31 * time.Minute, EffortQuickWin, 1},
+		{"31min medium", 31 * time.Minute, EffortMedium, 2},
+		{"exactly 90min medium", 90 * time.Minute, EffortMedium, 2},
+		{"exactly 90min deep-work", 90 * time.Minute, EffortDeepWork, 0},
+		{"91min deep-work", 91 * time.Minute, EffortDeepWork, 2},
+		{"91min medium", 91 * time.Minute, EffortMedium, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &TimeContext{HasCalendar: true, AvailableTime: tt.available}
+			tasks := []*Task{{Effort: tt.effort}}
+			got := TimeContextScore(tasks, ctx)
+			if got != tt.want {
+				t.Errorf("TimeContextScore(%v, %q) = %d, want %d", tt.available, tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- SelectDoorsWithTimeContext Tests ---
+
+func TestSelectDoorsWithTimeContext_NilContext_FallsBack(t *testing.T) {
+	t.Parallel()
+	pool := NewTaskPool()
+	pool.AddTask(&Task{ID: "1", Text: "task1", Status: StatusTodo, Effort: EffortQuickWin})
+	pool.AddTask(&Task{ID: "2", Text: "task2", Status: StatusTodo, Effort: EffortMedium})
+	pool.AddTask(&Task{ID: "3", Text: "task3", Status: StatusTodo, Effort: EffortDeepWork})
+
+	result := SelectDoorsWithTimeContext(pool, 3, nil)
+	if len(result) != 3 {
+		t.Fatalf("SelectDoorsWithTimeContext(nil ctx) returned %d tasks, want 3", len(result))
+	}
+}
+
+func TestSelectDoorsWithTimeContext_NoCalendar_FallsBack(t *testing.T) {
+	t.Parallel()
+	pool := NewTaskPool()
+	pool.AddTask(&Task{ID: "1", Text: "task1", Status: StatusTodo, Effort: EffortQuickWin})
+	pool.AddTask(&Task{ID: "2", Text: "task2", Status: StatusTodo, Effort: EffortMedium})
+	pool.AddTask(&Task{ID: "3", Text: "task3", Status: StatusTodo, Effort: EffortDeepWork})
+
+	ctx := &TimeContext{HasCalendar: false}
+	result := SelectDoorsWithTimeContext(pool, 3, ctx)
+	if len(result) != 3 {
+		t.Fatalf("SelectDoorsWithTimeContext(no calendar) returned %d tasks, want 3", len(result))
+	}
+}
+
+func TestSelectDoorsWithTimeContext_EmptyPool(t *testing.T) {
+	t.Parallel()
+	pool := NewTaskPool()
+	ctx := &TimeContext{HasCalendar: true, AvailableTime: 15 * time.Minute}
+	result := SelectDoorsWithTimeContext(pool, 3, ctx)
+	if result != nil {
+		t.Errorf("SelectDoorsWithTimeContext(empty pool) = %v, want nil", result)
+	}
+}
+
+func TestSelectDoorsWithTimeContext_FewerTasksThanCount(t *testing.T) {
+	t.Parallel()
+	pool := NewTaskPool()
+	pool.AddTask(&Task{ID: "1", Text: "task1", Status: StatusTodo, Effort: EffortQuickWin})
+	ctx := &TimeContext{HasCalendar: true, AvailableTime: 15 * time.Minute}
+	result := SelectDoorsWithTimeContext(pool, 3, ctx)
+	if len(result) != 1 {
+		t.Fatalf("SelectDoorsWithTimeContext(1 task) returned %d tasks, want 1", len(result))
+	}
+}
+
+func TestSelectDoorsWithTimeContext_ShortBlock_PrefersQuickWin(t *testing.T) {
+	t.Parallel()
+	pool := NewTaskPool()
+	// Add many quick-win and deep-work tasks to give the algorithm plenty of choices
+	for i := range 5 {
+		pool.AddTask(&Task{
+			ID: fmt.Sprintf("qw-%d", i), Text: fmt.Sprintf("quick task %d", i),
+			Status: StatusTodo, Effort: EffortQuickWin,
+			Type: TaskType([]string{"creative", "administrative", "technical", "physical", ""}[i%5]),
+		})
+	}
+	for i := range 5 {
+		pool.AddTask(&Task{
+			ID: fmt.Sprintf("dw-%d", i), Text: fmt.Sprintf("deep task %d", i),
+			Status: StatusTodo, Effort: EffortDeepWork,
+			Type: TaskType([]string{"creative", "administrative", "technical", "physical", ""}[i%5]),
+		})
+	}
+
+	ctx := &TimeContext{HasCalendar: true, AvailableTime: 15 * time.Minute}
+
+	// Run multiple times and check that quick-win tasks appear more often
+	quickWinCount := 0
+	deepWorkCount := 0
+	const iterations = 50
+	for range iterations {
+		// Reset recently-shown buffer
+		p := NewTaskPool()
+		for _, t := range pool.GetAllTasks() {
+			p.AddTask(t)
+		}
+		result := SelectDoorsWithTimeContext(p, 3, ctx)
+		for _, t := range result {
+			switch t.Effort {
+			case EffortQuickWin:
+				quickWinCount++
+			case EffortDeepWork:
+				deepWorkCount++
+			}
+		}
+	}
+
+	if quickWinCount <= deepWorkCount {
+		t.Errorf("Short block: quick-win count (%d) should exceed deep-work count (%d)", quickWinCount, deepWorkCount)
+	}
+}
+
+func TestSelectDoorsWithTimeContext_LongBlock_PrefersDeepWork(t *testing.T) {
+	t.Parallel()
+	pool := NewTaskPool()
+	for i := range 5 {
+		pool.AddTask(&Task{
+			ID: fmt.Sprintf("qw-%d", i), Text: fmt.Sprintf("quick task %d", i),
+			Status: StatusTodo, Effort: EffortQuickWin,
+			Type: TaskType([]string{"creative", "administrative", "technical", "physical", ""}[i%5]),
+		})
+	}
+	for i := range 5 {
+		pool.AddTask(&Task{
+			ID: fmt.Sprintf("dw-%d", i), Text: fmt.Sprintf("deep task %d", i),
+			Status: StatusTodo, Effort: EffortDeepWork,
+			Type: TaskType([]string{"creative", "administrative", "technical", "physical", ""}[i%5]),
+		})
+	}
+
+	ctx := &TimeContext{HasCalendar: true, AvailableTime: 120 * time.Minute}
+
+	quickWinCount := 0
+	deepWorkCount := 0
+	const iterations = 50
+	for range iterations {
+		p := NewTaskPool()
+		for _, t := range pool.GetAllTasks() {
+			p.AddTask(t)
+		}
+		result := SelectDoorsWithTimeContext(p, 3, ctx)
+		for _, t := range result {
+			switch t.Effort {
+			case EffortQuickWin:
+				quickWinCount++
+			case EffortDeepWork:
+				deepWorkCount++
+			}
+		}
+	}
+
+	if deepWorkCount <= quickWinCount {
+		t.Errorf("Long block: deep-work count (%d) should exceed quick-win count (%d)", deepWorkCount, quickWinCount)
+	}
+}
+
+func TestSelectDoorsWithTimeContextAndRand_ShortBlock_HighTimeScore(t *testing.T) {
+	t.Parallel()
+	pool := NewTaskPool()
+	pool.AddTask(&Task{ID: "1", Text: "t1", Status: StatusTodo, Effort: EffortQuickWin, Type: TypeCreative})
+	pool.AddTask(&Task{ID: "2", Text: "t2", Status: StatusTodo, Effort: EffortMedium, Type: TypeAdministrative})
+	pool.AddTask(&Task{ID: "3", Text: "t3", Status: StatusTodo, Effort: EffortDeepWork, Type: TypeTechnical})
+	pool.AddTask(&Task{ID: "4", Text: "t4", Status: StatusTodo, Effort: EffortQuickWin, Type: TypePhysical})
+
+	ctx := &TimeContext{HasCalendar: true, AvailableTime: 15 * time.Minute}
+	rng := rand.New(rand.NewPCG(42, 0))
+	result := selectDoorsWithTimeContextAndRand(pool, 3, ctx, rng)
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 doors, got %d", len(result))
+	}
+
+	// With a short block, quick-win tasks should score higher.
+	// Combined score should be at least diversity (>=5) + time context (>=3).
+	diversityScore := DiversityScore(result)
+	timeScore := TimeContextScore(result, ctx)
+	totalScore := diversityScore + timeScore
+
+	if totalScore < 8 {
+		t.Errorf("expected high combined score (>= 8), got diversity=%d + time=%d = %d",
+			diversityScore, timeScore, totalScore)
+	}
+}
+
+// --- FormatTimeContext Tests ---
+
+func TestFormatTimeContext_NilContext(t *testing.T) {
+	t.Parallel()
+	got := FormatTimeContext(nil)
+	if got != "" {
+		t.Errorf("FormatTimeContext(nil) = %q, want empty", got)
+	}
+}
+
+func TestFormatTimeContext_NoCalendar(t *testing.T) {
+	t.Parallel()
+	ctx := &TimeContext{HasCalendar: false}
+	got := FormatTimeContext(ctx)
+	if got != "" {
+		t.Errorf("FormatTimeContext(no calendar) = %q, want empty", got)
+	}
+}
+
+func TestFormatTimeContext_FarEvent(t *testing.T) {
+	t.Parallel()
+	ctx := &TimeContext{
+		HasCalendar: true,
+		NextEventIn: 5 * time.Hour,
+	}
+	got := FormatTimeContext(ctx)
+	if got != "" {
+		t.Errorf("FormatTimeContext(far event) = %q, want empty (>4hr hidden)", got)
+	}
+}
+
+func TestFormatTimeContext_Formatting(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		nextIn    time.Duration
+		eventName string
+		want      string
+	}{
+		{"45 min with name", 45 * time.Minute, "Team Standup", "Next event in 45 min — Team Standup"},
+		{"90 min with name", 90 * time.Minute, "Design Review", "Next event in 1h 30min — Design Review"},
+		{"10 min no name", 10 * time.Minute, "", "Next event in 10 min"},
+		{"2 hours with name", 2 * time.Hour, "All Hands", "Next event in 2h 0min — All Hands"},
+		{"exactly 4 hours", 4 * time.Hour, "Meeting", "Next event in 4h 0min — Meeting"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &TimeContext{
+				HasCalendar:   true,
+				NextEventIn:   tt.nextIn,
+				NextEventName: tt.eventName,
+			}
+			got := FormatTimeContext(ctx)
+			if got != tt.want {
+				t.Errorf("FormatTimeContext() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTimeContext_ZeroDuration(t *testing.T) {
+	t.Parallel()
+	ctx := &TimeContext{
+		HasCalendar: true,
+		NextEventIn: 0,
+	}
+	got := FormatTimeContext(ctx)
+	if got != "" {
+		t.Errorf("FormatTimeContext(zero duration) = %q, want empty", got)
+	}
+}

--- a/internal/tui/doors_view.go
+++ b/internal/tui/doors_view.go
@@ -58,6 +58,7 @@ type DoorsView struct {
 	patternAnalyzer   *tasks.PatternAnalyzer
 	completionCounter *tasks.CompletionCounter
 	syncTracker       *tasks.SyncStatusTracker
+	timeContext       *tasks.TimeContext
 }
 
 // NewDoorsView creates a new DoorsView.
@@ -99,6 +100,16 @@ func (dv *DoorsView) SetSyncTracker(tracker *tasks.SyncStatusTracker) {
 	dv.syncTracker = tracker
 }
 
+// SetTimeContext sets the calendar time context for time-aware door selection and display.
+func (dv *DoorsView) SetTimeContext(tc *tasks.TimeContext) {
+	dv.timeContext = tc
+}
+
+// TimeContext returns the current time context (for testing).
+func (dv *DoorsView) TimeContext() *tasks.TimeContext {
+	return dv.timeContext
+}
+
 // pickGreeting selects a random greeting, avoiding lastIdx to prevent consecutive repeats.
 func pickGreeting(lastIdx int) string {
 	if len(greetingMessages) <= 1 {
@@ -135,8 +146,13 @@ func (dv *DoorsView) RotateFooterMessage() {
 }
 
 // RefreshDoors selects new random doors from the pool.
+// Uses time-contextual selection when calendar data is available.
 func (dv *DoorsView) RefreshDoors() {
-	dv.currentDoors = tasks.SelectDoors(dv.pool, 3)
+	if dv.timeContext != nil && dv.timeContext.HasCalendar {
+		dv.currentDoors = tasks.SelectDoorsWithTimeContext(dv.pool, 3, dv.timeContext)
+	} else {
+		dv.currentDoors = tasks.SelectDoors(dv.pool, 3)
+	}
 	dv.selectedDoorIndex = -1
 }
 
@@ -172,6 +188,10 @@ func (dv *DoorsView) View() string {
 			s.WriteString(greetingStyle.Render(multiGreeting))
 			s.WriteString("\n")
 		}
+	}
+	if timeStr := tasks.FormatTimeContext(dv.timeContext); timeStr != "" {
+		s.WriteString(badgeStyle.Render(timeStr))
+		s.WriteString("\n")
 	}
 	s.WriteString("\n")
 


### PR DESCRIPTION
## Summary

- Implements Story 12.2: Time-Contextual Door Selection — doors now prefer tasks whose effort level matches the available time block from calendar data
- Adds `TimeContext` types, `TimeContextScore` scoring function, and `SelectDoorsWithTimeContext` that combines diversity + time scoring
- Adds `CalendarTimeContextProvider` that reads from the existing `CalendarReader` (Story 12.1) to determine next event and available time
- Extends `DoorsView` to display "Next event in X min" when calendar data is available
- Graceful fallback: no calendar data = standard diversity-based selection (zero behavioral change)

## Changes

### New Files
- `internal/tasks/time_context.go` — `TimeContext`, `TimeContextProvider`, `TimeContextScore`, `SelectDoorsWithTimeContext`, `FormatTimeContext`
- `internal/tasks/time_context_test.go` — 20+ table-driven tests covering scoring, boundary values, selection preferences, formatting
- `internal/calendar/time_context_provider.go` — `CalendarTimeContextProvider` impl
- `internal/calendar/time_context_provider_test.go` — 8 tests covering errors, all-day events, event ordering, past events
- `docs/stories/12.2.story.md` — Story file with ACs, technical design, tasks

### Modified Files
- `internal/tui/doors_view.go` — `SetTimeContext()`, time-aware `RefreshDoors()`, time context display in `View()`

## Scoring Design

Available time → effort preference:
| Available Time | quick-win | medium | deep-work | uncategorized |
|---|---|---|---|---|
| ≤ 30 min | +2 | +1 | +0 | +1 |
| 30–90 min | +1 | +2 | +0 | +1 |
| > 90 min | +0 | +1 | +2 | +1 |

Time context score is additive with existing diversity score, so it influences but doesn't dominate selection.

## Acceptance Criteria Satisfied

- [x] AC1: Door selection considers next event time
- [x] AC2: Short blocks prefer quick-win tasks
- [x] AC3: No calendar data = standard selection (fallback)
- [x] AC4: Time context shown in TUI ("Next event in X min")
- [x] AC5: Effort-to-time mapping with configurable thresholds
- [x] AC6: Graceful degradation on calendar errors

## Test Plan

- [x] All existing tests pass (no regressions)
- [x] `golangci-lint` passes with 0 issues
- [x] `gofumpt` formatted
- [x] Table-driven tests for scoring, boundaries, formatting
- [x] Statistical tests verify short blocks prefer quick-win, long blocks prefer deep-work
- [x] Calendar provider tests cover errors, all-day events, sorting, past events

## Opportunities (not implemented)

- Integration with mood selector (`SelectDoorsWithMood`) for combined mood+time scoring
- User-configurable time thresholds in config.yaml
- Wiring `CalendarTimeContextProvider` into `main()` / app startup