### PR TITLE
docs: Door theme system — analyst review, party mode, PRD update

### DIFF
--- a/docs/brief.md
+++ b/docs/brief.md
@@ -225,6 +225,8 @@ Once MVP proves the core philosophy and daily utility:
 
 4. **Cross-platform consistency** - Ensure experience works well across Mac, Linux, and Geodesic environments. Apple Notes continues providing mobile bridge.
 
+5. **Door theme system** - Replace the uniform rounded-border door appearance with visually distinct themed doors using ASCII/ANSI art frames. Each door gets its own visual personality (e.g., minimalist, sci-fi, Japanese shoji). Users can browse and select a door theme during first-run onboarding (scroll through previews), change themes later via a settings/preferences view in the TUI, or override the theme via config file edits (`config.yaml`). Themed doors add personality and delight, combat interface fatigue, and create stronger mental associations with tasks. Start with 3 high-reliability themes, expand the collection over time.
+
 **Long-term Direction (12+ months)**
 
 As understanding deepens from real use:

--- a/docs/prd/epic-details.md
+++ b/docs/prd/epic-details.md
@@ -1199,3 +1199,141 @@
 **Estimated Time:** 120-150 minutes
 
 ---
+
+## Epic 17: Door Theme System
+
+**Epic Goal:** Replace the uniform rounded-border door appearance with visually distinct themed doors using ASCII/ANSI art frames, with user-selectable themes via onboarding, settings view, and config.yaml.
+
+**Scope:** Theme type definitions, registry, three new theme implementations (Modern, Sci-Fi, Shoji), Classic theme wrapper, DoorsView integration, onboarding theme picker, settings `:theme` command, config persistence, and golden file tests.
+
+**Research:** See `docs/research/door-themes-research.md` (8 ANSI mockups, feasibility matrix), `docs/research/door-themes-analyst-review.md` (analyst assessment), `docs/research/door-themes-party-mode.md` (architecture decisions).
+
+---
+
+### Story 17.1: Theme Types, Registry, and Classic Theme Wrapper
+
+**As a** developer,
+**I want** a DoorTheme type, ThemeColors struct, theme registry, and a Classic theme that wraps the current rendering,
+**so that** the theme infrastructure is in place and existing behavior is preserved as a theme option.
+
+**Acceptance Criteria:**
+1. `DoorTheme` struct defined in `internal/tui/themes/theme.go` with fields: Name, Description, Render function, Colors (ThemeColors), MinWidth
+2. `ThemeColors` struct defined with Frame, Fill, Accent, Selected fields (all `lipgloss.Color`)
+3. Theme registry in `internal/tui/themes/registry.go` as `map[string]DoorTheme` with lookup helper
+4. `DefaultThemeName` constant set to `"modern"`
+5. Classic theme in `internal/tui/themes/classic.go` that wraps current Lipgloss `doorStyle`/`selectedDoorStyle` rendering
+6. Classic theme produces output identical to current door rendering (verified by test)
+7. All code passes `make fmt` and `make lint`
+
+**Estimated Time:** 60-90 minutes
+
+---
+
+### Story 17.2: Modern, Sci-Fi, and Shoji Theme Implementations
+
+**As a** user,
+**I want** three visually distinct door themes to choose from,
+**so that** my Three Doors interface has personality and visual variety.
+
+**Acceptance Criteria:**
+1. Modern/Minimalist theme (`modern.go`): clean single-line frame, minimal `●` doorknob, generous whitespace
+2. Sci-Fi/Spaceship theme (`scifi.go`): double-line outer frame (`╔╗╚╝═║`), side rails with `░▓` shade, upper content panel + lower control panel
+3. Japanese Shoji theme (`shoji.go`): grid pattern using `┼─│┬┴├┤` characters, task text overlaid on central cells
+4. All themes render correctly at widths from their declared MinWidth up to 60+ characters
+5. All themes handle the `selected` flag by adjusting frame colors
+6. All themes word-wrap content text to fit within their interior content area
+7. Only Unicode characters from box-drawing, block elements, and geometric shapes ranges used (NFR17)
+8. All code passes `make fmt` and `make lint`
+
+**Estimated Time:** 120-180 minutes
+
+**Dependencies:** Story 17.1
+
+---
+
+### Story 17.3: DoorsView Integration — Load Theme from Config
+
+**As a** user,
+**I want** my selected door theme applied to the Three Doors display,
+**so that** the doors render with my chosen visual style.
+
+**Acceptance Criteria:**
+1. `DoorsView` struct gains a `theme themes.DoorTheme` field
+2. Theme loaded from `config.yaml` `theme` key at DoorsView initialization
+3. `View()` method uses `theme.Render()` instead of `doorStyle.Render()`
+4. Invalid or missing theme config falls back to `DefaultThemeName` ("modern") with warning logged
+5. Terminal width checked against `theme.MinWidth`; falls back to Classic theme when too narrow
+6. Existing per-door color system replaced by theme's ThemeColors when a non-classic theme is active
+7. Door number labels overlaid consistently regardless of active theme
+8. All existing TUI tests continue to pass
+9. All code passes `make fmt` and `make lint`
+
+**Estimated Time:** 60-90 minutes
+
+**Dependencies:** Stories 17.1, 17.2
+
+---
+
+### Story 17.4: Theme Picker in Onboarding Flow
+
+**As a** new user,
+**I want** to browse and select a door theme during first-run onboarding,
+**so that** I can personalize my Three Doors experience from the start.
+
+**Acceptance Criteria:**
+1. Theme picker step added to the first-run onboarding flow (after values/goals, before key bindings walkthrough)
+2. Picker displays doors rendered with each available theme in a horizontal preview
+3. Left/right arrow keys browse between themes; current theme name and description shown
+4. Enter confirms selection; Escape or "Skip" defaults to Modern/Minimalist
+5. Selected theme written to `config.yaml`
+6. Picker handles narrow terminals gracefully (vertical layout or one-at-a-time display)
+7. All code passes `make fmt` and `make lint`
+
+**Estimated Time:** 90-120 minutes
+
+**Dependencies:** Story 17.3, Epic 10 (onboarding infrastructure — can stub if not yet implemented)
+
+---
+
+### Story 17.5: Settings View — `:theme` Command with Preview
+
+**As a** user,
+**I want** to change my door theme from within the TUI at any time,
+**so that** I can try different themes without editing config files.
+
+**Acceptance Criteria:**
+1. `:theme` command registered in command palette
+2. Command opens theme picker view (reuses component from Story 17.4)
+3. Current theme highlighted in the picker
+4. Theme change takes effect immediately (no restart required)
+5. New theme selection persisted to `config.yaml`
+6. `:theme` command listed in `:help` output
+7. All code passes `make fmt` and `make lint`
+
+**Estimated Time:** 60-90 minutes
+
+**Dependencies:** Stories 17.3, 17.4
+
+---
+
+### Story 17.6: Golden File Tests for All Themes
+
+**As a** developer,
+**I want** golden file tests for every door theme,
+**so that** visual regressions are caught automatically.
+
+**Acceptance Criteria:**
+1. Golden file test for each theme (Classic, Modern, Sci-Fi, Shoji) at 28-char and 40-char widths
+2. Both selected and unselected states tested per theme
+3. Golden files stored in `internal/tui/themes/testdata/`
+4. Tests use `go test -update` flag to regenerate golden files
+5. Width boundary tests: each theme at MinWidth (should render) and MinWidth-1 (should indicate fallback)
+6. Content wrapping tests: short (1 line), medium (2-3 lines), and long (5+ lines) task text
+7. All tests pass with `make test`
+8. All code passes `make fmt` and `make lint`
+
+**Estimated Time:** 60-90 minutes
+
+**Dependencies:** Stories 17.1, 17.2
+
+---

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -229,6 +229,27 @@
 - **Origin:** Party mode mobile app discussion (2026-03-02)
 - **Research:** See `docs/research/mobile-app-research.md` for full analysis
 
