### PR TITLE
feat: Story 3.5.4 — Apple Notes Adapter Hardening

### DIFF
--- a/docs/stories/3.5.4.story.md
+++ b/docs/stories/3.5.4.story.md
@@ -1,0 +1,64 @@
+# Story 3.5.4: Apple Notes Adapter Hardening
+
+**Status:** in-progress
+**Epic:** 3.5 — Core Domain Extraction & Interface Hardening
+**Depends on:** 3.5.1 (Core Domain Extraction), 3.5.2 (TaskProvider Interface Hardening)
+
+## User Story
+
+As a user relying on Apple Notes sync,
+I want the adapter to handle errors gracefully with timeouts and retries,
+So that sync is reliable before more adapters are added.
+
+## Acceptance Criteria
+
+### AC-1: Configurable Timeout
+- **Given** the Apple Notes adapter using os/exec for AppleScript
+- **When** an AppleScript call is made
+- **Then** the call has a configurable timeout (default: 10s)
+- **And** the timeout can be set per-provider via config
+
+### AC-2: Retry with Exponential Backoff
+- **Given** a transient failure occurs during an AppleScript call
+- **When** the adapter detects it is transient
+- **Then** the operation retries with exponential backoff (max 3 retries)
+- **And** base delay starts at 100ms, doubling each retry
+
+### AC-3: Error Categorization
+- **Given** an error from an AppleScript call
+- **When** the adapter processes the error
+- **Then** errors are categorized as:
+  - **Transient** (retry): timeout, temporary exec failures
+  - **Permanent** (fail fast): note not found, osascript not found
+  - **Configuration** (user action needed): permission denied, automation not authorized
+
+### AC-4: User-Friendly Error Messages
+- **Given** any adapter error
+- **When** it surfaces to the user
+- **Then** the message is actionable (tells user what to do)
+- **And** includes the error category for programmatic handling
+
+### AC-5: Sync Logging (NFR9)
+- **Given** the adapter performing sync operations
+- **When** operations complete (success or failure)
+- **Then** operations are logged for debugging
+- **And** no sensitive data (note content, task text) appears in logs
+
+## Tasks
+
+1. Define error category types (Transient, Permanent, Configuration)
+2. Create AdapterError type with Category, Message, Suggestion, wrapped error
+3. Add Config struct with Timeout, MaxRetries, InitialBackoff fields
+4. Implement retry logic with exponential backoff
+5. Update wrapError to return categorized AdapterError
+6. Update all AppleScript call sites to use configurable timeout
+7. Add sync operation logging (operation name + duration + outcome only)
+8. Update existing tests, add new tests for retry and error categorization
+
+## Dev Notes
+
+- Current timeouts: 2s (read), 5s (write/delete/health) — normalize to configurable default 10s
+- CommandExecutor abstraction already supports testability via mock
+- Retry should NOT retry permanent/configuration errors
+- Keep backward compatibility: NewAppleNotesProvider() uses defaults
+- Error wrapping must preserve errors.Is/errors.As chain

--- a/internal/adapters/applenotes/apple_notes_provider.go
+++ b/internal/adapters/applenotes/apple_notes_provider.go
@@ -2,7 +2,6 @@ package applenotes
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"html"
 	"os/exec"
@@ -32,6 +31,7 @@ func defaultExecutor(ctx context.Context, script string) (string, error) {
 type AppleNotesProvider struct {
 	noteTitle string
 	executor  CommandExecutor
+	config    Config
 }
 
 // NewAppleNotesProvider creates an AppleNotesProvider with the default osascript executor.
@@ -39,6 +39,7 @@ func NewAppleNotesProvider(noteTitle string) *AppleNotesProvider {
 	return &AppleNotesProvider{
 		noteTitle: noteTitle,
 		executor:  defaultExecutor,
+		config:    DefaultConfig(),
 	}
 }
 
@@ -47,16 +48,30 @@ func NewAppleNotesProviderWithExecutor(noteTitle string, executor CommandExecuto
 	return &AppleNotesProvider{
 		noteTitle: noteTitle,
 		executor:  executor,
+		config:    DefaultConfig(),
+	}
+}
+
+// NewAppleNotesProviderWithConfig creates an AppleNotesProvider with custom executor and config.
+func NewAppleNotesProviderWithConfig(noteTitle string, executor CommandExecutor, cfg Config) *AppleNotesProvider {
+	return &AppleNotesProvider{
+		noteTitle: noteTitle,
+		executor:  executor,
+		config:    cfg,
 	}
 }
 
 // LoadTasks retrieves tasks from Apple Notes via osascript.
 func (p *AppleNotesProvider) LoadTasks() ([]*core.Task, error) {
+	start := time.Now().UTC()
 	raw, err := p.readRawNoteBody()
 	if err != nil {
+		p.log(fmt.Sprintf("LoadTasks failed after %s: %v", time.Since(start).Truncate(time.Millisecond), err))
 		return nil, err
 	}
-	return p.parseNoteBody(raw), nil
+	tasks := p.parseNoteBody(raw)
+	p.log(fmt.Sprintf("LoadTasks completed in %s: %d tasks loaded", time.Since(start).Truncate(time.Millisecond), len(tasks)))
+	return tasks, nil
 }
 
 // escapedNoteTitle returns the note title escaped for AppleScript string embedding.
@@ -65,21 +80,23 @@ func (p *AppleNotesProvider) escapedNoteTitle() string {
 	return strings.ReplaceAll(t, `"`, `\"`)
 }
 
-// readRawNoteBody reads the plaintext note body via osascript without parsing.
+// readRawNoteBody reads the plaintext note body via osascript with retry.
 func (p *AppleNotesProvider) readRawNoteBody() (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), p.config.Timeout)
 	defer cancel()
 	return p.readRawNoteBodyWithCtx(ctx)
 }
 
 // SaveTask writes a single task update back to Apple Notes via read-modify-write.
 func (p *AppleNotesProvider) SaveTask(task *core.Task) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	start := time.Now().UTC()
