### PR TITLE
feat: Story 17.1 — Theme types, registry, and Classic theme wrapper

### DIFF
--- a/internal/tui/themes/classic.go
+++ b/internal/tui/themes/classic.go
@@ -1,0 +1,38 @@
+package themes
+
+import "github.com/charmbracelet/lipgloss"
+
+// NewClassicTheme creates the Classic theme that wraps the existing
+// Lipgloss doorStyle/selectedDoorStyle rendering from the TUI.
+func NewClassicTheme() *DoorTheme {
+	frameColor := lipgloss.Color("63")
+	selectedColor := lipgloss.Color("255")
+
+	unselectedStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(frameColor).
+		Padding(1, 2)
+
+	selectedStyle := lipgloss.NewStyle().
+		Border(lipgloss.ThickBorder()).
+		BorderForeground(selectedColor).
+		Padding(1, 2)
+
+	return &DoorTheme{
+		Name:        "classic",
+		Description: "Classic rounded border — the original ThreeDoors look",
+		Render: func(content string, width int, selected bool) string {
+			if selected {
+				return selectedStyle.Width(width).Render(content)
+			}
+			return unselectedStyle.Width(width).Render(content)
+		},
+		Colors: ThemeColors{
+			Frame:    frameColor,
+			Fill:     lipgloss.Color("0"),
+			Accent:   frameColor,
+			Selected: selectedColor,
+		},
+		MinWidth: 15,
+	}
+}

--- a/internal/tui/themes/classic_test.go
+++ b/internal/tui/themes/classic_test.go
@@ -1,0 +1,138 @@
+package themes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestNewClassicTheme(t *testing.T) {
+	t.Parallel()
+
+	theme := NewClassicTheme()
+
+	if theme.Name != "classic" {
+		t.Errorf("got name %q, want %q", theme.Name, "classic")
+	}
+	if theme.Description == "" {
+		t.Error("expected non-empty description")
+	}
+	if theme.Render == nil {
+		t.Fatal("expected non-nil Render function")
+	}
+	if theme.MinWidth < 1 {
+		t.Errorf("expected positive MinWidth, got %d", theme.MinWidth)
+	}
+}
+
+func TestClassicThemeColors(t *testing.T) {
+	t.Parallel()
+
+	theme := NewClassicTheme()
+
+	if theme.Colors.Frame == "" {
+		t.Error("expected non-empty Frame color")
+	}
+	if theme.Colors.Selected == "" {
+		t.Error("expected non-empty Selected color")
+	}
+}
+
+func TestClassicRenderUnselected(t *testing.T) {
+	t.Parallel()
+
+	theme := NewClassicTheme()
+	output := theme.Render("Test task", 30, false)
+
+	if !strings.Contains(output, "Test task") {
+		t.Error("rendered output should contain the content text")
+	}
+	if output == "" {
+		t.Error("rendered output should not be empty")
+	}
+}
+
+func TestClassicRenderSelected(t *testing.T) {
+	t.Parallel()
+
+	theme := NewClassicTheme()
+	unselected := theme.Render("Test task", 30, false)
+	selected := theme.Render("Test task", 30, true)
+
+	if selected == "" {
+		t.Error("selected output should not be empty")
+	}
+	if !strings.Contains(selected, "Test task") {
+		t.Error("selected output should contain the content text")
+	}
+	if selected == unselected {
+		t.Error("selected and unselected output should differ")
+	}
+}
+
+func TestClassicRenderMatchesExistingStyle(t *testing.T) {
+	t.Parallel()
+
+	// These styles match the existing doorStyle/selectedDoorStyle from internal/tui/styles.go.
+	colorAccent := lipgloss.Color("63")
+	colorDoorBright := lipgloss.Color("255")
+
+	existingDoorStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorAccent).
+		Padding(1, 2)
+
+	existingSelectedStyle := lipgloss.NewStyle().
+		Border(lipgloss.ThickBorder()).
+		BorderForeground(colorDoorBright).
+		Padding(1, 2)
+
+	theme := NewClassicTheme()
+	width := 30
+	content := "Test task text"
+
+	// Unselected should match existing doorStyle
+	themeOutput := theme.Render(content, width, false)
+	existingOutput := existingDoorStyle.Width(width).Render(content)
+
+	if themeOutput != existingOutput {
+		t.Errorf("classic unselected does not match existing doorStyle\ngot:\n%s\nwant:\n%s", themeOutput, existingOutput)
+	}
+
+	// Selected should match existing selectedDoorStyle
+	themeSelectedOutput := theme.Render(content, width, true)
+	existingSelectedOutput := existingSelectedStyle.Width(width).Render(content)
+
+	if themeSelectedOutput != existingSelectedOutput {
+		t.Errorf("classic selected does not match existing selectedDoorStyle\ngot:\n%s\nwant:\n%s", themeSelectedOutput, existingSelectedOutput)
+	}
+}
+
+func TestClassicRenderVaryingWidths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		width int
+	}{
+		{"narrow", 15},
+		{"medium", 30},
+		{"wide", 50},
+	}
+
+	theme := NewClassicTheme()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output := theme.Render("Task", tt.width, false)
+			if output == "" {
+				t.Error("output should not be empty")
+			}
+			if !strings.Contains(output, "Task") {
+				t.Error("output should contain the task text")
+			}
+		})
+	}
+}

