### PR TITLE
docs: Story files for Epic 17 — Door Theme System (17.1-17.6)

### DIFF
--- a/docs/stories/17.1.story.md
+++ b/docs/stories/17.1.story.md
@@ -1,0 +1,66 @@
+# Story 17.1: Theme Types, Registry, and Classic Theme Wrapper
+
+**Status:** draft
+**Epic:** 17 — Door Theme System
+**Blocks:** Stories 17.2, 17.3, 17.4, 17.5, 17.6
+
+## User Story
+
+As a developer,
+I want a DoorTheme type, ThemeColors struct, theme registry, and a Classic theme that wraps the current rendering,
+So that the theme infrastructure is in place and existing behavior is preserved as a theme option.
+
+## Acceptance Criteria
+
+**Given** the TUI currently renders doors with a single Lipgloss border style
+**When** the theme infrastructure is created
+**Then:**
+
+- AC1: `DoorTheme` struct defined in `internal/tui/themes/theme.go` with fields: Name (`string`), Description (`string`), Render function (`func(content string, width int, selected bool) string`), Colors (`ThemeColors`), MinWidth (`int`)
+- AC2: `ThemeColors` struct defined with Frame, Fill, Accent, Selected fields (all `lipgloss.Color`)
+- AC3: Theme registry in `internal/tui/themes/registry.go` as `map[string]DoorTheme` with `Get(name string) (DoorTheme, bool)` lookup helper
+- AC4: `DefaultThemeName` constant set to `"modern"`
+- AC5: Classic theme in `internal/tui/themes/classic.go` that wraps the current Lipgloss `doorStyle`/`selectedDoorStyle` rendering
+- AC6: Classic theme produces output identical to current door rendering (verified by test)
+- AC7: Unit tests for registry lookup (found, not-found) and Classic theme render output
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- The `DoorTheme.Render` function signature follows the pattern from the party-mode architecture discussion: `func(content string, width int, selected bool) string`
+- Classic theme wraps the existing `doorStyle` / `selectedDoorStyle` from `internal/tui/doors_view.go` — extract current style constants rather than duplicating
+- Registry uses a simple `map[string]DoorTheme` — no sync needed since themes are registered at init time and read-only thereafter
+- Accept interfaces, return concrete types: `NewClassicTheme() *DoorTheme` not `NewClassicTheme() ThemeInterface`
+- No `init()` functions — register themes explicitly in a `RegisterAll()` or via factory calls from `main()`
+- Reference: `docs/research/door-themes-analyst-review.md`, `docs/research/door-themes-party-mode.md`
+
+## Dependencies
+
+- None — this is the foundation story for Epic 17
+
+## Tasks
+
+1. Create `internal/tui/themes/` package directory
+2. Define `ThemeColors` and `DoorTheme` structs in `theme.go`
+3. Implement registry with `Get()` and `Register()` in `registry.go`
+4. Extract current door rendering logic into Classic theme in `classic.go`
+5. Write unit tests for registry and Classic theme in `registry_test.go` and `classic_test.go`
+6. Verify all quality gates pass
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] Classic theme output matches current door rendering exactly
+- [ ] No `init()` functions used
+- [ ] Timestamps use `time.Now().UTC()` if any time operations needed

