### PR TITLE
fix: install Apple Developer ID G2 intermediate for notarization

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,22 @@
+# Copy to .env.local and fill in values
+# .env.local is gitignored (*.env.* pattern)
+
+# Signing identity for codesigning binaries
+# Run `just sign-check` to list available identities
+# Example: "Developer ID Application: Your Name (TEAMID)"
+APPLE_SIGNING_IDENTITY=
+
+# Signing identity for pkg installers
+# Example: "Developer ID Installer: Your Name (TEAMID)"
+APPLE_INSTALLER_IDENTITY=
+
+# Apple ID email for notarytool
+APPLE_NOTARIZATION_APPLE_ID=
+
+# App-specific password for notarytool
+# Generate at https://appleid.apple.com/account/manage → App-Specific Passwords
+APPLE_NOTARIZATION_PASSWORD=
+
+# Team ID from Apple Developer account
+# Find at https://developer.apple.com/account → Membership Details
+APPLE_NOTARIZATION_TEAM_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,11 @@ jobs:
           security import installer-cert.p12 -k build.keychain -P "$APPLE_INSTALLER_CERTIFICATE_PASSWORD" -T /usr/bin/productsign
           rm installer-cert.p12
 
+          # Install Apple Developer ID G2 intermediate certificate
+          curl -sfo /tmp/DeveloperIDG2CA.cer https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+          security add-certificates -k build.keychain /tmp/DeveloperIDG2CA.cer
+          rm /tmp/DeveloperIDG2CA.cer
+
           # Allow codesign to access keychain
           security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,161 @@