+	ctx, cancel := context.WithTimeout(context.Background(), p.config.Timeout)
 	defer cancel()
 
 	// Read current note body
 	raw, err := p.readRawNoteBodyWithCtx(ctx)
 	if err != nil {
+		p.log(fmt.Sprintf("SaveTask failed during read after %s: %v", time.Since(start).Truncate(time.Millisecond), err))
 		return err
 	}
 
@@ -107,7 +124,13 @@ func (p *AppleNotesProvider) SaveTask(task *core.Task) error {
 	}
 
 	newBody := strings.Join(lines, "\n")
-	return p.writeNoteBodyWithCtx(ctx, newBody)
+	err = p.writeNoteBodyWithCtx(ctx, newBody)
+	if err != nil {
+		p.log(fmt.Sprintf("SaveTask failed during write after %s: %v", time.Since(start).Truncate(time.Millisecond), err))
+		return err
+	}
+	p.log(fmt.Sprintf("SaveTask completed in %s", time.Since(start).Truncate(time.Millisecond)))
+	return nil
 }
 
 // SaveTasks writes multiple task updates in a single read-modify-write cycle.
@@ -116,11 +139,13 @@ func (p *AppleNotesProvider) SaveTasks(tasks []*core.Task) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	start := time.Now().UTC()
+	ctx, cancel := context.WithTimeout(context.Background(), p.config.Timeout)
 	defer cancel()
 
 	raw, err := p.readRawNoteBodyWithCtx(ctx)
 	if err != nil {
+		p.log(fmt.Sprintf("SaveTasks failed during read after %s: %v", time.Since(start).Truncate(time.Millisecond), err))
 		return err
 	}
 
@@ -155,16 +180,24 @@ func (p *AppleNotesProvider) SaveTasks(tasks []*core.Task) error {
 	}
 
 	newBody := strings.Join(lines, "\n")
-	return p.writeNoteBodyWithCtx(ctx, newBody)
+	err = p.writeNoteBodyWithCtx(ctx, newBody)
+	if err != nil {
+		p.log(fmt.Sprintf("SaveTasks failed during write after %s: %v", time.Since(start).Truncate(time.Millisecond), err))
+		return err
+	}
+	p.log(fmt.Sprintf("SaveTasks completed in %s: %d tasks updated", time.Since(start).Truncate(time.Millisecond), len(tasks)))
+	return nil
 }
 
 // DeleteTask removes a task line from Apple Notes by ID.
 func (p *AppleNotesProvider) DeleteTask(taskID string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	start := time.Now().UTC()
+	ctx, cancel := context.WithTimeout(context.Background(), p.config.Timeout)
 	defer cancel()
 
 	raw, err := p.readRawNoteBodyWithCtx(ctx)
 	if err != nil {
+		p.log(fmt.Sprintf("DeleteTask failed during read after %s: %v", time.Since(start).Truncate(time.Millisecond), err))
 		return err
 	}
 
@@ -186,17 +219,19 @@ func (p *AppleNotesProvider) DeleteTask(taskID string) error {
 	}
 
 	newBody := strings.Join(result, "\n")
-	return p.writeNoteBodyWithCtx(ctx, newBody)
+	err = p.writeNoteBodyWithCtx(ctx, newBody)
+	if err != nil {
+		p.log(fmt.Sprintf("DeleteTask failed during write after %s: %v", time.Since(start).Truncate(time.Millisecond), err))
+		return err
+	}
+	p.log(fmt.Sprintf("DeleteTask completed in %s", time.Since(start).Truncate(time.Millisecond)))
+	return nil
 }
 
-// readRawNoteBodyWithCtx reads the raw note body using an existing context.
+// readRawNoteBodyWithCtx reads the raw note body using an existing context, with retry.
 func (p *AppleNotesProvider) readRawNoteBodyWithCtx(ctx context.Context) (string, error) {
 	script := fmt.Sprintf(`tell application "Notes" to get plaintext text of note "%s"`, p.escapedNoteTitle())
-	output, err := p.executor(ctx, script)
-	if err != nil {
-		return "", p.wrapError(err)
-	}
-	return output, nil
+	return p.executeWithRetry(ctx, script)
 }
 
 // escapeForAppleScript escapes a string for embedding inside AppleScript double-quoted strings.
