### PR TITLE
fix: increase notarization timeout to 4 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
               --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
               --password "$APPLE_NOTARIZATION_PASSWORD" \
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
-              --wait --timeout 3600
+              --wait --timeout 14400
             rm "${BINARY}.zip"
           done
 
@@ -180,7 +180,7 @@ jobs:
               --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
               --password "$APPLE_NOTARIZATION_PASSWORD" \
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
-              --wait --timeout 3600
+              --wait --timeout 14400
             xcrun stapler staple "$PKG"
           done
 


### PR DESCRIPTION
## Summary

- Bumps notarization timeout from 3600s to 14400s (4 hours) for both binary and pkg notarization steps

## Why

Previous timeouts have been insufficient for initial submissions from a new Apple Developer account. Giving a full 4-hour window to ensure completion. Can be reduced once we establish a routine baseline.

## Test plan

- [ ] Merge and verify `sign-and-notarize` job completes without timeout