### PR TITLE
feat: add .app and .dmg packaging for notarization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,56 +185,59 @@ jobs:
           codesign --verify --deep --strict threedoors-darwin-arm64
           codesign --verify --deep --strict threedoors-darwin-amd64
 
-      - name: Notarize binaries
-        env:
-          APPLE_NOTARIZATION_APPLE_ID: ${{ secrets.APPLE_NOTARIZATION_APPLE_ID }}
-          APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-          APPLE_NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_NOTARIZATION_TEAM_ID }}
+      - name: Build app bundles
         run: |
-          for BINARY in threedoors-darwin-arm64 threedoors-darwin-amd64; do
-            echo "Notarizing $BINARY..."
-            zip "${BINARY}.zip" "$BINARY"
-            xcrun notarytool submit "${BINARY}.zip" \
-              --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
-              --password "$APPLE_NOTARIZATION_PASSWORD" \
-              --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
-              --wait --timeout 14400
-            rm "${BINARY}.zip"
-          done
+          VERSION="${{ needs.build-binaries.outputs.version }}"
+          chmod +x scripts/create-app.sh
 
-      - name: Verify Gatekeeper assessment
+          ./scripts/create-app.sh threedoors-darwin-arm64 "$VERSION" .
+          mv ThreeDoors.app ThreeDoors-arm64.app
+
+          ./scripts/create-app.sh threedoors-darwin-amd64 "$VERSION" .
+          mv ThreeDoors.app ThreeDoors-amd64.app
+
+      - name: Sign app bundles
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
-          spctl --assess --type execute threedoors-darwin-arm64
-          spctl --assess --type execute threedoors-darwin-amd64
+          codesign --force --deep --options runtime --sign "$APPLE_SIGNING_IDENTITY" --timestamp ThreeDoors-arm64.app
+          codesign --force --deep --options runtime --sign "$APPLE_SIGNING_IDENTITY" --timestamp ThreeDoors-amd64.app
+
+      - name: Build dmg images
+        run: |
+          VERSION="${{ needs.build-binaries.outputs.version }}"
+          chmod +x scripts/create-dmg.sh
+
+          ./scripts/create-dmg.sh ThreeDoors-arm64.app "$VERSION" threedoors-arm64.dmg
+          ./scripts/create-dmg.sh ThreeDoors-amd64.app "$VERSION" threedoors-amd64.dmg
 
       - name: Build pkg installers
         env:
           APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
-          APPLE_NOTARIZATION_APPLE_ID: ${{ secrets.APPLE_NOTARIZATION_APPLE_ID }}
-          APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-          APPLE_NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_NOTARIZATION_TEAM_ID }}
         run: |
           VERSION="${{ needs.build-binaries.outputs.version }}"
           chmod +x scripts/create-pkg.sh
 
-          # Build arm64 pkg
           ./scripts/create-pkg.sh threedoors-darwin-arm64 "$VERSION" "$APPLE_INSTALLER_IDENTITY" threedoors-arm64.pkg
-
-          # Build amd64 pkg
           ./scripts/create-pkg.sh threedoors-darwin-amd64 "$VERSION" "$APPLE_INSTALLER_IDENTITY" threedoors-amd64.pkg
 
-          # Notarize and staple pkgs
-          for PKG in threedoors-arm64.pkg threedoors-amd64.pkg; do
-            echo "Notarizing $PKG..."
-            xcrun notarytool submit "$PKG" \
+      - name: Notarize and staple all artifacts
+        env:
+          APPLE_NOTARIZATION_APPLE_ID: ${{ secrets.APPLE_NOTARIZATION_APPLE_ID }}
+          APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+          APPLE_NOTARIZATION_TEAM_ID: ${{ secrets.APPLE_NOTARIZATION_TEAM_ID }}
+        run: |
+          for ARTIFACT in threedoors-arm64.pkg threedoors-amd64.pkg threedoors-arm64.dmg threedoors-amd64.dmg; do
+            echo "Notarizing $ARTIFACT..."
+            xcrun notarytool submit "$ARTIFACT" \
               --apple-id "$APPLE_NOTARIZATION_APPLE_ID" \
               --password "$APPLE_NOTARIZATION_PASSWORD" \
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
               --wait --timeout 14400
-            xcrun stapler staple "$PKG"
+            xcrun stapler staple "$ARTIFACT"
           done
 
-      - name: Upload signed binaries and pkgs
+      - name: Upload signed binaries and installers
         uses: actions/upload-artifact@v4
         with:
           name: signed-binaries