--- a/docs/stories/17.2.story.md
+++ b/docs/stories/17.2.story.md
@@ -1,0 +1,72 @@
+# Story 17.2: Modern, Sci-Fi, and Shoji Theme Implementations
+
+**Status:** draft
+**Epic:** 17 — Door Theme System
+**Depends on:** Story 17.1
+**Blocks:** Stories 17.3, 17.6
+
+## User Story
+
+As a user,
+I want three visually distinct door themes to choose from,
+So that my Three Doors interface has personality and visual variety.
+
+## Acceptance Criteria
+
+**Given** the theme infrastructure from Story 17.1 is in place
+**When** the three v1 themes are implemented
+**Then:**
+
+- AC1: Modern/Minimalist theme (`modern.go`): clean single-line box-drawing frame (`─│┌┐└┘`), minimal `●` doorknob, generous whitespace around content
+- AC2: Sci-Fi/Spaceship theme (`scifi.go`): double-line outer frame (`╔╗╚╝═║`), side rails with `░▓` shade blocks, upper content panel + lower control panel aesthetic
+- AC3: Japanese Shoji theme (`shoji.go`): grid pattern using `┼─│┬┴├┤` characters, task text overlaid on central cells of the lattice
+- AC4: All themes render correctly at widths from their declared MinWidth up to 60+ characters
+- AC5: All themes handle the `selected` flag by adjusting frame colors via `ThemeColors.Selected`
+- AC6: All themes word-wrap content text to fit within their interior content area
+- AC7: Only Unicode characters from box-drawing (`U+2500–U+257F`), block elements (`U+2580–U+259F`), and geometric shapes (`U+25A0–U+25FF`) ranges used (NFR17)
+- AC8: Each theme registered in the theme registry with a unique name key
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- Each theme is a single file in `internal/tui/themes/` — one primary type per file
+- Render functions are pure: `(content string, width int, selected bool) → string` — no I/O, no side effects
+- Use `fmt.Fprintf` with `strings.Builder` for efficient string construction — never `WriteString` + `Sprintf`
+- Width calculation must account for Unicode character widths — box-drawing characters are single-width in all target terminals
+- Content word-wrapping should use Lipgloss `wordwrap` or a simple width-aware split — avoid pulling in external dependencies
+- Performance target: render must complete within 1ms for standard widths (NFR18) — pure string manipulation, this is trivially achieved
+- Theme feasibility tiers from analyst review: Modern (Tier 1, lowest risk), Sci-Fi (Tier 1, `◈` rivet is only risk), Shoji (Tier 1, zero rendering risk)
+- Reference mockups in `docs/research/door-themes-research.md` (PR #116)
+
+## Dependencies
+
+- **Story 17.1** — `DoorTheme`, `ThemeColors`, registry must exist
+
+## Tasks
+
+1. Implement Modern/Minimalist theme in `modern.go` with render function
+2. Implement Sci-Fi/Spaceship theme in `scifi.go` with render function
+3. Implement Japanese Shoji theme in `shoji.go` with render function
+4. Register all three themes in the registry
+5. Write unit tests for each theme: render at MinWidth, standard width (40), wide (60+)
+6. Verify Unicode characters are within allowed ranges
+7. Verify all quality gates pass
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] All Unicode characters within NFR17 ranges
+- [ ] Each theme renders correctly at MinWidth and standard widths
+- [ ] Content word-wrapping works for short (1 line) and long (5+ lines) text
+- [ ] No external dependencies added

--- a/docs/stories/17.3.story.md
+++ b/docs/stories/17.3.story.md
@@ -1,0 +1,73 @@
+# Story 17.3: DoorsView Integration — Load Theme from Config
+
+**Status:** draft
+**Epic:** 17 — Door Theme System
+**Depends on:** Stories 17.1, 17.2
+**Blocks:** Stories 17.4, 17.5
+
+## User Story
+
+As a user,
+I want my selected door theme applied to the Three Doors display,
+So that the doors render with my chosen visual style.
+
+## Acceptance Criteria
+
+**Given** themes are registered in the theme registry (Stories 17.1, 17.2)
+**When** the DoorsView is initialized and rendered
+**Then:**
+
+- AC1: `DoorsView` struct gains a `theme themes.DoorTheme` field
+- AC2: Theme loaded from `config.yaml` `theme` key at DoorsView initialization
+- AC3: `View()` method uses `theme.Render(content, width, selected)` instead of `doorStyle.Render()`
+- AC4: Invalid or missing theme config falls back to `DefaultThemeName` ("modern") with warning logged
+- AC5: Terminal width checked against `theme.MinWidth`; falls back to Classic theme when too narrow (FR61)
+- AC6: Existing per-door color system replaced by theme's `ThemeColors` when a non-classic theme is active
+- AC7: Door number labels overlaid consistently regardless of active theme (FR62)
+- AC8: All existing TUI tests continue to pass — no regressions
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- The integration point is `DoorsView.View()` in `internal/tui/doors_view.go` — replace `doorStyle.Render(content)` calls with `theme.Render(content, doorWidth, isSelected)`
+- Config loading: the project uses `config.yaml` at `~/.threedoors/config.yaml` — add `Theme string` field to the config struct
+- Width-aware fallback: check `termWidth / 3` (per-door width) against `theme.MinWidth` — if too narrow, swap to Classic theme for that render cycle
+- Door number labels: currently rendered inside the door content — ensure themes leave space or overlay consistently
+- The `View()` method must remain fast — theme `Render()` is a pure function, no I/O
+- Keep `Update()` fast — theme lookup happens once at init, not per-keypress
+- Use `tea.Cmd` if config loading needs async I/O
+
+## Dependencies
+
+- **Story 17.1** — theme types and registry
+- **Story 17.2** — Modern, Sci-Fi, Shoji themes registered
+
+## Tasks
+
+1. Add `Theme string` field to config struct and YAML binding
+2. Add `theme themes.DoorTheme` field to `DoorsView` struct
+3. Load theme from config at `DoorsView` initialization with fallback logic
+4. Replace `doorStyle.Render()` calls in `View()` with `theme.Render()`
+5. Implement width-aware Classic fallback in `View()`
+6. Ensure door number labels render correctly with all themes
+7. Update existing TUI tests to verify no regressions
+8. Verify all quality gates pass
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass including existing TUI tests
+- [ ] `go test -race ./...` — no race conditions
+- [ ] Invalid theme name in config falls back gracefully
+- [ ] Missing theme key in config falls back gracefully
+- [ ] Narrow terminal triggers Classic fallback
+- [ ] Door labels visible and consistent across all themes