--- a/internal/tui/themes/registry.go
+++ b/internal/tui/themes/registry.go
@@ -1,0 +1,37 @@
+package themes
+
+import "sort"
+
+// Registry holds available door themes keyed by name.
+type Registry struct {
+	themes map[string]*DoorTheme
+}
+
+// NewRegistry creates an empty theme registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		themes: make(map[string]*DoorTheme),
+	}
+}
+
+// Register adds a theme to the registry. If a theme with the same name
+// already exists, it is replaced.
+func (r *Registry) Register(theme *DoorTheme) {
+	r.themes[theme.Name] = theme
+}
+
+// Get returns the theme with the given name, or false if not found.
+func (r *Registry) Get(name string) (*DoorTheme, bool) {
+	t, ok := r.themes[name]
+	return t, ok
+}
+
+// Names returns sorted names of all registered themes.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.themes))
+	for name := range r.themes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/tui/themes/registry_test.go
+++ b/internal/tui/themes/registry_test.go
@@ -1,0 +1,102 @@
+package themes
+
+import "testing"
+
+func TestRegisterAndGet(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	theme := &DoorTheme{
+		Name:        "test-theme",
+		Description: "A test theme",
+		Render: func(content string, width int, selected bool) string {
+			return content
+		},
+		MinWidth: 10,
+	}
+
+	reg.Register(theme)
+
+	got, ok := reg.Get("test-theme")
+	if !ok {
+		t.Fatal("expected to find registered theme")
+	}
+	if got.Name != "test-theme" {
+		t.Errorf("got name %q, want %q", got.Name, "test-theme")
+	}
+	if got.Description != "A test theme" {
+		t.Errorf("got description %q, want %q", got.Description, "A test theme")
+	}
+	if got.MinWidth != 10 {
+		t.Errorf("got MinWidth %d, want 10", got.MinWidth)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	_, ok := reg.Get("nonexistent")
+	if ok {
+		t.Error("expected not-found for unregistered theme")
+	}
+}
+
+func TestRegisterOverwrite(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	theme1 := &DoorTheme{
+		Name:        "dup",
+		Description: "first",
+		Render: func(content string, width int, selected bool) string {
+			return "v1"
+		},
+	}
+	theme2 := &DoorTheme{
+		Name:        "dup",
+		Description: "second",
+		Render: func(content string, width int, selected bool) string {
+			return "v2"
+		},
+	}
+
+	reg.Register(theme1)
+	reg.Register(theme2)
+
+	got, ok := reg.Get("dup")
+	if !ok {
+		t.Fatal("expected to find theme")
+	}
+	if got.Description != "second" {
+		t.Errorf("got description %q, want %q (latest registration wins)", got.Description, "second")
+	}
+}
+
+func TestNames(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&DoorTheme{
+		Name: "alpha",
+		Render: func(content string, width int, selected bool) string {
+			return content
+		},
+	})
+	reg.Register(&DoorTheme{
+		Name: "beta",
+		Render: func(content string, width int, selected bool) string {
+			return content
+		},
+	})
+
+	names := reg.Names()
+	if len(names) != 2 {
+		t.Fatalf("got %d names, want 2", len(names))
+	}
+
+	// Names should be sorted
+	if names[0] != "alpha" || names[1] != "beta" {
+		t.Errorf("got names %v, want [alpha beta]", names)
+	}
+}

--- a/internal/tui/themes/theme.go
+++ b/internal/tui/themes/theme.go
@@ -1,0 +1,23 @@
+package themes
+
+import "github.com/charmbracelet/lipgloss"
+
+// ThemeColors holds the color palette for a door theme.
+type ThemeColors struct {
+	Frame    lipgloss.Color
+	Fill     lipgloss.Color
+	Accent   lipgloss.Color
+	Selected lipgloss.Color
+}
+
+// DoorTheme defines the visual frame for a door.
+type DoorTheme struct {
+	Name        string
+	Description string
+	Render      func(content string, width int, selected bool) string
+	Colors      ThemeColors
+	MinWidth    int
+}
+
+// DefaultThemeName is the theme used when no theme is specified.
+const DefaultThemeName = "modern"


### PR DESCRIPTION
## Summary

- Adds `internal/tui/themes/` package with door theme infrastructure (Story 17.1, Epic 17)
- Defines `DoorTheme` struct (Name, Description, Render func, Colors, MinWidth) and `ThemeColors` struct (Frame, Fill, Accent, Selected)
- Implements theme `Registry` with `Get()`, `Register()`, and `Names()` methods
- Wraps existing `doorStyle`/`selectedDoorStyle` rendering as the Classic theme — verified to produce identical output
- Sets `DefaultThemeName` to `"modern"` per AC4

## Acceptance Criteria

- [x] AC1: `DoorTheme` struct in `internal/tui/themes/theme.go`
- [x] AC2: `ThemeColors` struct with Frame, Fill, Accent, Selected fields
- [x] AC3: Registry in `registry.go` with `Get(name)` lookup
- [x] AC4: `DefaultThemeName = "modern"`
- [x] AC5: Classic theme in `classic.go` wrapping existing styles
- [x] AC6: Classic theme output matches existing rendering (test-verified)
- [x] AC7: Unit tests for registry and Classic theme

## Quality Gates

- [x] `make fmt` — passes
- [x] `make lint` — zero warnings
- [x] `make test` — all tests green
- [x] `go test -race` — no race conditions
- [x] No `init()` functions used

## Test plan

- [x] 10 unit tests covering registry CRUD and Classic theme rendering
- [x] `TestClassicRenderMatchesExistingStyle` verifies exact output match with current `doorStyle`/`selectedDoorStyle`
- [x] Race detector clean

## Files

| File | Purpose |
|------|---------|
| `internal/tui/themes/theme.go` | DoorTheme, ThemeColors types, DefaultThemeName const |
| `internal/tui/themes/registry.go` | Registry struct with Get/Register/Names |
| `internal/tui/themes/classic.go` | Classic theme wrapping existing lipgloss styles |
| `internal/tui/themes/registry_test.go` | Registry unit tests |
| `internal/tui/themes/classic_test.go` | Classic theme unit tests |

Blocks: Stories 17.2–17.6