@@ -243,6 +246,8 @@ jobs:
             threedoors-darwin-amd64
             threedoors-arm64.pkg
             threedoors-amd64.pkg
+            threedoors-arm64.dmg
+            threedoors-amd64.dmg
           retention-days: 14
 
       - name: Cleanup keychain
@@ -280,7 +285,7 @@ jobs:
         run: cp unsigned-binaries/threedoors-linux-amd64 . && rm -rf unsigned-binaries
 
       - name: List release files
-        run: ls -la threedoors-* *.pkg 2>/dev/null || true
+        run: ls -la threedoors-* *.pkg *.dmg 2>/dev/null || true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -298,7 +303,7 @@ jobs:
             - `threedoors-darwin-arm64` — macOS Apple Silicon
             - `threedoors-darwin-amd64` — macOS Intel
             - `threedoors-linux-amd64` — Linux x86_64
-            ${{ needs.sign-and-notarize.result == 'success' && '- `threedoors-arm64.pkg` — macOS Installer (Apple Silicon)\n- `threedoors-amd64.pkg` — macOS Installer (Intel)' || '' }}
+            ${{ needs.sign-and-notarize.result == 'success' && '- `threedoors-arm64.pkg` — macOS Installer (Apple Silicon)\n- `threedoors-amd64.pkg` — macOS Installer (Intel)\n- `threedoors-arm64.dmg` — macOS Disk Image (Apple Silicon)\n- `threedoors-amd64.dmg` — macOS Disk Image (Intel)' || '' }}
           prerelease: true
           files: |
             threedoors-*

--- a/justfile
+++ b/justfile
@@ -87,28 +87,43 @@ sign: (_require-var "APPLE_SIGNING_IDENTITY" env("APPLE_SIGNING_IDENTITY", ""))
 verify:
     codesign --verify --verbose=2 bin/threedoors
 
-# Submit binary to Apple notarytool and wait for result
-notarize: (_require-var "APPLE_NOTARIZATION_APPLE_ID" env("APPLE_NOTARIZATION_APPLE_ID", "")) (_require-var "APPLE_NOTARIZATION_PASSWORD" env("APPLE_NOTARIZATION_PASSWORD", "")) (_require-var "APPLE_NOTARIZATION_TEAM_ID" env("APPLE_NOTARIZATION_TEAM_ID", ""))
-    #!/usr/bin/env bash
-    set -euo pipefail
-    echo "Zipping binary for notarization..."
-    zip -j bin/threedoors.zip bin/threedoors
-    echo "Submitting to Apple notarytool..."
-    xcrun notarytool submit bin/threedoors.zip \
-        --apple-id "${APPLE_NOTARIZATION_APPLE_ID}" \
-        --password "${APPLE_NOTARIZATION_PASSWORD}" \
-        --team-id "${APPLE_NOTARIZATION_TEAM_ID}" \
-        --wait --timeout 14400
-    rm -f bin/threedoors.zip
-    echo "Notarization complete."
+# Create .app bundle from signed binary
+app:
+    @chmod +x scripts/create-app.sh
+    ./scripts/create-app.sh bin/threedoors "{{VERSION}}" bin
+
+# Codesign the .app bundle
+sign-app: (_require-var "APPLE_SIGNING_IDENTITY" env("APPLE_SIGNING_IDENTITY", ""))
+    codesign --force --deep --options runtime --sign "${APPLE_SIGNING_IDENTITY}" --timestamp bin/ThreeDoors.app
+
+# Create .dmg disk image from .app bundle
+dmg:
+    @chmod +x scripts/create-dmg.sh
+    ./scripts/create-dmg.sh bin/ThreeDoors.app "{{VERSION}}" bin/ThreeDoors.dmg
 
 # Create a signed pkg installer
 pkg: (_require-var "APPLE_INSTALLER_IDENTITY" env("APPLE_INSTALLER_IDENTITY", ""))
     @chmod +x scripts/create-pkg.sh
     ./scripts/create-pkg.sh bin/threedoors "{{VERSION}}" "${APPLE_INSTALLER_IDENTITY}" bin/threedoors.pkg
 
