### PR TITLE
docs: add missing PR numbers to epic 19-22 story statuses

### DIFF
--- a/docs/stories/19.1.story.md
+++ b/docs/stories/19.1.story.md
@@ -1,6 +1,6 @@
 # Story 19.1: Jira HTTP Client
 
-**Status:** Done
+**Status:** Done (PR #132)
 **Epic:** 19 — Jira Integration
 **Blocks:** Stories 19.2, 19.3, 19.4
 

--- a/docs/stories/21.2.story.md
+++ b/docs/stories/21.2.story.md
@@ -1,6 +1,6 @@
 # Story 21.2: Circuit Breaker per Provider
 
-**Status:** Done
+**Status:** Done (PR #132)
 **Epic:** 21 — Sync Protocol Hardening
 **Blocks:** Story 21.4
 

--- a/docs/stories/21.3.story.md
+++ b/docs/stories/21.3.story.md
@@ -1,6 +1,6 @@
 # Story 21.3: Canonical ID Mapping (SourceRef)
 
-**Status:** Done (partial — SourceRef type and Task methods; TaskPool integration deferred)
+**Status:** Done (partial — PR #132: SourceRef type and Task methods; TaskPool integration AC4-AC6 deferred)
 **Epic:** 21 — Sync Protocol Hardening
 
 ## User Story


### PR DESCRIPTION
## Summary

- Added PR #132 attribution to stories 19.1, 21.2, and 21.3 (all implemented in the Jira & Task Sync Integration Pipeline PR)
- Clarified 21.3 partial status: AC4-AC6 (TaskPool integration) remain deferred

## Findings

### Epic 19 (Jira Integration)
| Story | Status | Notes |
|-------|--------|-------|
| 19.1 | **Done (PR #132)** | Was missing PR number |
| 19.2 | Done (PR #138) | Correct |
| 19.3 | Draft | Blocked on 19.1/19.2 (both done) — ready to implement |
| 19.4 | Draft | Blocked on 19.1-19.3 — needs 19.3 first |

### Epic 20 (Apple Reminders)
| Story | Status | Notes |
|-------|--------|-------|
| 20.1 | Done (PR #137) | Correct |
| 20.2 | Draft | Blocked on 20.1 (done) — ready to implement |
| 20.3 | Draft | Needs 20.2 |
| 20.4 | Draft | Needs 20.2-20.3 |

### Epic 21 (Sync Protocol Hardening)
| Story | Status | Notes |
|-------|--------|-------|
| 21.1 | Done (PR #139) | Correct |
| 21.2 | **Done (PR #132)** | Was missing PR number |
| 21.3 | **Partial (PR #132)** | SourceRef type + Task methods done; TaskPool integration (AC4-AC6) NOT done — confirmed by code inspection |
| 21.4 | Draft | Blocked on 21.1-21.3 — needs 21.3 completion first |

### Epic 22 (Self-Driving Dev Pipeline)
| Story | Status | Notes |
|-------|--------|-------|
| 22.1-22.8 | All Draft | Correct — no merged PRs for these |

### Key finding: 21.3 TaskPool integration
`FindBySourceRef`, identity resolution, and write routing (AC4-AC6) are **not implemented** — confirmed by checking `internal/tasks/task_pool.go` on upstream/main which has no SourceRef references. The SourceRef type and Task helper methods exist in `internal/core/task.go` but TaskPool doesn't use them yet.

## Test plan
- [x] Verified all 20 story files in epics 19-22
- [x] Cross-referenced against all 146 merged PRs
- [x] Code-verified 21.3 TaskPool integration status