--- a/docs/stories/17.4.story.md
+++ b/docs/stories/17.4.story.md
@@ -1,0 +1,73 @@
+# Story 17.4: Theme Picker in Onboarding Flow
+
+**Status:** draft
+**Epic:** 17 — Door Theme System
+**Depends on:** Story 17.3 (DoorsView integration), Epic 10 (onboarding infrastructure — can stub if not yet implemented)
+**Blocks:** Story 17.5
+
+## User Story
+
+As a new user,
+I want to browse and select a door theme during first-run onboarding,
+So that I can personalize my Three Doors experience from the start.
+
+## Acceptance Criteria
+
+**Given** the onboarding flow exists (Epic 10) and themes are integrated into DoorsView (Story 17.3)
+**When** a new user goes through first-run onboarding
+**Then:**
+
+- AC1: Theme picker step added to the first-run onboarding flow (after values/goals, before key bindings walkthrough)
+- AC2: Picker displays doors rendered with each available theme in a horizontal preview (FR57)
+- AC3: Left/right arrow keys browse between themes; current theme name and description shown below the preview
+- AC4: Enter confirms selection; Escape or "Skip" defaults to Modern/Minimalist
+- AC5: Selected theme written to `config.yaml` immediately upon confirmation (FR59)
+- AC6: Picker handles narrow terminals gracefully — vertical layout or one-at-a-time display when horizontal preview doesn't fit
+- AC7: Theme picker is a reusable Bubbletea component (shared with Story 17.5 `:theme` command)
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- Theme picker should be implemented as a standalone Bubbletea `Model` in `internal/tui/theme_picker.go` so it can be embedded in both the onboarding flow and the `:theme` command
+- The picker model needs: `themes []DoorTheme`, `cursor int`, `selected string` fields
+- Horizontal preview: render 3 doors side-by-side using the current cursor theme — reuse the same `DoorTheme.Render()` function
+- Width detection: if terminal width < `3 * theme.MinWidth + padding`, switch to single-door preview with left/right navigation
+- If Epic 10 onboarding is not yet implemented, create the picker component and add a TODO/stub for integration point
+- All user-visible output through Bubbletea `View()` — never `fmt.Println`
+- Use Lipgloss for any additional styling (header text, instructions, borders)
+- Config write uses the existing config persistence mechanism — atomic write (write to `.tmp`, sync, rename)
+
+## Dependencies
+
+- **Story 17.3** — DoorsView integration (themes work in the main view)
+- **Epic 10** — Onboarding infrastructure (theme picker step slots in here; can proceed independently with stub)
+
+## Tasks
+
+1. Create `ThemePicker` Bubbletea model in `internal/tui/theme_picker.go`
+2. Implement `Init()`, `Update()`, `View()` for the picker
+3. Handle keyboard navigation: left/right to browse, Enter to confirm, Escape to skip
+4. Implement horizontal preview layout with narrow-terminal fallback
+5. Integrate into onboarding flow (or create stub integration point)
+6. Persist selected theme to `config.yaml` on confirmation
+7. Write unit tests for picker navigation and selection logic
+8. Verify all quality gates pass
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] Theme preview renders correctly at various terminal widths
+- [ ] Skip/Escape defaults to Modern/Minimalist
+- [ ] Config file updated atomically on theme selection
+- [ ] Picker component is reusable (no onboarding-specific logic baked in)

