### PR TITLE
feat: Story 13.1 — Cross-Provider Task Pool Aggregation

### DIFF
--- a/cmd/threedoors/main.go
+++ b/cmd/threedoors/main.go
@@ -47,11 +47,22 @@ func main() {
 	}
 
 	var provider tasks.TaskProvider
-	baseProvider := tasks.NewProviderFromConfig(cfg)
-	if configErr == nil {
-		provider = tasks.NewWALProvider(baseProvider, configDir)
+	if len(cfg.Providers) > 1 {
+		// Multi-provider mode: aggregate tasks from all configured providers
+		agg, aggErr := tasks.ResolveAllProviders(cfg, tasks.DefaultRegistry())
+		if aggErr != nil {
+			fmt.Fprintf(os.Stderr, "Failed to initialize providers: %v\n", aggErr)
+			os.Exit(1)
+		}
+		provider = agg
 	} else {
-		provider = baseProvider
+		// Single-provider mode: backward-compatible path
+		baseProvider := tasks.NewProviderFromConfig(cfg)
+		if configErr == nil {
+			provider = tasks.NewWALProvider(baseProvider, configDir)
+		} else {
+			provider = baseProvider
+		}
 	}
 	loadedTasks, err := provider.LoadTasks()
 	if err != nil {

--- a/docs/stories/13.1.story.md
+++ b/docs/stories/13.1.story.md
@@ -1,0 +1,80 @@
+# Story 13.1: Cross-Provider Task Pool Aggregation
+
+Status: in-progress
+
+## Story
+
+**As a** user with multiple task sources,
+**I want** all tasks merged into a single pool,
+**So that** I see everything without switching sources.
+
+## Acceptance Criteria
+
+1. **Multi-Provider Loading** (AC:1)
+   - Given multiple providers configured in config.yaml
+   - When the task pool loads
+   - Then tasks are collected from all active providers
+   - And the unified pool is used for door selection, search, and all views
+
+2. **Provider Failure Isolation** (AC:2)
+   - Given multiple providers configured
+   - When one provider fails to load tasks
+   - Then the remaining providers still contribute tasks
+   - And the failure is logged as a warning
+   - And at least one provider must succeed (all failing returns error)
+
+3. **Provider Origin Metadata** (AC:3)
+   - Given tasks loaded from multiple providers
+   - When tasks are added to the unified pool
+   - Then each task's SourceProvider field records the originating provider name
+
+4. **Write Routing** (AC:4)
+   - Given a task originated from provider "obsidian"
+   - When SaveTask, DeleteTask, or MarkComplete is called
+   - Then the write is routed to the originating "obsidian" provider
+   - And tasks with unknown source fall back to the first configured provider
+
+5. **TaskProvider Interface Compliance** (AC:5)
+   - Given the MultiSourceAggregator
+   - When used as a TaskProvider
+   - Then it implements all five interface methods: LoadTasks, SaveTask, SaveTasks, DeleteTask, MarkComplete
+
+6. **Single Provider Backward Compatibility** (AC:6)
+   - Given only one provider configured (legacy or single-entry list)
+   - When the application starts
+   - Then behavior is identical to current single-provider mode
+
+## Technical Context
+
+### Prerequisites
+- Epic 7 complete (Adapter Registry, Config-Driven Provider Selection)
+- At least one additional adapter beyond textfile (obsidian, applenotes)
+
+### Architecture Reference
+- `docs/architecture/components.md` — MultiSourceAggregator component spec
+- `docs/architecture/high-level-architecture.md` — Multi-source aggregation pattern
+
+### Files to Create
+- `internal/tasks/aggregator.go` — MultiSourceAggregator implementing TaskProvider
+- `internal/tasks/aggregator_test.go` — Comprehensive tests
+
+### Files to Modify
+- `internal/tasks/task.go` — Add SourceProvider field to Task struct
+- `internal/tasks/provider_config.go` — Add ResolveAllProviders function
+- `cmd/threedoors/main.go` — Wire aggregator when multiple providers configured
+
+### FRs Covered
+- FR46: Unified cross-provider task pool
+
+## Tasks
+
+- [ ] Task 1: Add SourceProvider field to Task struct
+- [ ] Task 2: Create MultiSourceAggregator struct with registry reference
+- [ ] Task 3: Implement LoadTasks() — iterate all active providers, isolate failures, tag source
+- [ ] Task 4: Implement SaveTask() — route to originating provider via SourceProvider
+- [ ] Task 5: Implement SaveTasks() — group tasks by source, save to each provider
+- [ ] Task 6: Implement DeleteTask() and MarkComplete() — route to originating provider
+- [ ] Task 7: Add ResolveAllProviders to provider_config.go
+- [ ] Task 8: Update main.go to use aggregator when multiple providers configured
+- [ ] Task 9: Write comprehensive tests (multi-provider load, failure isolation, write routing, backward compat)
+- [ ] Task 10: Verify lint, fmt, tests pass

--- a/internal/tasks/aggregator.go
+++ b/internal/tasks/aggregator.go
@@ -1,0 +1,173 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+)
+
+// ErrAllProvidersFailed is returned when every configured provider fails to load tasks.
+var ErrAllProvidersFailed = errors.New("all providers failed to load tasks")
+
+// ErrNoProviders is returned when no providers are configured.
+var ErrNoProviders = errors.New("no providers configured")
+
+// MultiSourceAggregator merges tasks from multiple TaskProvider instances into
+// a unified pool. It implements TaskProvider so it can be used as a drop-in
+// replacement for single-provider usage. Writes are routed back to the
+// originating provider based on each task's SourceProvider field.
+type MultiSourceAggregator struct {
+	mu              sync.RWMutex
+	providers       map[string]TaskProvider
+	taskOrigins     map[string]string // taskID → provider name
+	defaultProvider string
+}
+
+// NewMultiSourceAggregator creates an aggregator over the given named providers.
+// The first provider in iteration order is used as the default for tasks with
+// unknown origin. For deterministic default selection, use NewMultiSourceAggregatorWithDefault.
+func NewMultiSourceAggregator(providers map[string]TaskProvider) *MultiSourceAggregator {
+	defaultName := ""
+	for name := range providers {
+		defaultName = name
+		break
+	}
+	return &MultiSourceAggregator{
+		providers:       providers,
+		taskOrigins:     make(map[string]string),
+		defaultProvider: defaultName,
+	}
+}
+
+// NewMultiSourceAggregatorWithDefault creates an aggregator with an explicit default
+// provider name for tasks whose SourceProvider is empty or unknown.
+func NewMultiSourceAggregatorWithDefault(providers map[string]TaskProvider, defaultProvider string) *MultiSourceAggregator {
+	return &MultiSourceAggregator{
+		providers:       providers,
+		taskOrigins:     make(map[string]string),
+		defaultProvider: defaultProvider,
+	}
+}
+
+// LoadTasks collects tasks from all providers. Individual provider failures are
+// isolated — if at least one provider succeeds, its tasks are returned and
+// failures are logged as warnings. Returns ErrAllProvidersFailed only if every
+// provider fails, and ErrNoProviders if none are configured.
+func (a *MultiSourceAggregator) LoadTasks() ([]*Task, error) {
+	if len(a.providers) == 0 {
+		return nil, ErrNoProviders
+	}
+
+	var allTasks []*Task
+	var errs []error
+	succeeded := 0
+
+	for name, provider := range a.providers {
+		tasks, err := provider.LoadTasks()
+		if err != nil {
+			log.Printf("Warning: provider %q failed to load tasks: %v", name, err)
+			errs = append(errs, fmt.Errorf("provider %q: %w", name, err))
+			continue
+		}
+
+		for _, t := range tasks {
+			t.SourceProvider = name
+			a.trackTaskOrigin(t.ID, name)
+		}
+		allTasks = append(allTasks, tasks...)
+		succeeded++
+	}
+
+	if succeeded == 0 {
+		return nil, fmt.Errorf("%w: %v", ErrAllProvidersFailed, errors.Join(errs...))
+	}
+
+	return allTasks, nil
+}
+
+// SaveTask routes the save to the task's originating provider based on
+// SourceProvider. If SourceProvider is empty or unknown, the default provider is used.
+func (a *MultiSourceAggregator) SaveTask(task *Task) error {
+	provider, _ := a.resolveProvider(task.SourceProvider)
+	return provider.SaveTask(task)
+}
+
+// SaveTasks groups tasks by their SourceProvider and saves each group to
+// its originating provider. Tasks with empty SourceProvider go to the default.
+func (a *MultiSourceAggregator) SaveTasks(tasks []*Task) error {
+	grouped := make(map[string][]*Task)
+	for _, t := range tasks {
+		name := t.SourceProvider
+		if name == "" {
+			name = a.defaultProvider
+		}
+		grouped[name] = append(grouped[name], t)
+	}
+
+	var errs []error
+	for name, group := range grouped {
+		provider, ok := a.providers[name]
+		if !ok {
+			provider = a.providers[a.defaultProvider]
+		}
+		if err := provider.SaveTasks(group); err != nil {
+			errs = append(errs, fmt.Errorf("save to provider %q: %w", name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// DeleteTask routes the delete to the task's originating provider.
+func (a *MultiSourceAggregator) DeleteTask(taskID string) error {
+	providerName := a.getTaskOrigin(taskID)
+	provider, _ := a.resolveProvider(providerName)
+	return provider.DeleteTask(taskID)
+}
+
+// MarkComplete routes the completion to the task's originating provider.
+func (a *MultiSourceAggregator) MarkComplete(taskID string) error {
+	providerName := a.getTaskOrigin(taskID)
+	provider, _ := a.resolveProvider(providerName)
+	return provider.MarkComplete(taskID)
+}
+
+// GetProviderForTask returns the TaskProvider instance that owns the given task.
+func (a *MultiSourceAggregator) GetProviderForTask(taskID string) (TaskProvider, error) {
+	providerName := a.getTaskOrigin(taskID)
+	if providerName == "" {
+		return nil, fmt.Errorf("get provider for task %q: origin unknown", taskID)
+	}
+	provider, ok := a.providers[providerName]
+	if !ok {
+		return nil, fmt.Errorf("get provider for task %q: provider %q not found", taskID, providerName)
+	}
+	return provider, nil
+}
+
+// trackTaskOrigin records which provider a task came from.
+func (a *MultiSourceAggregator) trackTaskOrigin(taskID, providerName string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.taskOrigins[taskID] = providerName
+}
+
+// getTaskOrigin returns the provider name for a task, or empty string if unknown.
+func (a *MultiSourceAggregator) getTaskOrigin(taskID string) string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.taskOrigins[taskID]
+}
+
+// resolveProvider returns the provider for the given name, falling back to
+// the default provider. Always returns a valid provider as long as the
+// aggregator has at least one provider.
+func (a *MultiSourceAggregator) resolveProvider(name string) (TaskProvider, bool) {
+	if name != "" {
+		if p, ok := a.providers[name]; ok {
+			return p, true
+		}
+	}
+	return a.providers[a.defaultProvider], false
+}

--- a/internal/tasks/aggregator_test.go
+++ b/internal/tasks/aggregator_test.go
@@ -1,0 +1,375 @@
+package tasks
+
+import (
+	"errors"
+	"testing"
+)
+
+// aggMockProvider is a configurable test double for TaskProvider used in aggregator tests.
+type aggMockProvider struct {
+	name       string
+	tasks      []*Task
+	loadErr    error
+	saveErr    error
+	deleteErr  error
+	savedTasks []*Task
+	deletedIDs []string
+	completed  []string
+}
+
+func newAggMockProvider(name string, taskTexts ...string) *aggMockProvider {
+	mp := &aggMockProvider{name: name}
+	for _, text := range taskTexts {
+		t := NewTask(text)
+		t.SourceProvider = name
+		mp.tasks = append(mp.tasks, t)
+	}
+	return mp
+}
+
+func (m *aggMockProvider) LoadTasks() ([]*Task, error) {
+	if m.loadErr != nil {
+		return nil, m.loadErr
+	}
+	return m.tasks, nil
+}
+
+func (m *aggMockProvider) SaveTask(task *Task) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.savedTasks = append(m.savedTasks, task)
+	return nil
+}
+
+func (m *aggMockProvider) SaveTasks(tasks []*Task) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.savedTasks = append(m.savedTasks, tasks...)
+	return nil
+}
+
+func (m *aggMockProvider) DeleteTask(taskID string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.deletedIDs = append(m.deletedIDs, taskID)
+	return nil
+}
+
+func (m *aggMockProvider) MarkComplete(taskID string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.completed = append(m.completed, taskID)
+	return nil
+}
+
+func TestMultiSourceAggregator_LoadTasks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		providers     map[string]TaskProvider
+		wantTaskCount int
+		wantErr       bool
+	}{
+		{
+			name: "loads from multiple providers",
+			providers: map[string]TaskProvider{
+				"textfile": newAggMockProvider("textfile", "task1", "task2"),
+				"obsidian": newAggMockProvider("obsidian", "task3"),
+			},
+			wantTaskCount: 3,
+			wantErr:       false,
+		},
+		{
+			name: "single provider works",
+			providers: map[string]TaskProvider{
+				"textfile": newAggMockProvider("textfile", "task1"),
+			},
+			wantTaskCount: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "no providers returns error",
+			providers:     map[string]TaskProvider{},
+			wantTaskCount: 0,
+			wantErr:       true,
+		},
+		{
+			name: "all providers failing returns error",
+			providers: map[string]TaskProvider{
+				"textfile": &aggMockProvider{name: "textfile", loadErr: errors.New("disk full")},
+				"obsidian": &aggMockProvider{name: "obsidian", loadErr: errors.New("vault missing")},
+			},
+			wantTaskCount: 0,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agg := NewMultiSourceAggregator(tt.providers)
+			tasks, err := agg.LoadTasks()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadTasks() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(tasks) != tt.wantTaskCount {
+				t.Errorf("LoadTasks() returned %d tasks, want %d", len(tasks), tt.wantTaskCount)
+			}
+		})
+	}
+}
+
+func TestMultiSourceAggregator_ProviderFailureIsolation(t *testing.T) {
+	t.Parallel()
+
+	failingProvider := &aggMockProvider{
+		name:    "obsidian",
+		loadErr: errors.New("vault not found"),
+	}
+	workingProvider := newAggMockProvider("textfile", "task1", "task2")
+
+	providers := map[string]TaskProvider{
+		"textfile": workingProvider,
+		"obsidian": failingProvider,
+	}
+
+	agg := NewMultiSourceAggregator(providers)
+	tasks, err := agg.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() should succeed when at least one provider works: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("LoadTasks() returned %d tasks, want 2 from working provider", len(tasks))
+	}
+}
+
+func TestMultiSourceAggregator_SourceProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile", "text task")
+	obsidianProvider := newAggMockProvider("obsidian", "obsidian task")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregator(providers)
+	tasks, err := agg.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() unexpected error: %v", err)
+	}
+
+	sourceProviders := make(map[string]bool)
+	for _, task := range tasks {
+		if task.SourceProvider == "" {
+			t.Errorf("task %q has empty SourceProvider", task.Text)
+		}
+		sourceProviders[task.SourceProvider] = true
+	}
+
+	if !sourceProviders["textfile"] {
+		t.Error("expected tasks with SourceProvider 'textfile'")
+	}
+	if !sourceProviders["obsidian"] {
+		t.Error("expected tasks with SourceProvider 'obsidian'")
+	}
+}
+
+func TestMultiSourceAggregator_SaveTaskRouting(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	obsidianProvider := newAggMockProvider("obsidian")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregator(providers)
+
+	task := NewTask("test task")
+	task.SourceProvider = "obsidian"
+
+	if err := agg.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask() unexpected error: %v", err)
+	}
+
+	if len(obsidianProvider.savedTasks) != 1 {
+		t.Errorf("expected obsidian provider to receive save, got %d saves", len(obsidianProvider.savedTasks))
+	}
+	if len(textProvider.savedTasks) != 0 {
+		t.Errorf("expected textfile provider to receive 0 saves, got %d", len(textProvider.savedTasks))
+	}
+}
+
+func TestMultiSourceAggregator_SaveTaskUnknownSourceFallback(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	obsidianProvider := newAggMockProvider("obsidian")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregatorWithDefault(providers, "textfile")
+
+	task := NewTask("orphan task")
+	task.SourceProvider = "" // no source
+
+	if err := agg.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask() unexpected error: %v", err)
+	}
+
+	if len(textProvider.savedTasks) != 1 {
+		t.Errorf("expected fallback to textfile, got %d saves", len(textProvider.savedTasks))
+	}
+}
+
+func TestMultiSourceAggregator_DeleteTaskRouting(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	obsidianProvider := newAggMockProvider("obsidian")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregator(providers)
+	agg.trackTaskOrigin("task-123", "obsidian")
+
+	if err := agg.DeleteTask("task-123"); err != nil {
+		t.Fatalf("DeleteTask() unexpected error: %v", err)
+	}
+
+	if len(obsidianProvider.deletedIDs) != 1 || obsidianProvider.deletedIDs[0] != "task-123" {
+		t.Errorf("expected obsidian provider to receive delete for task-123")
+	}
+	if len(textProvider.deletedIDs) != 0 {
+		t.Errorf("expected textfile provider to receive 0 deletes")
+	}
+}
+
+func TestMultiSourceAggregator_MarkCompleteRouting(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	obsidianProvider := newAggMockProvider("obsidian")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregator(providers)
+	agg.trackTaskOrigin("task-456", "textfile")
+
+	if err := agg.MarkComplete("task-456"); err != nil {
+		t.Fatalf("MarkComplete() unexpected error: %v", err)
+	}
+
+	if len(textProvider.completed) != 1 || textProvider.completed[0] != "task-456" {
+		t.Errorf("expected textfile provider to receive MarkComplete for task-456")
+	}
+}
+
+func TestMultiSourceAggregator_SaveTasksGroupsByProvider(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	obsidianProvider := newAggMockProvider("obsidian")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregatorWithDefault(providers, "textfile")
+
+	tasks := []*Task{
+		{ID: "1", Text: "text task", SourceProvider: "textfile"},
+		{ID: "2", Text: "obs task 1", SourceProvider: "obsidian"},
+		{ID: "3", Text: "obs task 2", SourceProvider: "obsidian"},
+		{ID: "4", Text: "orphan", SourceProvider: ""},
+	}
+
+	if err := agg.SaveTasks(tasks); err != nil {
+		t.Fatalf("SaveTasks() unexpected error: %v", err)
+	}
+
+	// textfile should get task 1 + orphan task 4
+	if len(textProvider.savedTasks) != 2 {
+		t.Errorf("textfile provider got %d tasks, want 2", len(textProvider.savedTasks))
+	}
+	// obsidian should get tasks 2 and 3
+	if len(obsidianProvider.savedTasks) != 2 {
+		t.Errorf("obsidian provider got %d tasks, want 2", len(obsidianProvider.savedTasks))
+	}
+}
+
+func TestMultiSourceAggregator_ImplementsTaskProvider(t *testing.T) {
+	t.Parallel()
+
+	providers := map[string]TaskProvider{
+		"textfile": newAggMockProvider("textfile"),
+	}
+
+	var _ TaskProvider = NewMultiSourceAggregator(providers)
+}
+
+func TestMultiSourceAggregator_GetProviderForTask(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	obsidianProvider := newAggMockProvider("obsidian")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregator(providers)
+	agg.trackTaskOrigin("task-abc", "obsidian")
+
+	provider, err := agg.GetProviderForTask("task-abc")
+	if err != nil {
+		t.Fatalf("GetProviderForTask() unexpected error: %v", err)
+	}
+	if provider != obsidianProvider {
+		t.Error("GetProviderForTask() returned wrong provider")
+	}
+
+	_, err = agg.GetProviderForTask("nonexistent")
+	if err == nil {
+		t.Error("GetProviderForTask() should error for unknown task")
+	}
+}
+
+func TestMultiSourceAggregator_LoadErrors(t *testing.T) {
+	t.Parallel()
+
+	agg := NewMultiSourceAggregator(map[string]TaskProvider{
+		"broken": &aggMockProvider{name: "broken", loadErr: errors.New("fail")},
+	})
+
+	_, err := agg.LoadTasks()
+	if err == nil {
+		t.Error("LoadTasks() should return error when all providers fail")
+	}
+
+	if !errors.Is(err, ErrAllProvidersFailed) {
+		t.Errorf("expected ErrAllProvidersFailed, got: %v", err)
+	}
+}