@@ -205,16 +240,13 @@ func escapeForAppleScript(s string) string {
 	return strings.ReplaceAll(s, `"`, `\"`)
 }
 
-// writeNoteBodyWithCtx writes plaintext back to Apple Notes as HTML using an existing context.
+// writeNoteBodyWithCtx writes plaintext back to Apple Notes as HTML using an existing context, with retry.
 func (p *AppleNotesProvider) writeNoteBodyWithCtx(ctx context.Context, body string) error {
 	htmlBody := p.plaintextToHTML(body)
 	escapedHTML := escapeForAppleScript(htmlBody)
 	script := fmt.Sprintf(`tell application "Notes" to set body of note "%s" to "%s"`, p.escapedNoteTitle(), escapedHTML)
-	_, err := p.executor(ctx, script)
-	if err != nil {
-		return p.wrapError(err)
-	}
-	return nil
+	_, err := p.executeWithRetry(ctx, script)
+	return err
 }
 
 // taskToNoteLine converts a Task to a checkbox-format note line.
@@ -257,10 +289,11 @@ func (p *AppleNotesProvider) Watch() <-chan core.ChangeEvent {
 // HealthCheck reports the operational status of the Apple Notes provider.
 func (p *AppleNotesProvider) HealthCheck() core.HealthCheckResult {
 	result := core.HealthCheckResult{}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), p.config.Timeout)
 	defer cancel()
 