+**Epic 17: Door Theme System** 🆕
+- **Goal:** Replace the uniform rounded-border door appearance with visually distinct themed doors using ASCII/ANSI art frames, with user-selectable themes via onboarding, settings view, and config.yaml
+- **Prerequisites:** Epic 3 ✅ (enhanced interaction), Epic 10 (onboarding — for theme picker integration, can proceed independently)
+- **Deliverables:**
+  - DoorTheme type, ThemeColors, and theme registry (`internal/tui/themes/`)
+  - Classic theme wrapper (preserves current Lipgloss border rendering)
+  - Three new themes: Modern/Minimalist, Sci-Fi/Spaceship, Japanese Shoji
+  - DoorsView integration — load theme from config, apply in View()
+  - Theme picker in first-run onboarding flow (horizontal preview, arrow key browsing)
+  - Settings view — `:theme` command with live preview
+  - Config.yaml persistence for theme selection
+  - Width-aware fallback to Classic theme at narrow terminal widths
+  - Golden file tests for all themes at multiple widths and selection states
+- **Stories:** 17.1 (Theme Types & Registry), 17.2 (Theme Implementations), 17.3 (DoorsView Integration), 17.4 (Onboarding Theme Picker), 17.5 (Settings Theme Command), 17.6 (Golden File Tests)
+- **Estimated Effort:** 2-3 weeks at 2-4 hrs/week
+- **FRs covered:** FR55, FR56, FR57, FR58, FR59, FR60, FR61, FR62
+- **NFRs covered:** NFR17, NFR18, NFR19
+- **Risk:** Unicode character width inconsistency across terminal emulators; mitigated by using only low-risk box-drawing characters for v1 themes
+- **Origin:** Door theme research (PR #116) + analyst review + party mode discussion (2026-03-03)
+- **Research:** See `docs/research/door-themes-research.md`, `docs/research/door-themes-analyst-review.md`, `docs/research/door-themes-party-mode.md`
+
 **Epic 18: Docker E2E & Headless TUI Testing Infrastructure** 🆕
 - **Goal:** Establish reproducible, automated E2E testing using Docker containers and Bubbletea's `teatest` package for headless TUI interaction testing — replacing manual testing as the sole E2E validation method
 - **Prerequisites:** Epic 3 ✅, Epic 9 (Stories 9.4, 9.5)
@@ -273,7 +294,8 @@
 | Epic 14: LLM Decomposition | 2 | Not Started |
 | Epic 15: Psychology Research | 2 | Not Started |
 | Epic 16: iPhone Mobile App | 7 | 🆕 Not Started |
+| Epic 17: Door Theme System | 6 | 🆕 Not Started |
 | Epic 18: Docker E2E & Headless TUI Testing | 5 | 🆕 Not Started |
-| **Total** | **74** | **21 complete, 53 remaining** |
+| **Total** | **80** | **21 complete, 59 remaining** |
 
 ---

--- a/docs/prd/product-scope.md
+++ b/docs/prd/product-scope.md
@@ -43,6 +43,8 @@
 - Local enrichment storage (SQLite) for metadata
 - Health check command for backend connectivity
 
+- Door theme system with user-selectable themed door frames (onboarding picker, settings view, config.yaml)
+
 **Out of Scope for Phase 2:**
 - Third-party integrations beyond Apple Notes
 - Cross-computer sync

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -164,6 +164,26 @@
 
 **FR51:** The system shall include functional E2E tests covering full user workflows
 
+**Door Theme System:**
+
+**FR55:** The system shall provide a theme registry containing named door themes, each defining a render function that produces a visually distinct ASCII/ANSI art frame around task content
+
+**FR56:** The system shall ship with at least three door themes (Modern/Minimalist, Sci-Fi/Spaceship, Japanese Shoji) plus a Classic theme that preserves the current Lipgloss border rendering
+
+**FR57:** The system shall allow users to browse and select a door theme during first-run onboarding, displaying a horizontal preview of doors rendered with each available theme
+
+**FR58:** The system shall provide a theme selection view accessible via `:theme` command in the TUI, allowing users to change their active theme with immediate visual effect (no restart required)
+
+**FR59:** The system shall persist the selected theme in `~/.threedoors/config.yaml` as a string key (e.g., `theme: modern`), falling back to the default theme (Modern/Minimalist) when the configured theme name is invalid
+
+**FR60:** The system shall apply the same theme to all three doors in the trio (single theme selection, not per-door assignment)
+
+**FR61:** The system shall gracefully fall back to Classic theme rendering when the terminal width is below a theme's declared minimum width
+
+**FR62:** The system shall overlay door number labels separately from the theme frame, maintaining consistent door identification across all themes
+
+---
+
 ## Non-Functional Requirements
 
 **Technical Demo Phase:**
@@ -217,6 +237,12 @@
 **NFR15:** The system shall never require OAuth or cloud API credentials for calendar integration; only local calendar sources (AppleScript, .ics files, CalDAV cache) are permitted
 
 **NFR16:** The system shall maintain CI coverage gates ensuring test coverage does not regress below established thresholds
+
+**NFR17:** Door theme rendering shall use only Unicode characters from the box-drawing (`U+2500–U+257F`), block elements (`U+2580–U+259F`), and geometric shapes (`U+25A0–U+25FF`) ranges to ensure consistent rendering across modern terminal emulators (iTerm2, Terminal.app, Alacritty, kitty, Windows Terminal)
+
+**NFR18:** Door theme render functions shall complete within 1ms for standard terminal widths (40-200 columns), as theme rendering is pure string manipulation with no I/O
+
+**NFR19:** Each door theme shall include golden file tests verifying rendered output at multiple widths (minimum width, standard width, wide terminal) in both selected and unselected states
 
 ---
 

--- a/docs/research/door-themes-analyst-review.md
+++ b/docs/research/door-themes-analyst-review.md
@@ -1,0 +1,132 @@
+# Door Theme System — Analyst Review
+
+**Date:** 2026-03-03
+**Reviewer:** Business Analyst (Mary)
+**Source:** `docs/research/door-themes-research.md` (PR #116)
+**Status:** Reviewed — Recommended for Implementation
+
+---
+
+## 1. Executive Assessment
+
+The door theme system is a **high-feasibility, low-risk feature** that directly supports ThreeDoors' core value proposition. The research document is thorough, technically grounded, and proposes a pragmatic architecture. The recommendation to start with three high-reliability themes (Modern, Sci-Fi, Shoji) is sound.
+
+**Overall Recommendation:** Proceed with implementation as a new epic. The theme system adds visual personality to the Three Doors interface without compromising the core UX principles of reduced friction and "progress over perfection."
+
+---
+
+## 2. Feasibility Assessment
+
+### Architecture: DoorTheme Struct + Render Functions
+
+The proposed `DoorTheme` struct with render functions is the right approach:
+
+- **Simplicity:** No interface hierarchies, no abstract factories — just a slice of render functions. This aligns with the project's Go idiom of "a little copying is better than a little dependency."
+- **Integration point is clean:** Replacing `style.Render(content)` with `theme.Render(content, width, selected)` in `DoorsView.View()` is a minimal, low-risk change to the existing TUI code.
+- **Testability:** Each theme is a pure function (content in → styled string out), making golden file testing straightforward. The project already has `golden_test.go` infrastructure.
+
+**Risk:** Custom frame drawing bypasses Lipgloss `Border()`, meaning themes must handle padding, alignment, and width calculation manually. This is manageable but increases per-theme code complexity.
+
+### Terminal Compatibility
+
+The feasibility matrix in the research is accurate:
+
+| Risk Level | Themes | Character Classes Used |
+|-----------|--------|----------------------|
+| **Low** | Modern, Sci-Fi, Shoji, Classic Wooden, Vault | Box-drawing (`─│┌┐═║╔╗`), block elements (`░▒▓`), basic shapes (`●◉`) |
+| **Medium** | Castle, Saloon, Garden Gate | Curved box-drawing (`╭╮╰╯`), decorative Unicode (`◠◡⚒╳`) |
+
+The low-risk themes use characters supported by virtually all modern terminal emulators (iTerm2, Alacritty, kitty, Windows Terminal, GNOME Terminal). Medium-risk themes rely on characters with inconsistent width rendering across fonts.
+
+### Performance
+
+Theme rendering is pure string manipulation — no I/O, no computation beyond string building. Performance is a non-concern. Even the most complex theme adds microseconds to a render cycle triggered by keypress events.
+
+---
+
+## 3. Theme Practicality Ranking (v1 Recommendations)
+
+### Tier 1 — Ship in v1 (High feasibility, strong visual identity)
+
+1. **Modern / Minimalist** — Simplest theme, maximum reliability. Clean lines, negative space, asymmetric doorknob. Functions as the "safe default."
+2. **Sci-Fi / Spaceship** — Strong visual identity using only double-line box-drawing (universal support). The panel-and-rivet aesthetic is distinctive. Minor risk: `◈` rivet character.
+3. **Japanese Shoji** — Pure grid of `┼─│` characters — zero rendering risk. The lattice pattern is visually unique and scales naturally by adding/removing grid cells.
+
+### Tier 2 — Ship in v1.1 (Moderate risk, needs cross-terminal testing)
+
+4. **Classic Wooden** — `▒` fill for wood grain is well-supported. Doorknob `◉` is reliable. Good candidate for quick addition.
+5. **Vault / Safe** — Standard double-line frame. Only risk is `╳` crosshatch inside the handle — easily simplified.
+
+### Tier 3 — Defer (Higher risk, complex alignment)
+
+6. **Castle / Medieval** — Arch requires `╭╮╰╯` curves plus precise alignment. `◆` studs and `⚒` symbol have variable widths.
+7. **Saloon / Western** — Complex hinge bracket construction. Horizontal slat alignment is fragile.
+8. **Garden Gate** — `◠◡` wave characters are the highest rendering risk in the entire set.
+
+---
+
+## 4. Product Fit Analysis
+
+### Alignment with Core Philosophy
+
+The theme system aligns strongly with ThreeDoors' product vision:
+
+- **"Personal achievement partner disguised as a todo app"** — Themed doors add personality and delight. The doors become characters, not just containers.
+- **"Works with human psychology"** — Visual variety combats interface fatigue. Distinct door appearances create stronger mental associations with tasks, potentially improving recall and engagement.
+- **"Progress over perfection"** — Theme selection during onboarding is a low-stakes, fun first interaction. No wrong answer. Immediate visual payoff.
+
+### Alignment with Existing Features
+
+| Feature | Theme System Interaction |
+|---------|------------------------|
+| **First-run onboarding (Epic 10, FR38)** | Theme picker is a natural addition to the welcome flow — browse previews, select a set |
+| **Config.yaml (FR29, FR32)** | Theme preference stored alongside other user settings |
+| **Per-door colors** | Themes can incorporate or replace the existing color system — the research addresses this as Open Question #5 |
+| **Session metrics** | Theme selection events can be logged for pattern analysis (which themes correlate with higher engagement?) |
+| **Golden file tests** | Theme rendering output is ideal for golden file comparison |
+
+### Strategic Value
+
+- **Low cost, high delight:** Theme implementation is estimated at ~3 theme files + integration in `DoorsView.View()`. The effort-to-impact ratio is excellent.
+- **Extensibility:** The theme registry pattern makes it trivial to add community-contributed themes later.
+- **Differentiation:** No other TUI task manager offers themed visual frames. This is a unique feature that reinforces ThreeDoors' identity.
+
+---
+
+## 5. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| Unicode characters render at wrong width in some terminals | Medium | Medium | Stick to Tier 1 themes for v1; test across iTerm2, Terminal.app, Alacritty |
+| Theme rendering breaks at narrow terminal widths | Medium | Low | Define minimum width per theme; fall back to simple bordered box below threshold |
+| Theme selection adds friction to onboarding | Low | Medium | Make theme selection optional with a sensible default; allow skipping |
+| Scope creep (seasonal variants, animated themes, etc.) | Medium | Low | Defer all enhancements to post-v1; keep initial scope to 3 static themes |
+| Per-door color system conflicts with theme colors | Low | Low | Theme `Colors` struct overrides per-door colors when a theme is active |
+
+---
+
+## 6. Open Questions — Analyst Recommendations
+
+From the research document's open questions:
+
+1. **Should themes persist across sessions?** → **Yes.** Store in config.yaml. Users form attachment to their chosen aesthetic. Re-randomizing would feel jarring.
+
+2. **Should door number labels be part of the theme frame?** → **Overlaid separately.** Door numbers are functional UI, not decorative. Keep them consistent across themes.
+
+3. **Do we want a theme preview command?** → **Yes, in settings view.** Essential for theme selection UX. Show all available themes rendered at standard width.
+
+4. **Should themes have seasonal variants?** → **Defer.** Fun idea, but pure scope creep for v1. Note as future opportunity.
+
+5. **How do themes interact with per-door colors?** → **Theme colors take precedence.** Each `DoorTheme` defines its own `ThemeColors` struct. The existing per-door color system becomes the fallback for the "Classic" (no-theme) mode.
+
+---
+
+## 7. Summary
+
+The door theme system is well-researched, architecturally sound, and strategically aligned with ThreeDoors' product vision. The recommended starting trio (Modern, Sci-Fi, Shoji) provides strong visual contrast using only reliable Unicode characters.
+
+**Recommendation:** Create Epic 17: Door Theme System with requirements covering theme registry, theme picker in onboarding, settings view for theme changes, and config.yaml persistence.
+
+---
+
+*Review conducted as part of the BMAD methodology analyst workflow.*

--- a/docs/research/door-themes-party-mode.md
+++ b/docs/research/door-themes-party-mode.md
@@ -1,0 +1,237 @@
+# Door Theme System — Party Mode Discussion
+
+**Date:** 2026-03-03
+**Participants:** PM (Pat), Architect (Alex), UX Designer (Jordan), Dev (Sam), QA (Taylor)
+**Topic:** Door theme system implementation strategy
+**Source Research:** `docs/research/door-themes-research.md` (PR #116)
+
+---
+
+## Discussion Summary
+
+### 1. Which Themes to Include in v1
+
+**Consensus: Three themes for v1, chosen for maximum visual contrast and minimum rendering risk.**
+
+| Theme | Champion | Rationale |
+|-------|----------|-----------|
+| **Modern / Minimalist** | UX, PM | Clean baseline, zero rendering risk, works as default |
+| **Sci-Fi / Spaceship** | Dev, Architect | Strong identity, double-line box-drawing is universal |
+| **Japanese Shoji** | UX, QA | Unique grid pattern, pure `┼─│` characters, scales naturally |
+
+**Also discussed:**
+- **Classic Wooden** was a close fourth — `▒` fill is reliable, but visually similar to "just a box with texture." Deferred to v1.1.
+- **Vault / Safe** also v1.1 candidate. Only concern: `╳` crosshatch in handle.
+- **Castle, Saloon, Garden Gate** deferred — require cross-terminal testing before shipping.
+
+**PM (Pat):** "Three themes gives enough variety to feel like a choice without overwhelming. The 'Classic' no-theme mode (current Lipgloss borders) should remain as a fourth option for users who prefer simplicity."
+
+**Architect (Alex):** "Agreed. The Classic mode is essentially the zero-value default — existing border rendering with no theme applied. Costs nothing to keep."
+
+---
+
+### 2. Theme Selection UX
+
+#### First-Run Onboarding (Epic 10 Integration)
+
+**Consensus: Add a theme picker step to the onboarding flow.**
+
+- Show a horizontal preview of all three doors rendered with each theme
+- User scrolls through themes with left/right arrows
+- Enter to confirm selection
+- "Skip" option defaults to Modern/Minimalist
+- Preview renders at a fixed width (e.g., 28 chars per door) to show the theme's character
+
+**UX (Jordan):** "The picker should feel like browsing, not configuring. Show the doors rendered with sample task text. Let the visual speak for itself — no lengthy descriptions needed."
+
+**QA (Taylor):** "We need to handle narrow terminals gracefully in the picker. If terminal is too narrow to show three doors side-by-side, show them vertically or one at a time."
+
+#### Settings View
+
+**Consensus: Add a theme selection option to the settings/preferences area.**
+
+- Accessible via `:theme` command or a settings menu item
+- Same preview experience as onboarding
+- Change takes effect immediately (no restart required)
+- Current theme highlighted in the picker
+
+**Dev (Sam):** "The DoorsView already re-renders on every Update cycle. Swapping the theme slice is instant — just reassign `dv.themes` and the next View() call picks it up."
+
+#### Config.yaml Support
+
+**Consensus: Theme preference persisted in config.yaml.**
+
+```yaml
+# ~/.threedoors/config.yaml
+theme: modern  # Options: classic, modern, scifi, shoji
+```
+
+- Theme name is a simple string key, not a path or struct
+- Invalid theme name falls back to "modern" with a warning logged
+- Config file is the source of truth; settings view writes to config
+- Each door in the trio uses the same theme (not mix-and-match for v1)
+
+**Architect (Alex):** "Same theme for all three doors in v1. Mix-and-match is a future enhancement. It complicates the picker UX and the config schema."
+
+**PM (Pat):** "Agreed. Single theme selection keeps the mental model simple. 'Pick your door style' is clearer than 'assign a style to each door.'"
+
+---
+
+### 3. Architecture Decisions
+
+#### DoorTheme Struct
+
+**Consensus: Adopt the research doc's proposed struct with minor refinements.**
+
+```go
+// DoorTheme defines the visual frame for a door.
+type DoorTheme struct {
+    Name        string
+    Description string  // Short description for picker UI
+    Render      func(content string, width, height int, selected bool) string
+    Colors      ThemeColors
+    MinWidth    int  // Minimum terminal width for this theme; below this, fall back to classic
+}
+
+type ThemeColors struct {
+    Frame    lipgloss.Color
+    Fill     lipgloss.Color
+    Accent   lipgloss.Color
+    Selected lipgloss.Color
+}
+```
+
+**Architect (Alex):** "Adding `MinWidth` to the struct lets each theme declare its own minimum. The DoorsView checks terminal width against the active theme's MinWidth and falls back to classic rendering if too narrow."
+
+**Dev (Sam):** "`Description` is needed for the picker UI — one line like 'Clean lines, minimal ornamentation' displayed below the preview."
+
+#### Theme Registry
+
+```go
+// Registry is a simple map, not a plugin system.
+var Registry = map[string]DoorTheme{
+    "classic": ClassicTheme,
+    "modern":  ModernTheme,
+    "scifi":   SciFiTheme,
+    "shoji":   ShojiTheme,
+}
+
+// DefaultTheme is used when no theme is configured or the configured theme is invalid.
+const DefaultThemeName = "modern"
+```
+
+**Architect (Alex):** "A map keyed by name is simpler than a slice. Lookup by config string is O(1). Registration is explicit — no reflection, no init() functions."
+
+**Dev (Sam):** "The registry lives in `internal/tui/themes/registry.go`. Each theme file registers itself by being included in the map literal. No runtime registration needed for v1."
+
+#### File Organization
+
+```
+internal/tui/themes/
+    theme.go       // DoorTheme, ThemeColors types
+    registry.go    // Registry map, DefaultThemeName, lookup helper
+    classic.go     // Classic (current Lipgloss borders, wrapped as a DoorTheme)
+    modern.go      // Modern / Minimalist
+    scifi.go       // Sci-Fi / Spaceship
+    shoji.go       // Japanese Shoji
+```
+
+**Architect (Alex):** "The `classic.go` theme wraps the existing Lipgloss border rendering as a DoorTheme. This means the current rendering path is preserved as a theme option, not deleted."
+
+#### Integration with DoorsView
+
+**Dev (Sam):** "The change to `doors_view.go` is minimal:"
+
+```go
+// In DoorsView struct, add:
+theme themes.DoorTheme
+
+// In View(), replace:
+// style := doorStyle.Width(doorWidth)
+// renderedDoors = append(renderedDoors, style.Render(content))
+// With:
+renderedDoors = append(renderedDoors, dv.theme.Render(content, doorWidth, doorHeight, i == dv.selectedDoor))
+```
+
+"The theme is loaded from config at DoorsView initialization. The `:theme` command swaps it at runtime."
+
+---
+
+### 4. Testing Strategy
+
+**Consensus: Golden file tests are the primary strategy, with width boundary tests as secondary.**
+
+#### Golden File Tests
+
+- Each theme gets a golden file test: render at 28-char width and 40-char width, compare output
+- Golden files stored in `internal/tui/themes/testdata/`
+- Use the project's existing golden test infrastructure (`golden_test.go` pattern)
+- Test both selected and unselected states
+
+**QA (Taylor):** "Golden files catch visual regressions instantly. If someone changes a box-drawing character, the diff is obvious. Run `go test ./internal/tui/themes/ -update` to regenerate."
+
+#### Width Boundary Tests
+
+- Test each theme at its declared `MinWidth` — should render correctly
+- Test at `MinWidth - 1` — should indicate fallback needed
+- Test at very wide terminal (120+ chars) — should scale gracefully
+
+#### Content Wrapping Tests
+
+- Test with short task text (1 line), medium (2-3 lines), and long (5+ lines that need wrapping)
+- Verify word wrapping works correctly within each theme's content area
+
+#### Cross-Terminal Testing (Manual)
+
+- Pre-release: manual verification across iTerm2, Terminal.app, Alacritty
+- Screenshot comparison (not automated for v1)
+- Document which themes work in which terminals
+
+**QA (Taylor):** "We should add a `vhs` tape (Charm's terminal recorder) for each theme as part of the docs. Serves as both documentation and visual regression reference."
+
+**Dev (Sam):** "VHS tapes are a nice-to-have for v1.1. For v1, golden files + manual terminal checks are sufficient."
+
+---
+
+### 5. Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| v1 themes | Modern, Sci-Fi, Shoji + Classic (fallback) | Maximum contrast, minimum rendering risk |
+| Theme application | Same theme for all 3 doors | Simpler UX and config; mix-and-match deferred |
+| Persistence | config.yaml string key | Simple, human-readable, consistent with existing config pattern |
+| Default theme | Modern / Minimalist | Cleanest rendering, lowest risk, welcoming aesthetic |
+| Per-door colors | Theme colors override per-door colors | ThemeColors struct takes precedence; classic mode preserves existing colors |
+| Door number labels | Overlaid separately, not part of theme frame | Functional UI stays consistent across themes |
+| Theme preview | Settings view + onboarding picker | Same component, reused in both contexts |
+| Seasonal variants | Deferred | Fun but scope creep |
+| Mix-and-match doors | Deferred | Per-door theme assignment is a future enhancement |
+
+---
+
+### 6. Risks Identified
+
+1. **Scope creep temptation** — Themes are inherently fun to design. Risk of spending too much time on visual polish vs. shipping. Mitigated by hard cap of 3 themes for v1.
+2. **Width calculation bugs** — Manual frame drawing requires precise width math. Off-by-one errors will be visible. Mitigated by golden file tests at multiple widths.
+3. **Lipgloss interaction** — Themes bypass `Border()` but still use `lipgloss.Width()` for measurement. ANSI escape codes in styled text can confuse width calculations. Mitigated by using `lipgloss.Width()` consistently.
+
+---
+
+### 7. Recommended Epic Structure
+
+**Epic 17: Door Theme System**
+
+| Story | Title | Effort |
+|-------|-------|--------|
+| 17.1 | Theme types, registry, and classic theme wrapper | S |
+| 17.2 | Modern, Sci-Fi, and Shoji theme implementations | M |
+| 17.3 | DoorsView integration — load theme from config, apply in View() | S |
+| 17.4 | Theme picker in onboarding flow | M |
+| 17.5 | Settings view — `:theme` command with preview | M |
+| 17.6 | Golden file tests for all themes | S |
+
+**Total estimated effort:** 2-3 weeks at 2-4 hrs/week
+
+---
+
+*Party mode discussion conducted as part of the BMAD methodology multi-agent workflow.*

--- a/docs/research/door-themes-research.md
+++ b/docs/research/door-themes-research.md
@@ -1,0 +1,430 @@
+# Door Theme System Research
+
+**Date:** 2026-03-03
+**Status:** Research / Exploration
+**Author:** Engineering
+
+---
+
+## 1. Current State
+
+### How Doors Are Rendered Today
+
+The three doors are rendered in `internal/tui/doors_view.go` using Lipgloss bordered boxes. Each door is a rectangle created by applying a `lipgloss.Style` with a border, padding, and a computed width.
+
+**Key styles from `internal/tui/styles.go`:**
+
+```go
+doorStyle = lipgloss.NewStyle().
+    Border(lipgloss.RoundedBorder()).
+    BorderForeground(colorAccent).
+    Padding(1, 2)
+
+selectedDoorStyle = lipgloss.NewStyle().
+    Border(lipgloss.ThickBorder()).
+    BorderForeground(colorDoorBright).
+    Padding(1, 2)
+```
+
+**Per-door colors** are applied when terminal width >= 60 characters:
+- Door 0 (left): cyan (`86`)
+- Door 1 (center): magenta (`212`)
+- Door 2 (right): yellow (`220`)
+
+**Content inside each door** is assembled as:
+1. Status indicator (e.g., `[todo]`) in the status color
+2. Task text
+3. Source provider badge (if applicable)
+4. Category badges (type icon, effort, location)
+5. Avoidance indicator (if bypassed 5+ times)
+
+The three rendered door strings are joined horizontally with `lipgloss.JoinHorizontal(lipgloss.Top, ...)`.
+
+**Current visual result** is three rounded-corner boxes side by side, differentiated only by border color. They are functional but visually uniform -- there is no "door" identity or personality.
+
+---
+
+## 2. Theme Concept
+
+### What a Theme System Could Look Like
+
+The idea is to make each door visually distinct -- not just by color, but by shape, ornamentation, and character. Instead of three identical rounded boxes, each door would have its own ASCII/ANSI art frame that evokes a different style of door.
+
+### Architectural Approach
+
+A theme in this context is a function (or struct) that knows how to render a door frame around arbitrary content. The simplest viable design:
+
+```go
+// DoorTheme defines the visual frame for a door.
+type DoorTheme struct {
+    Name   string
+    Render func(content string, width int, selected bool) string
+}
+```
+
+A theme registry would hold available themes:
+
+```go
+var DefaultThemes = []DoorTheme{
+    ClassicWoodenDoor,
+    CastleDoor,
+    SciFiDoor,
+    // ...
+}
+```
+
+At session start, three themes are randomly selected (or the user picks a theme set). Each door in the trio gets a different theme, making them visually distinct.
+
+This keeps things simple -- no interface hierarchies, no abstract factories. Just a slice of render functions.
+
+### Integration Point
+
+In `DoorsView.View()`, the current code:
+
+```go
+style := doorStyle.Width(doorWidth)
+renderedDoors = append(renderedDoors, style.Render(content))
+```
+
+Would become:
+
+```go
+theme := dv.themes[i]
+renderedDoors = append(renderedDoors, theme.Render(content, doorWidth, i == dv.selectedDoorIndex))
+```
+
+---
+
+## 3. ANSI Mockups
+
+All mockups are designed for a roughly 28-character-wide, 12-15-character-tall frame. Task text is shown inside or beneath the door.
+
+### 3.1 Classic Wooden Door
+
+A simple rectangular door with a panel and round doorknob.
+
+```
+    ┌──────────────────────┐
+    │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+    │▒┌──────────────────┐▒│
+    │▒│                  │▒│
+    │▒│  Fix login bug   │▒│
+    │▒│                  │▒│
+    │▒└──────────────────┘▒│
+    │▒                    ▒│
+    │▒        ┌──┐        ▒│
+    │▒        │◉ │        ▒│
+    │▒        └──┘        ▒│
+    │▒                    ▒│
+    │▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
+    └──────────────────────┘
+```
+
+**Lipgloss approach:** Custom border using box-drawing characters. The `▒` fill simulates wood grain. Content is placed in the upper panel area. The doorknob (`◉`) is decorative.
+
+### 3.2 Castle / Medieval Door
+
+An arched top with iron studs and heavy stone frame.
+
+```
+          ╭──────────╮
+        ╭─╯            ╰─╮
+      ╭─╯                ╰─╮
+    ┌─╯                    ╰─┐
+    │ ◆                    ◆ │
+    │                        │
+    │   Update API docs      │
+    │                        │
+    │ ◆        ⚒         ◆ │
+    │                        │
+    │ ◆                    ◆ │
+    │                        │
+    │ ◆                    ◆ │
+    ╞════════════════════════╡
+    └────────────────────────┘
+```
+
+**Notes:** The arch is drawn with curved box-drawing characters (`╭╮╰╯`). Iron studs are `◆` diamonds placed symmetrically. The heavy bottom rail uses double-line characters (`═`). The forged iron hinge symbol `⚒` adds character.
+
+### 3.3 Modern / Minimalist Door
+
+Clean lines, generous whitespace, understated elegance.
+
+```
+    ─────────────────────────
+    │                       │
+    │                       │
+    │                       │
+    │   Write unit tests    │
+    │                       │
+    │                       │
+    │                   ●   │
+    │                       │
+    │                       │
+    │                       │
+    ─────────────────────────
+```
+
+**Notes:** No rounded corners, no ornamentation. Single thin lines. The doorknob is a minimal filled circle (`●`) placed asymmetrically to the right side. This theme relies on negative space. Border color alone provides personality.
+
+### 3.4 Sci-Fi / Spaceship Door
+
+Mechanical panels, rivets, and a sliding-door aesthetic.
+
+```
+    ╔══╤════════════════╤══╗
+    ║░░│                │░░║
+    ║░░│                │░░║
+    ║░░│  Deploy to     │░░║
+    ║░░│  staging       │░░║
+    ║░░│                │░░║
+    ╠══╪════════════════╪══╣
+    ║▓▓│ ◈  ◈      ◈  ◈│▓▓║
+    ║░░│                │░░║
+    ║░░│   [ACCESS]     │░░║
+    ║░░│                │░░║
+    ╚══╧════════════════╧══╝
+```
+
+**Notes:** Double-line outer frame (`╔╗╚╝═║`) for a heavy industrial feel. Side rails use shade characters (`░▓`). Interior divided into upper content panel and lower control panel with rivets (`◈`). The `[ACCESS]` label is a decorative touch suggesting an airlock or console. Mid-bar uses `╠╣╪` cross characters.
+
+### 3.5 Saloon / Western Doors
+
+Swinging half-doors with slatted panels, showing the task "over the top."
+
+```
+           Review PR #42
+
+    ╱│╲                ╱│╲
+    ┌┤├────────────────┤├┐
+    │╞╡                ╞╡│
+    │├┤  ═══════════   ├┤│
+    │╞╡  ═══════════   ╞╡│
+    │├┤  ═══════════   ├┤│
+    │╞╡  ═══════════   ╞╡│
+    │├┤                ├┤│
+    │╞╡     ◎         ╞╡│
+    └┤├────────────────┤├┘
+```
+
+**Notes:** The swinging-door hinge brackets (`╱│╲`) sit at the top. Horizontal slats are drawn with `═` lines. The push-plate is `◎`. Task text is displayed above the doors (since saloon doors are short). Side hinges use alternating `├┤` and `╞╡` for a barrel-hinge look.
+
+### 3.6 Vault / Safe Door
+
+A heavy circular handle on a thick steel door.
+
+```
+    ╔════════════════════════╗
+    ║ ┌────────────────────┐ ║
+    ║ │                    │ ║
+    ║ │  Backup database   │ ║
+    ║ │                    │ ║
+    ║ │      ╭────╮        │ ║
+    ║ │      │ ╳╳ │        │ ║
+    ║ │      ╰────╯        │ ║
+    ║ │                    │ ║
+    ║ └────────────────────┘ ║
+    ║ ▪ ▪ ▪ ▪ ▪ ▪ ▪ ▪ ▪ ▪  ║
+    ╚════════════════════════╝
+```
+
+**Notes:** Double-line outer frame for the thick vault wall. Inner recessed panel uses single lines. The circular handle is drawn with curved box characters and `╳` crosshatch for the locking mechanism. Bottom row of rivets (`▪`) reinforces the heavy steel look. The double-border gap between inner and outer frames creates a sense of depth/thickness.
+
+### 3.7 Japanese Shoji Door
+
+A sliding screen with a lattice grid pattern.
+
+```
+    ┬──┬──┬──┬──┬──┬──┬──┬
+    │  │  │  │  │  │  │  │
+    ├──┼──┼──┼──┼──┼──┼──┤
+    │  │  │  │  │  │  │  │
+    ├──┼──┼──┼──┼──┼──┼──┤
+    │  │ Clean up   │  │  │
+    │  │ backlog    │  │  │
+    ├──┼──┼──┼──┼──┼──┼──┤
+    │  │  │  │  │  │  │  │
+    ├──┼──┼──┼──┼──┼──┼──┤
+    │  │  │  │  │  │  │  │
+    ┴──┴──┴──┴──┴──┴──┴──┴
+```
+
+**Notes:** The grid pattern uses `┼` cross junctions and `─│` lines to simulate the wooden lattice of a shoji screen. Task text overlays the central cells, as if written on the paper pane. Top and bottom use `┬` and `┴` for the frame rail. No doorknob -- shoji doors slide. The regularity of the grid is the visual signature.
+
+### 3.8 Garden Gate
+
+A wrought-iron garden gate with decorative scrollwork.
+
+```
+         ◠◡◠◡◠◡◠◡◠◡◠
+    ┌────╫──────────╫────┐
+    │    ║          ║    │
+    │  ╔═╩══════════╩═╗  │
+    │  ║              ║  │
+    │  ║ Prune old    ║  │
+    │  ║ branches     ║  │
+    │  ║              ║  │
+    │  ╚══════════════╝  │
+    │    │  │    │  │    │
+    │    │  │    │  │    │
+    │    │  │    │  │    │
+    └────┴──┴────┴──┴────┘
+```
+
+**Notes:** Decorative scrollwork at the top using `◠◡` wave characters. Double-line inner frame for the ornate ironwork feel. Vertical bars at the bottom simulate gate pickets. The content sits in the upper panel section, as if on a sign hanging on the gate.
+
+---
+
+## 4. Implementation Notes
+
+### 4.1 Theme as a Render Function
+
+Each theme is a function that takes content and dimensions and returns a fully rendered string. No Lipgloss `Border()` is used -- the theme draws its own frame character by character.
+
+```go
+type DoorTheme struct {
+    Name     string
+    Render   func(content string, width, height int, selected bool) string
+    // Colors holds the palette for this theme
+    Colors   ThemeColors
+}
+
+type ThemeColors struct {
+    Frame    lipgloss.Color
+    Fill     lipgloss.Color
+    Accent   lipgloss.Color
+    Selected lipgloss.Color
+}
+```
+
+### 4.2 Interaction with Lipgloss
+
+Lipgloss is still used for:
+- **Color application:** `lipgloss.NewStyle().Foreground(color).Render(char)` for coloring individual frame characters
+- **Text styling:** Bold, italic, faint for content inside the door
+- **Horizontal joining:** `lipgloss.JoinHorizontal()` to lay out the three doors side by side
+- **Width measurement:** `lipgloss.Width()` to measure rendered string widths accounting for ANSI escape codes
+
+Lipgloss is NOT used for:
+- Border drawing (themes handle this manually)
+- Padding (themes control internal spacing)
+
+### 4.3 Content Wrapping
+
+Task text needs to be word-wrapped to fit inside the theme's content area. The content area width varies by theme (some have thicker frames than others). Use `lipgloss.NewStyle().Width(innerWidth).Render(text)` for word wrapping, or a manual word-wrap function.
+
+### 4.4 Selection Mode
+
+When a door is selected (highlighted), themes should have a "selected" variant. Options:
+- Brighten or change the frame color
+- Add a glow effect (extra layer of characters around the frame)
+- Bold the frame characters
+- Add a pointer/cursor indicator (`>>` or `▶`) beside the door
+
+The simplest approach: each theme's `Render` function receives a `selected bool` and adjusts colors accordingly.
+
+### 4.5 Theme Assignment Strategy
+
+Three options, from simplest to most complex:
+
+1. **Random per session:** At session start, randomly pick 3 themes from the pool. Each door gets a different theme. Themes persist for the session.
+
+2. **User-selectable theme set:** A config option like `theme: medieval` that picks a cohesive set of three door variants. This requires designing variant sets rather than mix-and-match.
+
+3. **Category-driven:** Map task types to door themes (creative tasks get the garden gate, technical tasks get the sci-fi door, etc.). Visually reinforces task categories.
+
+**Recommendation:** Start with option 1 (random per session). It is the simplest, requires no config, and provides visual variety. Option 3 is the most interesting but couples visual design to domain logic.
+
+### 4.6 Width Adaptation
+
+Themes need to handle varying terminal widths. Each theme should define:
+- A minimum width (below which it falls back to a simple bordered box)
+- A target width (where it looks best)
+- How to scale: some themes (shoji grid) scale by adding/removing grid cells; others (vault door) scale by adjusting internal padding
+
+### 4.7 File Organization
+
+```
+internal/tui/
+    themes/
+        theme.go          // DoorTheme type, ThemeColors, registry
+        classic.go        // Classic wooden door
+        castle.go         // Medieval door
+        modern.go         // Minimalist door
+        scifi.go          // Spaceship door
+        saloon.go         // Western swinging doors
+        vault.go          // Safe door
+        shoji.go          // Japanese screen
+        garden.go         // Garden gate
+```
+
+Each file is small (one render function, one color set). The `theme.go` file defines the type and the registry slice.
+
+---
+
+## 5. Feasibility Assessment
+
+### What Works Well in Terminals
+
+**Box-drawing characters** (`─│┌┐└┘├┤┬┴┼` and double-line variants `═║╔╗╚╝`) render consistently across modern terminal emulators (iTerm2, Alacritty, kitty, Windows Terminal, GNOME Terminal). These are the backbone of all the mockups above and are highly reliable.
+
+**Block/shade elements** (`░▒▓█`) work well for fill patterns. They render at consistent widths and are good for simulating textures (wood grain, metal panels).
+
+**Geometric shapes** (`●○◉◎◆◇▪▫▸▶`) are well-supported and useful for doorknobs, rivets, studs, and decorative elements.
+
+**Curved box-drawing** (`╭╮╰╯`) is supported in most modern terminals. These enable arched tops (castle door) and rounded handles (vault door).
+
+**Color via ANSI 256-color palette** is universally supported. Lipgloss handles this cleanly. Coloring frame characters adds significant visual impact with minimal code complexity.
+
+### What Is Risky
+
+**Unicode decorative characters** (`◠◡` waves, `⚒` tools, `╳` crosses) have inconsistent widths across fonts and terminals. Some monospace fonts render these as double-width, which breaks alignment. These should be used sparingly and tested.
+
+**Emoji** in frame elements should be avoided entirely. Emoji widths are notoriously inconsistent (some terminals render as 1 cell, others as 2). The existing emoji in task type icons (`typeIcon()`) already carries this risk for content, but it should not spread to frame rendering.
+
+**Complex multi-line art** that depends on exact character alignment is fragile. If any single character in the frame renders at an unexpected width, the entire door collapses visually. Themes should be tested across at least: iTerm2, Terminal.app, Alacritty, and one Linux terminal.
+
+**True color (24-bit)** works in most modern terminals but not all. Sticking to the 256-color palette (which Lipgloss `Color("123")` uses) is safer.
+
+### Theme-by-Theme Feasibility
+
+| Theme | Feasibility | Risk | Notes |
+|-------|------------|------|-------|
+| Classic Wooden | High | Low | Uses only basic box-drawing + `▒` fill |
+| Castle / Medieval | Medium | Medium | Arch requires `╭╮╰╯` curves; `◆` studs may vary |
+| Modern / Minimalist | High | Low | Simplest theme; just lines and `●` |
+| Sci-Fi / Spaceship | High | Low | Double-line box-drawing is universal; `◈` is the only risk |
+| Saloon / Western | Medium | Medium | Complex hinge brackets; horizontal slats need precise alignment |
+| Vault / Safe | High | Low | Standard box-drawing; `╳` inside handle is minor risk |
+| Japanese Shoji | High | Low | Pure grid of `┼─│` characters; very reliable |
+| Garden Gate | Medium | Medium | `◠◡` wave characters are highest risk; pickets are fine |
+
+### Recommended Starting Set
+
+For a first implementation, start with the three highest-feasibility themes that also provide the most visual contrast:
+
+1. **Modern / Minimalist** -- clean, reliable baseline
+2. **Sci-Fi / Spaceship** -- heavy double-line frame, strong visual identity
+3. **Japanese Shoji** -- grid pattern is unique and uses only basic box-drawing
+
+This trio covers three very different visual aesthetics while using only well-supported Unicode characters.
+
+### Performance Considerations
+
+Rendering custom frames is string manipulation -- no I/O, no computation. Even the most complex theme adds microseconds to render time. This is not a concern for a TUI that redraws on keypress events.
+
+### Testing Strategy
+
+- **Golden file tests:** Render each theme at known widths and compare output against golden files (the project already has `golden_test.go` infrastructure).
+- **Width boundary tests:** Verify themes degrade gracefully at minimum widths.
+- **Terminal screenshot tests:** Manual verification across terminal emulators for the initial release. Automated screenshot testing (e.g., with `vhs` from Charm) could follow.
+
+---
+
+## 6. Open Questions
+
+1. Should themes persist across sessions (saved in user config) or re-randomize each time?
+2. Should the door number label (Door 1, 2, 3) be part of the theme frame or overlaid separately?
+3. Do we want a "theme preview" command that shows all available themes?
+4. Should themes have seasonal variants (spooky doors in October, festive doors in December)?
+5. How do themes interact with the existing per-door color system? Replace it, or layer on top?


### PR DESCRIPTION
## Summary

- **Analyst review** of door theme research (PR #116): assessed feasibility, ranked themes by practicality, confirmed product fit alignment
- **Party mode discussion**: multi-agent consensus on v1 themes (Modern, Sci-Fi, Shoji + Classic fallback), architecture (DoorTheme struct, registry, render functions), UX (onboarding picker, `:theme` command, config.yaml), and testing strategy (golden files)
- **Product brief updated**: door themes added as Phase 2 near-term feature with onboarding picker, settings view, and config.yaml support
- **PRD updated**:
  - FR55-FR62: theme registry, three themes, onboarding picker, settings command, config persistence, width fallback, door label overlay
  - NFR17-NFR19: Unicode character ranges, render performance (<1ms), golden file test coverage
  - Epic 17: Door Theme System (6 stories: types/registry, implementations, DoorsView integration, onboarding picker, settings command, golden file tests)
  - Product scope and story count table updated

## New Files

- `docs/research/door-themes-analyst-review.md` — feasibility assessment, theme ranking, product fit analysis
- `docs/research/door-themes-party-mode.md` — multi-agent discussion on implementation, architecture, testing

## Modified Files

- `docs/brief.md` — added door themes to Phase 2 features
- `docs/prd/requirements.md` — FR55-FR62, NFR17-NFR19
- `docs/prd/epic-list.md` — Epic 17, updated story count
- `docs/prd/epic-details.md` — Stories 17.1-17.6 with acceptance criteria
- `docs/prd/product-scope.md` — door themes in Phase 2 scope

## Dependencies

- Builds on PR #116 (door theme research with ANSI mockups)
- Epic 17 depends on Epic 3 (complete) and optionally Epic 10 (onboarding) for the theme picker step

## Opportunities Noted

- Classic Wooden and Vault themes are strong v1.1 candidates (low risk, just need testing)
- Community-contributed themes could be supported via the registry pattern
- VHS tape (Charm terminal recorder) screenshots for theme documentation

## Test plan

- [x] No code changes — documentation only
- [x] Existing tests unaffected