+# ThreeDoors justfile — local build, sign, and notarize workflow
+# Loads .env.local automatically for signing secrets
+set dotenv-load
+set dotenv-filename := ".env.local"
+
+THREEDOORS_DIR := env("THREEDOORS_DIR", env("HOME") / ".threedoors")
+VERSION := env("VERSION", "dev")
+
+# ─── Core recipes (mirror Makefile) ───────────────────────────────
+
+# Build the binary
+build:
+    go build -ldflags "-X main.version={{VERSION}}" -o bin/threedoors ./cmd/threedoors
+
+# Build and run
+run: build
+    ./bin/threedoors
+
+# Remove build artifacts
+clean:
+    rm -rf bin/
+
+# Format with gofumpt
+fmt:
+    gofumpt -w .
+
+# Run golangci-lint
+lint:
+    golangci-lint run ./...
+
+# Run all tests
+test:
+    go test ./... -v
+
+# Run shell-script analytics
+analyze:
+    @chmod +x scripts/*.sh
+    @echo "=== Session Analysis ==="
+    @./scripts/analyze_sessions.sh {{THREEDOORS_DIR}}/sessions.jsonl
+    @echo ""
+    @echo "=== Daily Completions ==="
+    @./scripts/daily_completions.sh {{THREEDOORS_DIR}}/completed.txt
+    @echo ""
+    @echo "=== Validation Decision ==="
+    @./scripts/validation_decision.sh {{THREEDOORS_DIR}}/sessions.jsonl
+
+# Run script unit tests
+test-scripts:
+    @chmod +x scripts/*.sh
+    @echo "Testing analyze_sessions.sh..."
+    @./scripts/analyze_sessions.sh scripts/testdata/sessions.jsonl > /dev/null
+    @echo "  PASS"
+    @echo "Testing daily_completions.sh..."
+    @./scripts/daily_completions.sh scripts/testdata/completed.txt > /dev/null
+    @echo "  PASS"
+    @echo "Testing validation_decision.sh..."
+    @./scripts/validation_decision.sh scripts/testdata/sessions.jsonl > /dev/null
+    @echo "  PASS"
+    @echo "All script tests passed."
+
+# Run distribution smoke tests
+test-dist: build
+    @echo "=== Distribution Tests ==="
+    @echo "Testing --version flag..."
+    @./bin/threedoors --version | grep -q "ThreeDoors" && echo "  PASS" || (echo "  FAIL" && exit 1)
+    @echo "Testing Homebrew formula syntax..."
+    @ruby -c Formula/threedoors.rb > /dev/null 2>&1 && echo "  PASS" || (echo "  FAIL" && exit 1)
+    @echo "Testing shell script syntax..."
+    @bash -n scripts/create-pkg.sh && echo "  PASS" || (echo "  FAIL" && exit 1)
+    @echo "All distribution tests passed."
+
+# ─── Cross-compile (mirrors CI) ──────────────────────────────────
+
+# Build for all release targets
+build-all:
+    GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version={{VERSION}}" -o bin/threedoors-darwin-arm64 ./cmd/threedoors
+    GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version={{VERSION}}" -o bin/threedoors-darwin-amd64 ./cmd/threedoors
+    GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version={{VERSION}}" -o bin/threedoors-linux-amd64 ./cmd/threedoors
+
+# ─── Signing & packaging ─────────────────────────────────────────
+
+# Codesign the binary
+sign: (_require-var "APPLE_SIGNING_IDENTITY" env("APPLE_SIGNING_IDENTITY", ""))
+    codesign --force --options runtime --sign "${APPLE_SIGNING_IDENTITY}" --timestamp bin/threedoors
+
+# Verify the codesign signature
+verify:
+    codesign --verify --verbose=2 bin/threedoors
+
+# Submit binary to Apple notarytool and wait for result
+notarize: (_require-var "APPLE_NOTARIZATION_APPLE_ID" env("APPLE_NOTARIZATION_APPLE_ID", "")) (_require-var "APPLE_NOTARIZATION_PASSWORD" env("APPLE_NOTARIZATION_PASSWORD", "")) (_require-var "APPLE_NOTARIZATION_TEAM_ID" env("APPLE_NOTARIZATION_TEAM_ID", ""))
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Zipping binary for notarization..."
+    zip -j bin/threedoors.zip bin/threedoors
+    echo "Submitting to Apple notarytool..."
+    xcrun notarytool submit bin/threedoors.zip \
+        --apple-id "${APPLE_NOTARIZATION_APPLE_ID}" \
+        --password "${APPLE_NOTARIZATION_PASSWORD}" \
+        --team-id "${APPLE_NOTARIZATION_TEAM_ID}" \
+        --wait --timeout 14400
+    rm -f bin/threedoors.zip
+    echo "Notarization complete."
+
+# Create a signed pkg installer
+pkg: (_require-var "APPLE_INSTALLER_IDENTITY" env("APPLE_INSTALLER_IDENTITY", ""))
+    @chmod +x scripts/create-pkg.sh
+    ./scripts/create-pkg.sh bin/threedoors "{{VERSION}}" "${APPLE_INSTALLER_IDENTITY}" bin/threedoors.pkg
+
+# Full local release: build → sign → verify → notarize → pkg
+release-local: build sign verify notarize pkg
+    @echo "Local release complete."
+
+# ─── Diagnostics ─────────────────────────────────────────────────
+
+# Show available codesigning identities
+sign-check:
+    security find-identity -v -p codesigning
+
+# Check notarization status for a submission ID
+notarize-status id: (_require-var "APPLE_NOTARIZATION_APPLE_ID" env("APPLE_NOTARIZATION_APPLE_ID", "")) (_require-var "APPLE_NOTARIZATION_PASSWORD" env("APPLE_NOTARIZATION_PASSWORD", "")) (_require-var "APPLE_NOTARIZATION_TEAM_ID" env("APPLE_NOTARIZATION_TEAM_ID", ""))
+    xcrun notarytool info "{{id}}" \
+        --apple-id "${APPLE_NOTARIZATION_APPLE_ID}" \
+        --password "${APPLE_NOTARIZATION_PASSWORD}" \
+        --team-id "${APPLE_NOTARIZATION_TEAM_ID}"
+
+# Get Apple's detailed log for a submission ID
+notarize-log id: (_require-var "APPLE_NOTARIZATION_APPLE_ID" env("APPLE_NOTARIZATION_APPLE_ID", "")) (_require-var "APPLE_NOTARIZATION_PASSWORD" env("APPLE_NOTARIZATION_PASSWORD", "")) (_require-var "APPLE_NOTARIZATION_TEAM_ID" env("APPLE_NOTARIZATION_TEAM_ID", ""))
+    xcrun notarytool log "{{id}}" \
+        --apple-id "${APPLE_NOTARIZATION_APPLE_ID}" \
+        --password "${APPLE_NOTARIZATION_PASSWORD}" \
+        --team-id "${APPLE_NOTARIZATION_TEAM_ID}"
+
+# List recent notarization submissions
+notarize-history: (_require-var "APPLE_NOTARIZATION_APPLE_ID" env("APPLE_NOTARIZATION_APPLE_ID", "")) (_require-var "APPLE_NOTARIZATION_PASSWORD" env("APPLE_NOTARIZATION_PASSWORD", "")) (_require-var "APPLE_NOTARIZATION_TEAM_ID" env("APPLE_NOTARIZATION_TEAM_ID", ""))
+    xcrun notarytool history \
+        --apple-id "${APPLE_NOTARIZATION_APPLE_ID}" \
+        --password "${APPLE_NOTARIZATION_PASSWORD}" \
+        --team-id "${APPLE_NOTARIZATION_TEAM_ID}"
+
+# Run Gatekeeper assessment on the binary
+gatekeeper-check:
+    spctl --assess --verbose=2 bin/threedoors
+
+# ─── Internal helpers ─────────────────────────────────────────────
+
+# Check that an env var is set, print setup instructions if not
+[private]
+_require-var name value:
+    #!/usr/bin/env bash
+    if [ -z "{{value}}" ]; then
+        echo "ERROR: {{name}} is not set."
+        echo ""
+        echo "To set up local signing:"
+        echo "  1. Copy .env.local.example to .env.local"
+        echo "  2. Fill in your values"
+        echo "  3. Run 'just sign-check' to find your signing identities"
+        echo ""
+        echo ".env.local is gitignored (*.env.* pattern)."
+        exit 1
+    fi


### PR DESCRIPTION
## Summary

- All 39 notarization submissions today were stuck "In Progress" because the Developer ID G2 intermediate certificate was missing from the keychain — both locally and in CI
- The Developer ID Application cert is issued by Apple's G2 authority (`OU=G2`), but only the old intermediate (`OU=Apple Certification Authority`) was installed, breaking the trust chain
- CI now downloads and installs `DeveloperIDG2CA.cer` into the build keychain before signing
- Adds a `justfile` for local build/sign/notarize workflow with diagnostic recipes (`sign-check`, `notarize-history`, `notarize-log`, etc.)
- Adds `.env.local.example` template for local signing secrets

## Root cause

```
$ security find-certificate -c "Developer ID Application" -p | openssl x509 -noout -text | grep Issuer
    Issuer: CN=Developer ID Certification Authority, OU=G2, O=Apple Inc., C=US
```

The cert's issuer is the **G2** intermediate, but the keychain only had the original intermediate. Without the G2 intermediate, `codesign` produces signatures that Apple's notary service can't validate, causing submissions to hang indefinitely.

## Test plan

- [ ] `just --list` shows all recipes
- [ ] `just sign-check` shows valid identity (after local G2 fix)
- [ ] `just build && just sign && just verify` succeeds locally
- [ ] CI signing step installs G2 intermediate before codesign
- [ ] New notarization submission completes (Accepted or Rejected, not stuck)