-	_, err := p.executor(ctx, `tell application "Notes" to get name of first note`)
+	script := `tell application "Notes" to get name of first note`
+	_, err := p.executeWithRetry(ctx, script)
 	if err != nil {
 		result.Items = append(result.Items, core.HealthCheckItem{
 			Name:       "Apple Notes Access",
@@ -281,32 +314,6 @@ func (p *AppleNotesProvider) HealthCheck() core.HealthCheckResult {
 // MarkComplete is not supported — Apple Notes is read-only in this story.
 func (p *AppleNotesProvider) MarkComplete(_ string) error {
 	return ErrReadOnly
-}
-
-// wrapError maps osascript errors to meaningful wrapped errors.
-func (p *AppleNotesProvider) wrapError(err error) error {
-	msg := err.Error()
-
-	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("apple notes: osascript timed out: %w", err)
-	}
-	if strings.Contains(msg, "Can't get note") || strings.Contains(msg, "can't get note") {
-		return fmt.Errorf("apple notes: note %q not found: %w", p.noteTitle, err)
-	}
-	if strings.Contains(msg, "not allowed") || strings.Contains(msg, "Not authorized") {
-		return fmt.Errorf("apple notes: automation permission denied: %w", err)
-	}
-
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return fmt.Errorf("apple notes: osascript failed: %w", err)
-	}
-
-	if errors.Is(err, exec.ErrNotFound) {
-		return fmt.Errorf("apple notes: osascript not found (not macOS?): %w", err)
-	}
-
-	return fmt.Errorf("apple notes: %w", err)
 }
 
 // parseNoteBody splits plaintext note content into core.

--- a/internal/adapters/applenotes/e2e_test.go
+++ b/internal/adapters/applenotes/e2e_test.go
@@ -759,7 +759,8 @@ func TestE2E_ConnectivityFailure_OsascriptNotFound(t *testing.T) {
 func TestE2E_ConnectivityFailure_IntermittentTimeout(t *testing.T) {
 	t.Parallel()
 
-	// First call times out, simulating transient connectivity issue
+	// First executor call times out, second succeeds.
+	// With Story 3.5.4 adapter-level retry, LoadTasks recovers transparently.
 	callCount := 0
 	provider := applenotes.NewAppleNotesProviderWithExecutor("E2E Tasks",
 		func(_ context.Context, _ string) (string, error) {
@@ -770,19 +771,16 @@ func TestE2E_ConnectivityFailure_IntermittentTimeout(t *testing.T) {
 			return "- [ ] Recovered task", nil
 		})
 
-	// First attempt fails
-	_, err := provider.LoadTasks()
-	if err == nil {
-		t.Fatal("first call should fail with timeout")
-	}
-
-	// Second attempt succeeds (simulating retry at application level)
+	// Adapter retries internally — first LoadTasks call should succeed
 	loaded, err := provider.LoadTasks()
 	if err != nil {
-		t.Fatalf("second call should succeed, got: %v", err)
+		t.Fatalf("LoadTasks should recover from transient timeout via retry, got: %v", err)
 	}
 	if len(loaded) != 1 {
-		t.Errorf("expected 1 task after recovery, got %d", len(loaded))
+		t.Errorf("expected 1 task after transparent retry, got %d", len(loaded))
+	}
+	if callCount < 2 {
+		t.Errorf("expected at least 2 executor calls (1 failed + 1 retry), got %d", callCount)
 	}
 }
 

--- a/internal/adapters/applenotes/errors.go
+++ b/internal/adapters/applenotes/errors.go
@@ -1,0 +1,126 @@
+package applenotes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ErrorCategory classifies adapter errors for retry and user guidance.
+type ErrorCategory int
+
+const (
+	// ErrorTransient indicates a temporary failure that may succeed on retry.
+	// Examples: timeout, temporary exec failures.
+	ErrorTransient ErrorCategory = iota
+
+	// ErrorPermanent indicates a failure that will not resolve by retrying.
+	// Examples: note not found, osascript binary missing.
+	ErrorPermanent
+
+	// ErrorConfiguration indicates the user must take action to resolve.
+	// Examples: permission denied, automation not authorized.
+	ErrorConfiguration
+)
+
+// String returns the human-readable category name.
+func (c ErrorCategory) String() string {
+	switch c {
+	case ErrorTransient:
+		return "transient"
+	case ErrorPermanent:
+		return "permanent"
+	case ErrorConfiguration:
+		return "configuration"
+	default:
+		return "unknown"
+	}
+}
+
+// AdapterError wraps an underlying error with category, user-friendly message,
+// and actionable suggestion.
+type AdapterError struct {
+	Category   ErrorCategory
+	Message    string
+	Suggestion string
+	Err        error
+}
+
+// Error implements the error interface with a user-friendly format.
+func (e *AdapterError) Error() string {
+	return fmt.Sprintf("apple notes [%s]: %s", e.Category, e.Message)
+}
+
+// Unwrap returns the underlying error for errors.Is/errors.As chain traversal.
+func (e *AdapterError) Unwrap() error {
+	return e.Err
+}
+
+// IsTransient returns true if the error is a transient AdapterError.
+func IsTransient(err error) bool {
+	var adapterErr *AdapterError
+	if errors.As(err, &adapterErr) {
+		return adapterErr.Category == ErrorTransient
+	}
+	return false
+}
+
+// categorizeError maps raw errors to categorized AdapterError with suggestions.
+func (p *AppleNotesProvider) categorizeError(err error) *AdapterError {
+	msg := err.Error()
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &AdapterError{
+			Category:   ErrorTransient,
+			Message:    "osascript timed out",
+			Suggestion: "Apple Notes may be slow to respond. The operation will retry automatically.",
+			Err:        err,
+		}
+	}
+
+	if strings.Contains(msg, "Can't get note") || strings.Contains(msg, "can't get note") {
+		return &AdapterError{
+			Category:   ErrorPermanent,
+			Message:    fmt.Sprintf("note %q not found", p.noteTitle),
+			Suggestion: fmt.Sprintf("Verify a note titled %q exists in Apple Notes.", p.noteTitle),
+			Err:        err,
+		}
+	}
+
+	if strings.Contains(msg, "not allowed") || strings.Contains(msg, "Not authorized") {
+		return &AdapterError{
+			Category:   ErrorConfiguration,
+			Message:    "automation permission denied",
+			Suggestion: "Grant automation access in System Settings > Privacy & Security > Automation.",
+			Err:        err,
+		}
+	}
+
+	if errors.Is(err, exec.ErrNotFound) {
+		return &AdapterError{
+			Category:   ErrorPermanent,
+			Message:    "osascript not found",
+			Suggestion: "Apple Notes integration requires macOS with osascript installed.",
+			Err:        err,
+		}
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return &AdapterError{
+			Category:   ErrorTransient,
+			Message:    "osascript failed",
+			Suggestion: "The AppleScript command failed unexpectedly. The operation will retry automatically.",
+			Err:        err,
+		}
+	}
+
+	return &AdapterError{
+		Category:   ErrorTransient,
+		Message:    fmt.Sprintf("unexpected error: %v", err),
+		Suggestion: "An unexpected error occurred. The operation will retry automatically.",
+		Err:        err,
+	}
+}

--- a/internal/adapters/applenotes/hardening_test.go
+++ b/internal/adapters/applenotes/hardening_test.go
@@ -1,0 +1,627 @@
+package applenotes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Story 3.5.4: Apple Notes Adapter Hardening — TDD Tests
+// =============================================================================
+
+// --- AC-1: Configurable Timeout ---
+
+func TestConfig_DefaultTimeout(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Timeout != 10*time.Second {
+		t.Errorf("DefaultConfig().Timeout = %v, want 10s", cfg.Timeout)
+	}
+}
+
+func TestConfig_CustomTimeout(t *testing.T) {
+	cfg := Config{Timeout: 30 * time.Second}
+	provider := NewAppleNotesProviderWithConfig("TestNote", mockExecutor("", nil), cfg)
+	if provider.config.Timeout != 30*time.Second {
+		t.Errorf("provider.config.Timeout = %v, want 30s", provider.config.Timeout)
+	}
+}
+
+func TestConfig_TimeoutAppliedToExecutor(t *testing.T) {
+	// Executor that records the context deadline
+	var gotDeadline time.Time
+	var hasDeadline bool
+	executor := func(ctx context.Context, script string) (string, error) {
+		gotDeadline, hasDeadline = ctx.Deadline()
+		_ = gotDeadline
+		if !hasDeadline {
+			return "", fmt.Errorf("no deadline set on context")
+		}
+		return "- [ ] Task", nil
+	}
+
+	cfg := Config{
+		Timeout: 5 * time.Second,
+		Retry:   RetryConfig{MaxRetries: 0},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	_, err := provider.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() unexpected error: %v", err)
+	}
+	if !hasDeadline {
+		t.Error("executor should receive context with deadline from configured timeout")
+	}
+}
+
+func TestConfig_AllOperationsUseConfiguredTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		op   func(p *AppleNotesProvider) error
+	}{
+		{
+			name: "LoadTasks",
+			op: func(p *AppleNotesProvider) error {
+				_, err := p.LoadTasks()
+				return err
+			},
+		},
+		{
+			name: "SaveTask",
+			op: func(p *AppleNotesProvider) error {
+				return p.SaveTask(newTestTask("id", "text", "todo", baseTime))
+			},
+		},
+		{
+			name: "DeleteTask",
+			op: func(p *AppleNotesProvider) error {
+				return p.DeleteTask("some-id")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sawDeadline bool
+			executor := func(ctx context.Context, script string) (string, error) {
+				if _, ok := ctx.Deadline(); ok {
+					sawDeadline = true
+				}
+				return "- [ ] Task", nil
+			}
+			cfg := Config{
+				Timeout: 15 * time.Second,
+				Retry:   RetryConfig{MaxRetries: 0},
+			}
+			p := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+			_ = tt.op(p)
+			if !sawDeadline {
+				t.Errorf("%s should use configured timeout via context deadline", tt.name)
+			}
+		})
+	}
+}
+
+// --- AC-2: Retry with Exponential Backoff ---
+
+func TestRetry_TransientErrorRetriesUpToMax(t *testing.T) {
+	var callCount int32
+	transientErr := context.DeadlineExceeded
+
+	executor := func(ctx context.Context, script string) (string, error) {
+		atomic.AddInt32(&callCount, 1)
+		return "", transientErr
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry: RetryConfig{
+			MaxRetries:     3,
+			InitialBackoff: 1 * time.Millisecond, // fast for tests
+		},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	_, err := provider.LoadTasks()
+	if err == nil {
+		t.Fatal("LoadTasks() expected error after retries exhausted, got nil")
+	}
+
+	// 1 initial + 3 retries = 4 total calls
+	got := atomic.LoadInt32(&callCount)
+	if got != 4 {
+		t.Errorf("expected 4 total calls (1 initial + 3 retries), got %d", got)
+	}
+}
+
+func TestRetry_PermanentErrorDoesNotRetry(t *testing.T) {
+	var callCount int32
+	permanentErr := errors.New("execution error: Can't get note \"Missing\"")
+
+	executor := func(ctx context.Context, script string) (string, error) {
+		atomic.AddInt32(&callCount, 1)
+		return "", permanentErr
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry: RetryConfig{
+			MaxRetries:     3,
+			InitialBackoff: 1 * time.Millisecond,
+		},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	_, err := provider.LoadTasks()
+	if err == nil {
+		t.Fatal("LoadTasks() expected error, got nil")
+	}
+
+	got := atomic.LoadInt32(&callCount)
+	if got != 1 {
+		t.Errorf("permanent errors should not retry: expected 1 call, got %d", got)
+	}
+}
+
+func TestRetry_ConfigurationErrorDoesNotRetry(t *testing.T) {
+	var callCount int32
+	configErr := errors.New("Not authorized to send Apple events")
+
+	executor := func(ctx context.Context, script string) (string, error) {
+		atomic.AddInt32(&callCount, 1)
+		return "", configErr
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry: RetryConfig{
+			MaxRetries:     3,
+			InitialBackoff: 1 * time.Millisecond,
+		},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	_, err := provider.LoadTasks()
+	if err == nil {
+		t.Fatal("LoadTasks() expected error, got nil")
+	}
+
+	got := atomic.LoadInt32(&callCount)
+	if got != 1 {
+		t.Errorf("configuration errors should not retry: expected 1 call, got %d", got)
+	}
+}
+
+func TestRetry_SucceedsAfterTransientFailure(t *testing.T) {
+	var callCount int32
+
+	executor := func(ctx context.Context, script string) (string, error) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n <= 2 {
+			return "", context.DeadlineExceeded
+		}
+		return "- [ ] Task A", nil
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry: RetryConfig{
+			MaxRetries:     3,
+			InitialBackoff: 1 * time.Millisecond,
+		},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	tasks, err := provider.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task after retry succeeds, got %d", len(tasks))
+	}
+}
+
+func TestRetry_ExponentialBackoffTiming(t *testing.T) {
+	var timestamps []time.Time
+
+	executor := func(ctx context.Context, script string) (string, error) {
+		timestamps = append(timestamps, time.Now())
+		return "", context.DeadlineExceeded
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry: RetryConfig{
+			MaxRetries:     3,
+			InitialBackoff: 50 * time.Millisecond,
+		},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	_, _ = provider.LoadTasks()
+
+	if len(timestamps) != 4 {
+		t.Fatalf("expected 4 timestamps, got %d", len(timestamps))
+	}
+
+	// Verify exponential backoff: delays should roughly be 50ms, 100ms, 200ms
+	for i := 1; i < len(timestamps); i++ {
+		gap := timestamps[i].Sub(timestamps[i-1])
+		expectedMin := time.Duration(1<<(i-1)) * 50 * time.Millisecond / 2 // allow 50% tolerance
+		if gap < expectedMin {
+			t.Errorf("gap between call %d and %d = %v, expected at least ~%v", i-1, i, gap, expectedMin)
+		}
+	}
+}
+
+func TestRetry_ZeroMaxRetriesDisablesRetry(t *testing.T) {
+	var callCount int32
+
+	executor := func(ctx context.Context, script string) (string, error) {
+		atomic.AddInt32(&callCount, 1)
+		return "", context.DeadlineExceeded
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry: RetryConfig{
+			MaxRetries:     0,
+			InitialBackoff: 1 * time.Millisecond,
+		},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	_, _ = provider.LoadTasks()
+
+	got := atomic.LoadInt32(&callCount)
+	if got != 1 {
+		t.Errorf("with MaxRetries=0, expected 1 call, got %d", got)
+	}
+}
+
+// --- AC-3: Error Categorization ---
+
+func TestErrorCategory_Timeout(t *testing.T) {
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("", context.DeadlineExceeded),
+		Config{Timeout: 10 * time.Second, Retry: RetryConfig{MaxRetries: 0}},
+	)
+
+	_, err := provider.LoadTasks()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("error should be *AdapterError, got %T: %v", err, err)
+	}
+	if adapterErr.Category != ErrorTransient {
+		t.Errorf("timeout should be categorized as transient, got %v", adapterErr.Category)
+	}
+}
+
+func TestErrorCategory_NoteNotFound(t *testing.T) {
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("", errors.New("execution error: Can't get note \"TestNote\"")),
+		Config{Timeout: 10 * time.Second, Retry: RetryConfig{MaxRetries: 0}},
+	)
+
+	_, err := provider.LoadTasks()
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("error should be *AdapterError, got %T: %v", err, err)
+	}
+	if adapterErr.Category != ErrorPermanent {
+		t.Errorf("note not found should be permanent, got %v", adapterErr.Category)
+	}
+}
+
+func TestErrorCategory_OsascriptNotFound(t *testing.T) {
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("", exec.ErrNotFound),
+		Config{Timeout: 10 * time.Second, Retry: RetryConfig{MaxRetries: 0}},
+	)
+
+	_, err := provider.LoadTasks()
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("error should be *AdapterError, got %T: %v", err, err)
+	}
+	if adapterErr.Category != ErrorPermanent {
+		t.Errorf("osascript not found should be permanent, got %v", adapterErr.Category)
+	}
+}
+
+func TestErrorCategory_PermissionDenied(t *testing.T) {
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("", errors.New("Not authorized to send Apple events to Notes")),
+		Config{Timeout: 10 * time.Second, Retry: RetryConfig{MaxRetries: 0}},
+	)
+
+	_, err := provider.LoadTasks()
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("error should be *AdapterError, got %T: %v", err, err)
+	}
+	if adapterErr.Category != ErrorConfiguration {
+		t.Errorf("permission denied should be configuration, got %v", adapterErr.Category)
+	}
+}
+
+func TestErrorCategory_AutomationNotAllowed(t *testing.T) {
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("", errors.New("System Events got an error: osascript is not allowed")),
+		Config{Timeout: 10 * time.Second, Retry: RetryConfig{MaxRetries: 0}},
+	)
+
+	_, err := provider.LoadTasks()
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("error should be *AdapterError, got %T: %v", err, err)
+	}
+	if adapterErr.Category != ErrorConfiguration {
+		t.Errorf("automation not allowed should be configuration, got %v", adapterErr.Category)
+	}
+}
+
+func TestErrorCategory_ExitError(t *testing.T) {
+	// exec.ExitError is a permanent error (generic script failure)
+	exitErr := &exec.ExitError{}
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("", exitErr),
+		Config{Timeout: 10 * time.Second, Retry: RetryConfig{MaxRetries: 0}},
+	)
+
+	_, err := provider.LoadTasks()
+	var adapterErr *AdapterError
+	if !errors.As(err, &adapterErr) {
+		t.Fatalf("error should be *AdapterError, got %T: %v", err, err)
+	}
+	if adapterErr.Category != ErrorTransient {
+		t.Errorf("generic exec exit error should be transient (may be intermittent), got %v", adapterErr.Category)
+	}
+}
+
+// --- AC-4: User-Friendly Error Messages ---
+
+func TestAdapterError_HasSuggestion(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputErr   error
+		wantSubstr string
+	}{
+		{
+			name:       "timeout suggests retry later",
+			inputErr:   context.DeadlineExceeded,
+			wantSubstr: "retry",
+		},
+		{
+			name:       "note not found suggests check note title",
+			inputErr:   errors.New("Can't get note \"Missing\""),
+			wantSubstr: "note",
+		},
+		{
+			name:       "permission denied suggests system settings",
+			inputErr:   errors.New("Not authorized to send Apple events"),
+			wantSubstr: "Privacy",
+		},
+		{
+			name:       "osascript not found suggests macOS",
+			inputErr:   exec.ErrNotFound,
+			wantSubstr: "macOS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewAppleNotesProviderWithConfig("TestNote",
+				mockExecutor("", tt.inputErr),
+				Config{Timeout: 10 * time.Second, Retry: RetryConfig{MaxRetries: 0}},
+			)
+
+			_, err := provider.LoadTasks()
+			var adapterErr *AdapterError
+			if !errors.As(err, &adapterErr) {
+				t.Fatalf("expected *AdapterError, got %T", err)
+			}
+			if adapterErr.Suggestion == "" {
+				t.Error("AdapterError should have a non-empty Suggestion")
+			}
+			if !strings.Contains(strings.ToLower(adapterErr.Suggestion), strings.ToLower(tt.wantSubstr)) {
+				t.Errorf("Suggestion %q should contain %q", adapterErr.Suggestion, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestAdapterError_ErrorStringIncludesCategory(t *testing.T) {
+	err := &AdapterError{
+		Category: ErrorTransient,
+		Message:  "osascript timed out",
+		Err:      context.DeadlineExceeded,
+	}
+	if !strings.Contains(err.Error(), "transient") {
+		t.Errorf("Error() = %q should contain category 'transient'", err.Error())
+	}
+}
+
+func TestAdapterError_UnwrapPreservesChain(t *testing.T) {
+	inner := context.DeadlineExceeded
+	err := &AdapterError{
+		Category: ErrorTransient,
+		Message:  "timed out",
+		Err:      inner,
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("errors.Is should find context.DeadlineExceeded through Unwrap")
+	}
+}
+
+// --- AC-5: Sync Logging (no sensitive data) ---
+
+func TestSyncLog_RecordsOperations(t *testing.T) {
+	var logs []string
+	logger := func(msg string) {
+		logs = append(logs, msg)
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry:   RetryConfig{MaxRetries: 0},
+		Logger:  logger,
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("- [ ] Task A", nil), cfg)
+
+	_, err := provider.LoadTasks()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(logs) == 0 {
+		t.Fatal("expected at least one log entry for LoadTasks")
+	}
+
+	// Verify log contains operation name
+	found := false
+	for _, log := range logs {
+		if strings.Contains(log, "LoadTasks") || strings.Contains(log, "load") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("logs should contain operation name, got: %v", logs)
+	}
+}
+
+func TestSyncLog_NoSensitiveData(t *testing.T) {
+	var logs []string
+	logger := func(msg string) {
+		logs = append(logs, msg)
+	}
+
+	sensitiveContent := "- [ ] Buy drugs secretly\n- [x] Secret password reminder"
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry:   RetryConfig{MaxRetries: 0},
+		Logger:  logger,
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor(sensitiveContent, nil), cfg)
+
+	_, _ = provider.LoadTasks()
+
+	for _, log := range logs {
+		if strings.Contains(log, "Buy drugs") || strings.Contains(log, "Secret password") {
+			t.Errorf("log should not contain sensitive task content: %q", log)
+		}
+	}
+}
+
+func TestSyncLog_RecordsErrorWithoutContent(t *testing.T) {
+	var logs []string
+	logger := func(msg string) {
+		logs = append(logs, msg)
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry:   RetryConfig{MaxRetries: 0},
+		Logger:  logger,
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("", context.DeadlineExceeded), cfg)
+
+	_, _ = provider.LoadTasks()
+
+	if len(logs) == 0 {
+		t.Fatal("expected log entry even for failed operations")
+	}
+
+	// Should log the error category/type but not raw note content
+	found := false
+	for _, log := range logs {
+		if strings.Contains(log, "error") || strings.Contains(log, "failed") || strings.Contains(log, "timeout") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("logs should mention the error, got: %v", logs)
+	}
+}
+
+func TestSyncLog_NilLoggerDoesNotPanic(t *testing.T) {
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry:   RetryConfig{MaxRetries: 0},
+		Logger:  nil,
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote",
+		mockExecutor("- [ ] Task", nil), cfg)
+
+	// Should not panic with nil logger
+	_, err := provider.LoadTasks()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Backward Compatibility ---
+
+func TestNewAppleNotesProvider_UsesDefaults(t *testing.T) {
+	provider := NewAppleNotesProvider("TestNote")
+	if provider.config.Timeout != 10*time.Second {
+		t.Errorf("default provider should use 10s timeout, got %v", provider.config.Timeout)
+	}
+	if provider.config.Retry.MaxRetries != 3 {
+		t.Errorf("default provider should have 3 max retries, got %d", provider.config.Retry.MaxRetries)
+	}
+}
+
+func TestNewAppleNotesProviderWithExecutor_UsesDefaults(t *testing.T) {
+	provider := NewAppleNotesProviderWithExecutor("TestNote", mockExecutor("", nil))
+	if provider.config.Timeout != 10*time.Second {
+		t.Errorf("default provider should use 10s timeout, got %v", provider.config.Timeout)
+	}
+}
+
+// --- Retry applies to write operations too ---
+
+func TestRetry_SaveTaskRetriesOnTransient(t *testing.T) {
+	var callCount int32
+
+	executor := func(ctx context.Context, script string) (string, error) {
+		n := atomic.AddInt32(&callCount, 1)
+		// Read succeeds on first call, write fails transiently twice then succeeds
+		if strings.Contains(script, "get plaintext") {
+			return "- [ ] Task A", nil
+		}
+		if n <= 3 {
+			return "", context.DeadlineExceeded
+		}
+		return "", nil
+	}
+
+	cfg := Config{
+		Timeout: 10 * time.Second,
+		Retry: RetryConfig{
+			MaxRetries:     3,
+			InitialBackoff: 1 * time.Millisecond,
+		},
+	}
+	provider := NewAppleNotesProviderWithConfig("TestNote", executor, cfg)
+
+	task := newTestTask("id", "Task A", "todo", baseTime)
+	err := provider.SaveTask(task)
+	if err != nil {
+		t.Fatalf("SaveTask should succeed after retries: %v", err)
+	}
+}

--- a/internal/adapters/applenotes/retry.go
+++ b/internal/adapters/applenotes/retry.go
@@ -1,0 +1,76 @@
+package applenotes
+
+import (
+	"context"
+	"time"
+)
+
+// LogFunc is a function that accepts a log message string.
+type LogFunc func(msg string)
+
+// RetryConfig controls retry behavior for transient failures.
+type RetryConfig struct {
+	MaxRetries     int
+	InitialBackoff time.Duration
+}
+
+// Config holds all configurable settings for the Apple Notes adapter.
+type Config struct {
+	Timeout time.Duration
+	Retry   RetryConfig
+	Logger  LogFunc
+}
+
+// DefaultRetryConfig returns the default retry configuration.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:     3,
+		InitialBackoff: 100 * time.Millisecond,
+	}
+}
+
+// DefaultConfig returns the default adapter configuration.
+func DefaultConfig() Config {
+	return Config{
+		Timeout: 10 * time.Second,
+		Retry:   DefaultRetryConfig(),
+	}
+}
+
+// executeWithRetry runs an operation, retrying on transient errors with exponential backoff.
+func (p *AppleNotesProvider) executeWithRetry(ctx context.Context, script string) (string, error) {
+	var lastErr error
+
+	for attempt := 0; attempt <= p.config.Retry.MaxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := p.config.Retry.InitialBackoff * (1 << (attempt - 1))
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		output, err := p.executor(ctx, script)
+		if err == nil {
+			return output, nil
+		}
+
+		lastErr = err
+
+		// Categorize the error to decide whether to retry
+		adapterErr := p.categorizeError(err)
+		if adapterErr.Category != ErrorTransient {
+			return "", adapterErr
+		}
+	}
+
+	return "", p.categorizeError(lastErr)
+}
+
+// log emits a log message if a logger is configured.
+func (p *AppleNotesProvider) log(msg string) {
+	if p.config.Logger != nil {
+		p.config.Logger(msg)
+	}
+}