--- a/internal/tasks/provider_config.go
+++ b/internal/tasks/provider_config.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -119,6 +120,45 @@ func resolveFromFlatConfig(cfg *ProviderConfig, reg *Registry) (TaskProvider, er
 	}
 
 	return provider, nil
+}
+
+// ResolveAllProviders initializes all configured providers and returns a
+// MultiSourceAggregator that merges their tasks. If only one provider is
+// configured, it still wraps it in the aggregator for consistent behavior.
+// The first configured provider is used as the default for tasks with unknown origin.
+func ResolveAllProviders(cfg *ProviderConfig, reg *Registry) (*MultiSourceAggregator, error) {
+	entries := cfg.Providers
+	if len(entries) == 0 {
+		name := cfg.Provider
+		if name == "" {
+			name = "textfile"
+		}
+		entries = []ProviderEntry{{Name: name}}
+	}
+
+	providers := make(map[string]TaskProvider)
+	var firstProvider string
+	for _, entry := range entries {
+		if !reg.IsRegistered(entry.Name) {
+			log.Printf("Warning: provider %q not registered, skipping", entry.Name)
+			continue
+		}
+		provider, err := reg.InitProvider(entry.Name, cfg)
+		if err != nil {
+			log.Printf("Warning: provider %q failed to initialize: %v", entry.Name, err)
+			continue
+		}
+		providers[entry.Name] = provider
+		if firstProvider == "" {
+			firstProvider = entry.Name
+		}
+	}
+
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("no providers could be initialized")
+	}
+
+	return NewMultiSourceAggregatorWithDefault(providers, firstProvider), nil
 }
 
 // GenerateSampleConfig writes a sample config.yaml with commented-out provider examples.

