### PR TITLE
fix: grant pkgbuild access to installer certificate in CI keychain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
 
           # Import installer certificate (for pkg signing)
           echo "$APPLE_INSTALLER_CERTIFICATE_P12" | base64 --decode > installer-cert.p12
-          security import installer-cert.p12 -k build.keychain -P "$APPLE_INSTALLER_CERTIFICATE_PASSWORD" -T /usr/bin/productsign
+          security import installer-cert.p12 -k build.keychain -P "$APPLE_INSTALLER_CERTIFICATE_PASSWORD" -T /usr/bin/pkgbuild -T /usr/bin/productbuild -T /usr/bin/productsign
           rm installer-cert.p12
 
           # Install Apple Developer ID G2 intermediate certificate


### PR DESCRIPTION
## Summary

- `pkgbuild` fails with "Could not find appropriate signing identity" because the installer cert import only whitelists `/usr/bin/productsign`
- Add `/usr/bin/pkgbuild` and `/usr/bin/productbuild` to the trusted applications list

## One-line fix

```diff
- security import installer-cert.p12 -k build.keychain -P "..." -T /usr/bin/productsign
+ security import installer-cert.p12 -k build.keychain -P "..." -T /usr/bin/pkgbuild -T /usr/bin/productbuild -T /usr/bin/productsign
```