--- a/docs/stories/17.5.story.md
+++ b/docs/stories/17.5.story.md
@@ -1,0 +1,70 @@
+# Story 17.5: Settings View — `:theme` Command with Preview
+
+**Status:** draft
+**Epic:** 17 — Door Theme System
+**Depends on:** Stories 17.3 (DoorsView integration), 17.4 (theme picker component)
+
+## User Story
+
+As a user,
+I want to change my door theme from within the TUI at any time,
+So that I can try different themes without editing config files.
+
+## Acceptance Criteria
+
+**Given** the theme picker component exists (Story 17.4) and themes are integrated (Story 17.3)
+**When** a user types `:theme` in the TUI command palette
+**Then:**
+
+- AC1: `:theme` command registered in the command palette (FR58)
+- AC2: Command opens the theme picker view (reuses `ThemePicker` component from Story 17.4)
+- AC3: Current active theme highlighted/indicated in the picker
+- AC4: Theme change takes effect immediately in the DoorsView — no restart required (FR58)
+- AC5: New theme selection persisted to `config.yaml` (FR59)
+- AC6: `:theme` command listed in `:help` output
+- AC7: Escape from picker returns to normal view without changing theme
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- Reuse the `ThemePicker` component from Story 17.4 — pass current theme name to highlight it
+- The `:theme` command follows the existing command palette pattern in the TUI — check how other `:` commands are registered
+- Immediate theme switch: when user confirms a new theme, send a `tea.Msg` to `DoorsView` to swap its `theme` field — no full restart needed
+- Config persistence: same atomic write pattern as Story 17.4
+- The picker should show the current theme with a visual indicator (e.g., `[current]` label or different styling)
+- Keep `Update()` fast — theme switch is just a field assignment + config write (use `tea.Cmd` for the file I/O)
+
+## Dependencies
+
+- **Story 17.3** — DoorsView integration (theme field exists on DoorsView)
+- **Story 17.4** — ThemePicker component (reusable picker model)
+
+## Tasks
+
+1. Register `:theme` command in the command palette
+2. Wire command to open `ThemePicker` with current theme highlighted
+3. Handle theme selection: update `DoorsView.theme` field via `tea.Msg`
+4. Persist new theme to `config.yaml` via `tea.Cmd`
+5. Add `:theme` to `:help` output
+6. Handle Escape — return to normal view, no change
+7. Write unit tests for command registration and theme switch flow
+8. Verify all quality gates pass
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] `:theme` appears in `:help` output
+- [ ] Theme change is immediate — no restart needed
+- [ ] Escape cancels without changing theme
+- [ ] Config persisted atomically