--- a/internal/tasks/task.go
+++ b/internal/tasks/task.go
@@ -16,18 +16,19 @@ type TaskNote struct {
 
 // Task represents a single task with full lifecycle metadata.
 type Task struct {
-	ID          string       `yaml:"id" json:"id"`
-	Text        string       `yaml:"text" json:"text"`
-	Context     string       `yaml:"context,omitempty" json:"context,omitempty"`
-	Status      TaskStatus   `yaml:"status" json:"status"`
-	Type        TaskType     `yaml:"type,omitempty" json:"type,omitempty"`
-	Effort      TaskEffort   `yaml:"effort,omitempty" json:"effort,omitempty"`
-	Location    TaskLocation `yaml:"location,omitempty" json:"location,omitempty"`
-	Notes       []TaskNote   `yaml:"notes,omitempty" json:"notes,omitempty"`
-	Blocker     string       `yaml:"blocker,omitempty" json:"blocker,omitempty"`
-	CreatedAt   time.Time    `yaml:"created_at" json:"created_at"`
-	UpdatedAt   time.Time    `yaml:"updated_at" json:"updated_at"`
-	CompletedAt *time.Time   `yaml:"completed_at,omitempty" json:"completed_at,omitempty"`
+	ID             string       `yaml:"id" json:"id"`
+	Text           string       `yaml:"text" json:"text"`
+	Context        string       `yaml:"context,omitempty" json:"context,omitempty"`
+	Status         TaskStatus   `yaml:"status" json:"status"`
+	Type           TaskType     `yaml:"type,omitempty" json:"type,omitempty"`
+	Effort         TaskEffort   `yaml:"effort,omitempty" json:"effort,omitempty"`
+	Location       TaskLocation `yaml:"location,omitempty" json:"location,omitempty"`
+	Notes          []TaskNote   `yaml:"notes,omitempty" json:"notes,omitempty"`
+	Blocker        string       `yaml:"blocker,omitempty" json:"blocker,omitempty"`
+	CreatedAt      time.Time    `yaml:"created_at" json:"created_at"`
+	UpdatedAt      time.Time    `yaml:"updated_at" json:"updated_at"`
+	CompletedAt    *time.Time   `yaml:"completed_at,omitempty" json:"completed_at,omitempty"`
+	SourceProvider string       `yaml:"source_provider,omitempty" json:"source_provider,omitempty"`
 }
 
 // NewTask creates a new task with a UUID and default "todo" status.


### PR DESCRIPTION
## Summary

- **MultiSourceAggregator** (`internal/tasks/aggregator.go`): New `TaskProvider` implementation that iterates all active providers, merges tasks into a unified pool, and routes writes back to originating providers
- **SourceProvider field** on `Task` struct: Tracks which provider each task came from, enabling correct write routing
- **Provider failure isolation**: One provider failing doesn't block others — failures are logged as warnings, partial results returned
- **Backward compatible**: Single-provider configs continue to use the existing WAL-wrapped path unchanged

## Changes

| File | Change |
|------|--------|
| `internal/tasks/aggregator.go` | New MultiSourceAggregator implementing TaskProvider |
| `internal/tasks/aggregator_test.go` | 11 tests: multi-load, failure isolation, write routing, grouping |
| `internal/tasks/task.go` | Add `SourceProvider` field to Task struct |
| `internal/tasks/provider_config.go` | Add `ResolveAllProviders()` function |
| `cmd/threedoors/main.go` | Wire aggregator when `len(cfg.Providers) > 1` |
| `docs/stories/13.1.story.md` | Story file with ACs and tasks |

## Acceptance Criteria Satisfied

- [x] AC:1 — Tasks collected from all active providers into unified pool
- [x] AC:2 — Provider failures isolated (one failing doesn't block others)
- [x] AC:3 — Provider origin metadata tracked via SourceProvider field
- [x] AC:4 — Writes routed to originating provider; unknown source falls back to default
- [x] AC:5 — Implements full TaskProvider interface
- [x] AC:6 — Single provider backward compatibility preserved

## Test Plan

- [x] 11 unit tests covering all aggregator behaviors
- [x] Full test suite passes (`go test ./...`)
- [x] Race detector clean (`go test -race`)
- [x] `golangci-lint` — 0 issues
- [x] `gofumpt` formatting applied

## Opportunities (not implemented, out of scope)

- Story 13.2: Duplicate detection across providers (next story in epic)
- WAL wrapping per-provider in multi-provider mode
- Source attribution badges in TUI views