-# Full local release: build → sign → verify → notarize → pkg
-release-local: build sign verify notarize pkg
+# Notarize an artifact (pkg, dmg, or zip)
+notarize artifact: (_require-var "APPLE_NOTARIZATION_APPLE_ID" env("APPLE_NOTARIZATION_APPLE_ID", "")) (_require-var "APPLE_NOTARIZATION_PASSWORD" env("APPLE_NOTARIZATION_PASSWORD", "")) (_require-var "APPLE_NOTARIZATION_TEAM_ID" env("APPLE_NOTARIZATION_TEAM_ID", ""))
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Submitting {{artifact}} to Apple notarytool..."
+    xcrun notarytool submit "{{artifact}}" \
+        --apple-id "${APPLE_NOTARIZATION_APPLE_ID}" \
+        --password "${APPLE_NOTARIZATION_PASSWORD}" \
+        --team-id "${APPLE_NOTARIZATION_TEAM_ID}" \
+        --wait --timeout 14400
+    echo "Stapling notarization ticket..."
+    xcrun stapler staple "{{artifact}}"
+    echo "Notarization complete for {{artifact}}."
+
+# Full local release: build all formats, sign, notarize
+release-local: build sign verify app sign-app dmg pkg
+    just notarize bin/threedoors.pkg
+    just notarize bin/ThreeDoors.dmg
     @echo "Local release complete."
 
 # ─── Diagnostics ─────────────────────────────────────────────────

--- a/packaging/Info.plist
+++ b/packaging/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.arcaven.threedoors</string>
+	<key>CFBundleName</key>
+	<string>ThreeDoors</string>
+	<key>CFBundleDisplayName</key>
+	<string>ThreeDoors</string>
+	<key>CFBundleExecutable</key>
+	<string>threedoors</string>
+	<key>CFBundleVersion</key>
+	<string>VERSION_PLACEHOLDER</string>
+	<key>CFBundleShortVersionString</key>
+	<string>VERSION_PLACEHOLDER</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/create-app.sh
+++ b/scripts/create-app.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# create-app.sh - Create a macOS .app bundle for ThreeDoors
+# Usage: ./scripts/create-app.sh <binary-path> <version> <output-dir>
+
+BINARY_PATH="${1:?Usage: create-app.sh <binary-path> <version> <output-dir>}"
+VERSION="${2:?Version required}"
+OUTPUT_DIR="${3:?Output directory required}"
+
+if [ ! -f "$BINARY_PATH" ]; then
+  echo "Error: binary not found: $BINARY_PATH" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+APP_BUNDLE="${OUTPUT_DIR}/ThreeDoors.app"
+
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+cp "$BINARY_PATH" "$APP_BUNDLE/Contents/MacOS/threedoors"
+chmod +x "$APP_BUNDLE/Contents/MacOS/threedoors"
+
+sed "s/VERSION_PLACEHOLDER/$VERSION/g" "$PROJECT_ROOT/packaging/Info.plist" \
+  > "$APP_BUNDLE/Contents/Info.plist"
+
+echo "APPL????" > "$APP_BUNDLE/Contents/PkgInfo"
+
+echo "Created app bundle: $APP_BUNDLE"

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# create-dmg.sh - Create a macOS .dmg disk image containing ThreeDoors.app
+# Usage: ./scripts/create-dmg.sh <app-bundle-path> <version> <output-path>
+
+APP_PATH="${1:?Usage: create-dmg.sh <app-bundle-path> <version> <output-path>}"
+VERSION="${2:?Version required}"
+OUTPUT_PATH="${3:?Output path required}"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "Error: app bundle not found: $APP_PATH" >&2
+  exit 1
+fi
+
+STAGING_DIR=$(mktemp -d)
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+cp -R "$APP_PATH" "$STAGING_DIR/"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+rm -f "$OUTPUT_PATH"
+hdiutil create -volname "ThreeDoors $VERSION" \
+  -srcfolder "$STAGING_DIR" \
+  -ov -format UDZO \
+  "$OUTPUT_PATH"
+
+echo "Created dmg: $OUTPUT_PATH"


### PR DESCRIPTION
## Summary

- Apple rejects bare Mach-O binaries for notarization ("the code is valid but does not seem to be an app")
- Removed the bare-binary notarization step that was failing
- CI now builds, signs, and notarizes both `.pkg` and `.dmg` for arm64 and amd64
- Bare signed binaries still produced for Homebrew (unchanged)
- justfile gains `app`, `sign-app`, `dmg` recipes; `notarize` now takes any artifact path

## New files

- `packaging/Info.plist` — app bundle metadata
- `scripts/create-app.sh` — assembles `.app` bundle from signed binary
- `scripts/create-dmg.sh` — creates `.dmg` with Applications symlink

## Test plan

- [ ] CI produces .pkg and .dmg artifacts for both architectures
- [ ] Notarization completes (not stuck "In Progress")
- [ ] `just app && just sign-app && just dmg` works locally