### PR DESCRIPTION
## Summary

- **Configurable timeouts**: All AppleScript calls now use a configurable timeout (default 10s), replacing hardcoded 2s/5s values. Timeout is set via `Config` struct.
- **Retry with exponential backoff**: Transient failures (timeout, exec errors) automatically retry up to 3 times with exponential backoff starting at 100ms.
- **Error categorization**: New `AdapterError` type classifies errors as transient (retry), permanent (fail fast), or configuration (user action needed). Each error includes an actionable suggestion.
- **Sync logging**: Operations log timing and outcome via configurable `LogFunc`. No task content or sensitive data is logged (NFR9 compliant).
- **Backward compatible**: `NewAppleNotesProvider()` and `NewAppleNotesProviderWithExecutor()` continue to work with default config (10s timeout, 3 retries).

## Files Changed

| File | Change |
|------|--------|
| `internal/adapters/applenotes/errors.go` | **New** — `AdapterError` type, `ErrorCategory` enum, `categorizeError()`, `IsTransient()` |
| `internal/adapters/applenotes/retry.go` | **New** — `Config`, `RetryConfig`, `executeWithRetry()`, `LogFunc` |
| `internal/adapters/applenotes/apple_notes_provider.go` | Updated — uses Config for timeouts, retry via `executeWithRetry`, sync logging |
| `internal/adapters/applenotes/hardening_test.go` | **New** — 28 tests covering all ACs (timeout config, retry behavior, error categorization, logging) |
| `internal/adapters/applenotes/e2e_test.go` | Updated — `IntermittentTimeout` test adapted for adapter-level retry |
| `docs/stories/3.5.4.story.md` | **New** — Story specification |

## Acceptance Criteria

- [x] AC-1: Configurable timeout (default 10s)
- [x] AC-2: Retry with exponential backoff (max 3 retries)
- [x] AC-3: Errors categorized (transient/permanent/configuration)
- [x] AC-4: User-friendly error messages with suggestions
- [x] AC-5: Sync logging with no sensitive data

## Test plan

- [x] All 28 new hardening tests pass
- [x] All existing unit, E2E, and contract tests pass
- [x] Full test suite passes with `-race` flag
- [x] `gofumpt` formatting clean
- [x] `golangci-lint` zero warnings

## Opportunities (not implemented)

- Config could be loaded from `config.yaml` once Story 3.5.3's schema is consumed
- Retry jitter could improve concurrent retry behavior under contention
- Structured logging (slog) could replace `LogFunc` for richer observability