### PR TITLE
fix: set CI=true in Dockerfile.test for flaky watcher test

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,7 +2,7 @@
 # Story 18.4: Builds a test runner image with Go toolchain and linting tools.
 # Source code is mounted at runtime via docker-compose, not copied into the image.
 
-FROM golang:1.24-bookworm
+FROM golang:1.25-bookworm
 
 # Pin tool versions to match CI (.github/workflows/ci.yml)
 ARG GOFUMPT_VERSION=v0.7.0
@@ -30,6 +30,7 @@ USER testuser
 
 # Default environment for test execution
 ENV CGO_ENABLED=0
+ENV CI=true
 
 # Default command runs the full test suite with coverage
 CMD ["go", "test", "./...", "-v", "-count=1", "-timeout", "5m", "-coverprofile=test-results/coverage.out"]


### PR DESCRIPTION
## Summary
- Adds `ENV CI=true` to `Dockerfile.test` so `TestObsidianWatcher_IgnoresSelfWrites` correctly skips inside Docker E2E containers
- Bumps Go base image from 1.24 to 1.25 to match `go.mod` requirement

## Context
The `t.Skip` guard in the flaky watcher test checks `os.Getenv("CI")`, but the Docker test container never had this env var set — causing the test to run and fail due to unreliable filesystem event timing. This was the last blocker for PR #107.

## Test plan
- [ ] Docker E2E suite passes (flaky test skips instead of failing)
- [ ] Go version matches go.mod requirement