--- a/docs/stories/17.6.story.md
+++ b/docs/stories/17.6.story.md
@@ -1,0 +1,73 @@
+# Story 17.6: Golden File Tests for All Themes
+
+**Status:** draft
+**Epic:** 17 — Door Theme System
+**Depends on:** Stories 17.1 (theme types), 17.2 (theme implementations)
+
+## User Story
+
+As a developer,
+I want golden file tests for every door theme,
+So that visual regressions are caught automatically.
+
+## Acceptance Criteria
+
+**Given** all themes (Classic, Modern, Sci-Fi, Shoji) are implemented
+**When** golden file tests are created
+**Then:**
+
+- AC1: Golden file test for each theme (Classic, Modern, Sci-Fi, Shoji) at 28-char and 40-char widths
+- AC2: Both selected and unselected states tested per theme (8 golden files minimum per width)
+- AC3: Golden files stored in `internal/tui/themes/testdata/`
+- AC4: Tests use `go test -update` flag pattern to regenerate golden files when intentional changes are made
+- AC5: Width boundary tests: each theme at MinWidth (should render correctly) and MinWidth-1 (should indicate fallback needed)
+- AC6: Content wrapping tests: short (1 line), medium (2-3 lines), and long (5+ lines) task text verified
+- AC7: All tests pass with `make test`
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- The project already has golden file test infrastructure — check `internal/tui/` for existing `golden_test.go` patterns (NFR19)
+- Golden file update pattern: use a test flag like `-update` to regenerate files, then commit the new golden files
+- File naming convention for golden files: `testdata/<theme>_<width>_<state>.golden` (e.g., `testdata/modern_40_selected.golden`)
+- Each golden file captures the exact string output of `DoorTheme.Render(content, width, selected)`
+- Boundary tests verify that `MinWidth - 1` produces either an error or a signal for fallback — themes should not silently produce broken output
+- Content wrapping tests ensure themes handle varying content lengths gracefully without visual artifacts
+- Table-driven tests are required for >2 test cases — the matrix of themes × widths × states is ideal for table-driven approach
+- Use `t.Helper()` in comparison helpers, `t.Cleanup()` for temp file cleanup
+- Test files: `internal/tui/themes/golden_test.go` and `internal/tui/themes/testdata/`
+
+## Dependencies
+
+- **Story 17.1** — theme types and Classic theme
+- **Story 17.2** — Modern, Sci-Fi, Shoji theme implementations
+
+## Tasks
+
+1. Create `internal/tui/themes/testdata/` directory
+2. Implement golden file test helper with `-update` flag support
+3. Write table-driven test matrix: 4 themes × 2 widths × 2 states
+4. Add width boundary tests for each theme at MinWidth and MinWidth-1
+5. Add content length variation tests (short, medium, long)
+6. Generate initial golden files with `-update` flag
+7. Verify all golden file comparisons pass on clean run
+8. Verify all quality gates pass
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] Golden files committed to `internal/tui/themes/testdata/`
+- [ ] `-update` flag regenerates golden files correctly
+- [ ] Table-driven tests cover full theme × width × state matrix
+- [ ] No flaky tests — golden file comparisons are deterministic


### PR DESCRIPTION
## Summary

- Created 6 detailed story files for Epic 17: Door Theme System (Stories 17.1 through 17.6)
- Stories based on epic details and research from PR #117 (wise-penguin's PRD update)
- Each story follows project conventions: user story format, acceptance criteria, technical notes, dependency chain, quality gates, and pre-PR checklist

## Story Overview

| Story | Title | Dependencies | Est. Time |
|-------|-------|-------------|-----------|
| 17.1 | Theme Types, Registry, and Classic Theme Wrapper | None (foundation) | 60-90 min |
| 17.2 | Modern, Sci-Fi, and Shoji Theme Implementations | 17.1 | 120-180 min |
| 17.3 | DoorsView Integration — Load Theme from Config | 17.1, 17.2 | 60-90 min |
| 17.4 | Theme Picker in Onboarding Flow | 17.3, Epic 10 | 90-120 min |
| 17.5 | Settings View — `:theme` Command with Preview | 17.3, 17.4 | 60-90 min |
| 17.6 | Golden File Tests for All Themes | 17.1, 17.2 | 60-90 min |

## Implementation Order

```
17.1 (types/registry) → 17.2 (theme implementations) → 17.3 (DoorsView integration)
                                                    ↗ 17.4 (onboarding picker) → 17.5 (settings command)
                              17.2 + 17.3 → 17.6 (golden file tests)
```

Stories 17.4/17.5 and 17.6 can be parallelized after 17.3 is complete.

## Key Design Decisions

- **Reusable ThemePicker component** — Story 17.4 creates it, Story 17.5 reuses it for `:theme` command
- **Width-aware fallback** — Classic theme used automatically when terminal is too narrow for selected theme
- **Pure render functions** — `func(content, width, selected) string` — no I/O, easy to test
- **NFR17 compliance** — only box-drawing, block elements, and geometric shapes Unicode ranges

## Dependencies

- Builds on PR #117 (Epic 17 added to PRD by wise-penguin)
- References research from PR #116 (door theme ANSI mockups)

## Opportunities Noted (not implemented)

- Sprint velocity tracking could use these stories for estimation calibration
- Stories could reference specific line numbers in existing code once PR #117 merges

## Test plan

- [x] No code changes — documentation only
- [x] Story format matches project conventions (verified against 3.5.6.story.md)
- [x] Dependency chain is consistent across all stories
- [x] Acceptance criteria reference correct FRs/NFRs from PR #117