### PR TITLE
feat: Story 21.3 — Complete SourceRef TaskPool Integration

### DIFF
--- a/docs/stories/21.3.story.md
+++ b/docs/stories/21.3.story.md
@@ -1,6 +1,6 @@
 # Story 21.3: Canonical ID Mapping (SourceRef)
 
-**Status:** Done (partial — PR #132: SourceRef type and Task methods; TaskPool integration AC4-AC6 deferred)
+**Status:** Done (PR #151)
 **Epic:** 21 — Sync Protocol Hardening
 
 ## User Story
@@ -58,10 +58,10 @@ So that deduplication is reliable and write-back works to all sources.
 
 ## Pre-PR Checklist
 
-- [ ] `make fmt` — no formatting changes needed
-- [ ] `make lint` — zero warnings
-- [ ] `make test` — all tests pass, including existing tests
-- [ ] `go test -race ./...` — no race conditions
-- [ ] Backward compatibility: empty SourceRefs works like before
-- [ ] Migration tested: old format → new format
-- [ ] YAML/JSON serialization round-trip tested
+- [x] `make fmt` — no formatting changes needed
+- [x] `make lint` — zero warnings
+- [x] `make test` — all tests pass, including existing tests
+- [x] `go test -race ./...` — no race conditions
+- [x] Backward compatibility: empty SourceRefs works like before
+- [x] Migration tested: old format → new format
+- [x] YAML/JSON serialization round-trip tested

--- a/internal/core/aggregator.go
+++ b/internal/core/aggregator.go
@@ -73,6 +73,10 @@ func (a *MultiSourceAggregator) LoadTasks() ([]*Task, error) {
 
 		for _, t := range tasks {
 			t.SourceProvider = name
+			t.MigrateSourceProvider()
+			if !t.HasSourceRef(name, t.ID) {
+				t.AddSourceRef(name, t.ID)
+			}
 			a.trackTaskOrigin(t.ID, name)
 		}
 		allTasks = append(allTasks, tasks...)
@@ -86,11 +90,36 @@ func (a *MultiSourceAggregator) LoadTasks() ([]*Task, error) {
 	return allTasks, nil
 }
 
-// SaveTask routes the save to the task's originating provider based on
-// SourceProvider. If SourceProvider is empty or unknown, the default provider is used.
+// SaveTask routes the save to all providers referenced by the task's SourceRefs.
+// If SourceRefs is empty, falls back to SourceProvider or the default provider.
 func (a *MultiSourceAggregator) SaveTask(task *Task) error {
-	provider, _ := a.resolveProvider(task.SourceProvider)
-	return provider.SaveTask(task)
+	if len(task.SourceRefs) == 0 {
+		provider, _ := a.resolveProvider(task.SourceProvider)
+		return provider.SaveTask(task)
+	}
+
+	var errs []error
+	saved := make(map[string]bool)
+	for _, ref := range task.SourceRefs {
+		if saved[ref.Provider] {
+			continue
+		}
+		provider, ok := a.providers[ref.Provider]
+		if !ok {
+			continue
+		}
+		if err := provider.SaveTask(task); err != nil {
+			errs = append(errs, fmt.Errorf("save to provider %q: %w", ref.Provider, err))
+		}
+		saved[ref.Provider] = true
+	}
+
+	if len(saved) == 0 {
+		provider, _ := a.resolveProvider(task.SourceProvider)
+		return provider.SaveTask(task)
+	}
+
+	return errors.Join(errs...)
 }
 
 // SaveTasks groups tasks by their SourceProvider and saves each group to

--- a/internal/core/aggregator_test.go
+++ b/internal/core/aggregator_test.go
@@ -379,3 +379,143 @@ func TestMultiSourceAggregator_LoadErrors(t *testing.T) {
 		t.Errorf("expected ErrAllProvidersFailed, got: %v", err)
 	}
 }
+
+func TestMultiSourceAggregator_LoadTasks_MigratesSourceRefs(t *testing.T) {
+	t.Parallel()
+
+	// Task with legacy SourceProvider, no SourceRefs
+	task := NewTask("legacy task")
+	task.SourceProvider = "textfile"
+
+	provider := &aggMockProvider{name: "textfile", tasks: []*Task{task}}
+
+	agg := NewMultiSourceAggregator(map[string]TaskProvider{"textfile": provider})
+	tasks, err := agg.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() unexpected error: %v", err)
+	}
+
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	loaded := tasks[0]
+
+	if len(loaded.SourceRefs) == 0 {
+		t.Fatal("expected SourceRefs to be populated after load")
+	}
+	if !loaded.HasSourceRef("textfile", loaded.ID) {
+		t.Errorf("expected SourceRef with provider %q and native ID %q", "textfile", loaded.ID)
+	}
+}
+
+func TestMultiSourceAggregator_LoadTasks_AddsSourceRefForProvider(t *testing.T) {
+	t.Parallel()
+
+	// Task with no SourceProvider or SourceRefs at all
+	task := NewTask("new task")
+
+	provider := &aggMockProvider{name: "obsidian", tasks: []*Task{task}}
+
+	agg := NewMultiSourceAggregator(map[string]TaskProvider{"obsidian": provider})
+	tasks, err := agg.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks() unexpected error: %v", err)
+	}
+
+	loaded := tasks[0]
+	if !loaded.HasSourceRef("obsidian", loaded.ID) {
+		t.Error("expected SourceRef added for the loading provider")
+	}
+}
+
+func TestMultiSourceAggregator_SaveTask_MultiProviderWriteRouting(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	obsidianProvider := newAggMockProvider("obsidian")
+
+	providers := map[string]TaskProvider{
+		"textfile": textProvider,
+		"obsidian": obsidianProvider,
+	}
+
+	agg := NewMultiSourceAggregatorWithDefault(providers, "textfile")
+
+	task := NewTask("multi-provider task")
+	task.AddSourceRef("textfile", task.ID)
+	task.AddSourceRef("obsidian", "obs-note-123")
+
+	if err := agg.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask() unexpected error: %v", err)
+	}
+
+	if len(textProvider.savedTasks) != 1 {
+		t.Errorf("textfile should get 1 save, got %d", len(textProvider.savedTasks))
+	}
+	if len(obsidianProvider.savedTasks) != 1 {
+		t.Errorf("obsidian should get 1 save, got %d", len(obsidianProvider.savedTasks))
+	}
+}
+
+func TestMultiSourceAggregator_SaveTask_FallsBackWithNoRefs(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	providers := map[string]TaskProvider{"textfile": textProvider}
+
+	agg := NewMultiSourceAggregatorWithDefault(providers, "textfile")
+
+	task := NewTask("no refs task")
+	// No SourceRefs, no SourceProvider
+
+	if err := agg.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask() unexpected error: %v", err)
+	}
+
+	if len(textProvider.savedTasks) != 1 {
+		t.Errorf("default provider should get save, got %d saves", len(textProvider.savedTasks))
+	}
+}
+
+func TestMultiSourceAggregator_SaveTask_SkipsUnknownProviderInRefs(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	providers := map[string]TaskProvider{"textfile": textProvider}
+
+	agg := NewMultiSourceAggregatorWithDefault(providers, "textfile")
+
+	task := NewTask("task with unknown provider ref")
+	task.AddSourceRef("textfile", task.ID)
+	task.AddSourceRef("nonexistent", "xyz")
+
+	if err := agg.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask() unexpected error: %v", err)
+	}
+
+	if len(textProvider.savedTasks) != 1 {
+		t.Errorf("known provider should get save, got %d", len(textProvider.savedTasks))
+	}
+}
+
+func TestMultiSourceAggregator_SaveTask_DeduplicatesSameProvider(t *testing.T) {
+	t.Parallel()
+
+	textProvider := newAggMockProvider("textfile")
+	providers := map[string]TaskProvider{"textfile": textProvider}
+
+	agg := NewMultiSourceAggregatorWithDefault(providers, "textfile")
+
+	task := NewTask("task")
+	task.AddSourceRef("textfile", "id-1")
+	task.AddSourceRef("textfile", "id-2") // same provider, different native ID
+
+	if err := agg.SaveTask(task); err != nil {
+		t.Fatalf("SaveTask() unexpected error: %v", err)
+	}
+
+	// Should only save once to the same provider
+	if len(textProvider.savedTasks) != 1 {
+		t.Errorf("same provider should only get 1 save, got %d", len(textProvider.savedTasks))
+	}
+}

--- a/internal/core/provider_config.go
+++ b/internal/core/provider_config.go
@@ -46,7 +46,8 @@ type ProviderConfig struct {
 }
 
 // CurrentSchemaVersion is the current config.yaml schema version.
-const CurrentSchemaVersion = 1
+// Version 2 introduced SourceRefs for multi-provider task identity.
+const CurrentSchemaVersion = 2
 
 // defaultProviderConfig returns the default configuration.
 func defaultProviderConfig() *ProviderConfig {
@@ -85,7 +86,17 @@ func LoadProviderConfig(path string) (*ProviderConfig, error) {
 		cfg.NoteTitle = "ThreeDoors Tasks"
 	}
 
+	MigrateConfig(cfg)
+
 	return cfg, nil
+}
+
+// MigrateConfig updates a config to the current schema version.
+// Version 1 → 2: no config-level changes needed (SourceRef migration happens at task load time).
+func MigrateConfig(cfg *ProviderConfig) {
+	if cfg.SchemaVersion < CurrentSchemaVersion {
+		cfg.SchemaVersion = CurrentSchemaVersion
+	}
 }
 
 // ResolveActiveProvider creates a TaskProvider based on the configuration and registry.

--- a/internal/core/provider_config_test.go
+++ b/internal/core/provider_config_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -558,8 +559,8 @@ func TestLoadProviderConfig_SchemaVersionParsed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProviderConfig() unexpected error: %v", err)
 	}
-	if cfg.SchemaVersion != 1 {
-		t.Errorf("SchemaVersion = %d, want 1", cfg.SchemaVersion)
+	if cfg.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d (migrated from 1)", cfg.SchemaVersion, CurrentSchemaVersion)
 	}
 }
 
@@ -623,8 +624,8 @@ func TestGenerateSampleConfig_IncludesSchemaVersion(t *testing.T) {
 	}
 
 	content := string(data)
-	if !strings.Contains(content, "schema_version: 1") {
-		t.Error("sample config should include schema_version: 1")
+	if !strings.Contains(content, fmt.Sprintf("schema_version: %d", CurrentSchemaVersion)) {
+		t.Errorf("sample config should include schema_version: %d", CurrentSchemaVersion)
 	}
 }
 
@@ -662,9 +663,9 @@ llm:
 		t.Fatalf("LoadProviderConfig() unexpected error: %v", err)
 	}
 
-	// Provider config sections should be parsed
-	if cfg.SchemaVersion != 1 {
-		t.Errorf("SchemaVersion = %d, want 1", cfg.SchemaVersion)
+	// Provider config sections should be parsed (v1 migrated to current)
+	if cfg.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d (migrated)", cfg.SchemaVersion, CurrentSchemaVersion)
 	}
 	if len(cfg.Providers) != 2 {
 		t.Errorf("expected 2 providers, got %d", len(cfg.Providers))

--- a/internal/core/source_ref_test.go
+++ b/internal/core/source_ref_test.go
@@ -268,3 +268,64 @@ func TestSourceRefOmittedWhenEmpty(t *testing.T) {
 		t.Error("expected source_refs to be omitted from YAML when empty")
 	}
 }
+
+func TestMigrateTasks_Batch(t *testing.T) {
+	t.Parallel()
+
+	tasks := []*Task{
+		{ID: "t1", SourceProvider: "textfile"},
+		{ID: "t2", SourceProvider: "obsidian"},
+		{ID: "t3", SourceProvider: ""}, // no source provider
+		{ID: "t4", SourceProvider: "jira", SourceRefs: []SourceRef{{Provider: "jira", NativeID: "PROJ-1"}}},
+	}
+
+	MigrateTasks(tasks)
+
+	// t1: should gain a SourceRef
+	if len(tasks[0].SourceRefs) != 1 || tasks[0].SourceRefs[0].Provider != "textfile" {
+		t.Errorf("t1: expected migration to textfile ref, got %+v", tasks[0].SourceRefs)
+	}
+
+	// t2: should gain a SourceRef
+	if len(tasks[1].SourceRefs) != 1 || tasks[1].SourceRefs[0].Provider != "obsidian" {
+		t.Errorf("t2: expected migration to obsidian ref, got %+v", tasks[1].SourceRefs)
+	}
+
+	// t3: no source provider, should remain empty
+	if len(tasks[2].SourceRefs) != 0 {
+		t.Errorf("t3: expected no refs for empty source provider, got %+v", tasks[2].SourceRefs)
+	}
+
+	// t4: already has refs, should not be modified
+	if len(tasks[3].SourceRefs) != 1 || tasks[3].SourceRefs[0].NativeID != "PROJ-1" {
+		t.Errorf("t4: existing refs should be preserved, got %+v", tasks[3].SourceRefs)
+	}
+}
+
+func TestSourceRefBackwardCompatibility_EmptySourceRefs(t *testing.T) {
+	t.Parallel()
+
+	// Task with no SourceRefs should behave identically to pre-SourceRef behavior
+	task := &Task{
+		ID:             "t1",
+		Text:           "legacy task",
+		SourceProvider: "textfile",
+	}
+
+	// EffectiveSourceProvider falls back to legacy field
+	if got := task.EffectiveSourceProvider(); got != "textfile" {
+		t.Errorf("EffectiveSourceProvider() = %q, want %q", got, "textfile")
+	}
+
+	// HasSourceRef returns false
+	if task.HasSourceRef("textfile", "t1") {
+		t.Error("HasSourceRef() should return false for empty refs")
+	}
+
+	// FindBySourceRef on pool returns nil
+	pool := NewTaskPool()
+	pool.AddTask(task)
+	if pool.FindBySourceRef("textfile", "t1") != nil {
+		t.Error("FindBySourceRef() should return nil for task with no SourceRefs")
+	}
+}

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -83,6 +83,14 @@ func (t *Task) MigrateSourceProvider() {
 	}}
 }
 
+// MigrateTasks runs MigrateSourceProvider on each task in the slice.
+// This converts legacy SourceProvider fields to SourceRefs entries.
+func MigrateTasks(tasks []*Task) {
+	for _, t := range tasks {
+		t.MigrateSourceProvider()
+	}
+}
+
 // NewTask creates a new task with a UUID and default "todo" status.
 func NewTask(text string) *Task {
 	now := time.Now().UTC()

--- a/internal/core/task_pool.go
+++ b/internal/core/task_pool.go
@@ -1,8 +1,15 @@
 package core
 
+// sourceRefKey is the composite key for the SourceRef index.
+type sourceRefKey struct {
+	Provider string
+	NativeID string
+}
+
 // TaskPool manages an in-memory collection of tasks.
 type TaskPool struct {
 	tasks            map[string]*Task
+	sourceRefIndex   map[sourceRefKey]string // sourceRefKey → task ID
 	recentlyShown    []string
 	recentlyShownIdx int
 	maxRecentlyShown int
@@ -12,15 +19,17 @@ type TaskPool struct {
 func NewTaskPool() *TaskPool {
 	return &TaskPool{
 		tasks:            make(map[string]*Task),
+		sourceRefIndex:   make(map[sourceRefKey]string),
 		recentlyShown:    make([]string, 10),
 		recentlyShownIdx: 0,
 		maxRecentlyShown: 10,
 	}
 }
 
-// AddTask adds a task to the pool.
+// AddTask adds a task to the pool and indexes its SourceRefs.
 func (tp *TaskPool) AddTask(task *Task) {
 	tp.tasks[task.ID] = task
+	tp.indexSourceRefs(task)
 }
 
 // GetTask retrieves a task by ID.
@@ -28,13 +37,19 @@ func (tp *TaskPool) GetTask(id string) *Task {
 	return tp.tasks[id]
 }
 
-// UpdateTask updates an existing task in the pool.
+// UpdateTask updates an existing task in the pool and re-indexes its SourceRefs.
 func (tp *TaskPool) UpdateTask(task *Task) {
+	// Remove old index entries by iterating stored keys (handles same-pointer mutation).
+	tp.removeSourceRefIndexByID(task.ID)
 	tp.tasks[task.ID] = task
+	tp.indexSourceRefs(task)
 }
 
-// RemoveTask removes a task from the pool by ID.
+// RemoveTask removes a task from the pool by ID and cleans up its SourceRef index.
 func (tp *TaskPool) RemoveTask(id string) {
+	if task, ok := tp.tasks[id]; ok {
+		tp.removeSourceRefIndex(task)
+	}
 	delete(tp.tasks, id)
 }
 
@@ -100,4 +115,40 @@ func (tp *TaskPool) IsRecentlyShown(taskID string) bool {
 // Count returns the total number of tasks.
 func (tp *TaskPool) Count() int {
 	return len(tp.tasks)
+}
+
+// FindBySourceRef returns the task matching the given provider and native ID,
+// or nil if no match is found. Uses an internal index for O(1) lookup.
+func (tp *TaskPool) FindBySourceRef(provider, nativeID string) *Task {
+	key := sourceRefKey{Provider: provider, NativeID: nativeID}
+	if id, ok := tp.sourceRefIndex[key]; ok {
+		return tp.tasks[id]
+	}
+	return nil
+}
+
+// indexSourceRefs adds all SourceRefs of a task to the index.
+func (tp *TaskPool) indexSourceRefs(task *Task) {
+	for _, ref := range task.SourceRefs {
+		key := sourceRefKey(ref)
+		tp.sourceRefIndex[key] = task.ID
+	}
+}
+
+// removeSourceRefIndex removes all SourceRefs of a task from the index.
+func (tp *TaskPool) removeSourceRefIndex(task *Task) {
+	for _, ref := range task.SourceRefs {
+		key := sourceRefKey(ref)
+		delete(tp.sourceRefIndex, key)
+	}
+}
+
+// removeSourceRefIndexByID removes all index entries pointing to the given task ID.
+// This is safe even when the task's SourceRefs have already been mutated in place.
+func (tp *TaskPool) removeSourceRefIndexByID(taskID string) {
+	for key, id := range tp.sourceRefIndex {
+		if id == taskID {
+			delete(tp.sourceRefIndex, key)
+		}
+	}
 }

--- a/internal/core/task_pool_test.go
+++ b/internal/core/task_pool_test.go
@@ -98,3 +98,126 @@ func TestTaskPool_GetAvailableForDoors_FewTasks(t *testing.T) {
 		t.Errorf("Expected 1 available task (including recently shown), got %d", len(available))
 	}
 }
+
+func TestTaskPool_FindBySourceRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		refs     []SourceRef
+		provider string
+		nativeID string
+		wantNil  bool
+	}{
+		{
+			name:     "finds task by exact match",
+			refs:     []SourceRef{{Provider: "jira", NativeID: "PROJ-42"}},
+			provider: "jira",
+			nativeID: "PROJ-42",
+			wantNil:  false,
+		},
+		{
+			name:     "returns nil for missing ref",
+			refs:     []SourceRef{{Provider: "jira", NativeID: "PROJ-42"}},
+			provider: "jira",
+			nativeID: "PROJ-99",
+			wantNil:  true,
+		},
+		{
+			name:     "returns nil for different provider",
+			refs:     []SourceRef{{Provider: "jira", NativeID: "PROJ-42"}},
+			provider: "obsidian",
+			nativeID: "PROJ-42",
+			wantNil:  true,
+		},
+		{
+			name: "finds via second ref",
+			refs: []SourceRef{
+				{Provider: "textfile", NativeID: "abc"},
+				{Provider: "jira", NativeID: "PROJ-42"},
+			},
+			provider: "jira",
+			nativeID: "PROJ-42",
+			wantNil:  false,
+		},
+		{
+			name:     "empty pool returns nil",
+			refs:     nil,
+			provider: "jira",
+			nativeID: "PROJ-42",
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pool := NewTaskPool()
+			if len(tt.refs) > 0 {
+				task := NewTask("test task")
+				task.SourceRefs = tt.refs
+				pool.AddTask(task)
+			}
+
+			got := pool.FindBySourceRef(tt.provider, tt.nativeID)
+			if tt.wantNil && got != nil {
+				t.Errorf("FindBySourceRef(%q, %q) = %v, want nil", tt.provider, tt.nativeID, got)
+			}
+			if !tt.wantNil && got == nil {
+				t.Errorf("FindBySourceRef(%q, %q) = nil, want task", tt.provider, tt.nativeID)
+			}
+		})
+	}
+}
+
+func TestTaskPool_FindBySourceRef_IndexUpdatedOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	pool := NewTaskPool()
+	task := NewTask("task")
+	task.AddSourceRef("jira", "PROJ-1")
+	pool.AddTask(task)
+
+	if pool.FindBySourceRef("jira", "PROJ-1") == nil {
+		t.Fatal("expected to find task after add")
+	}
+
+	// Update task with new ref, removing old
+	task.SourceRefs = []SourceRef{{Provider: "obsidian", NativeID: "note-1"}}
+	pool.UpdateTask(task)
+
+	if pool.FindBySourceRef("jira", "PROJ-1") != nil {
+		t.Error("old ref should be removed from index after update")
+	}
+	if pool.FindBySourceRef("obsidian", "note-1") == nil {
+		t.Error("new ref should be in index after update")
+	}
+}
+
+func TestTaskPool_FindBySourceRef_IndexCleanedOnRemove(t *testing.T) {
+	t.Parallel()
+
+	pool := NewTaskPool()
+	task := NewTask("task")
+	task.AddSourceRef("jira", "PROJ-1")
+	pool.AddTask(task)
+
+	pool.RemoveTask(task.ID)
+
+	if pool.FindBySourceRef("jira", "PROJ-1") != nil {
+		t.Error("ref should be removed from index after task removal")
+	}
+}
+
+func TestTaskPool_FindBySourceRef_NoRefsTask(t *testing.T) {
+	t.Parallel()
+
+	pool := NewTaskPool()
+	task := NewTask("no refs task")
+	pool.AddTask(task)
+
+	// Should not panic, just return nil for any lookup
+	if pool.FindBySourceRef("any", "any") != nil {
+		t.Error("expected nil for task with no source refs")
+	}
+}


### PR DESCRIPTION
## Summary

Completes Story 21.3 (Canonical ID Mapping — SourceRef) by finishing the deferred TaskPool integration. The SourceRef type and Task methods were already in place; this PR adds:

- **AC4**: `FindBySourceRef(provider, nativeID)` on TaskPool with O(1) indexed lookup via internal `sourceRefIndex` map
- **AC5**: Aggregator `LoadTasks` now calls `MigrateSourceProvider()` and `AddSourceRef()` for each loaded task, ensuring all tasks have proper SourceRefs after load
- **AC6**: `SaveTask` multi-provider write routing — iterates SourceRefs and saves to each known provider (deduplicating same-provider refs)
- **AC7**: Schema version bumped to 2 with `MigrateConfig()` function; existing v1 configs auto-migrate on load
- **AC8**: Comprehensive tests covering FindBySourceRef (table-driven), index maintenance on Add/Update/Remove, aggregator migration, multi-provider write routing, batch migration, backward compatibility

### Files changed
- `internal/core/task_pool.go` — SourceRef index + FindBySourceRef
- `internal/core/aggregator.go` — Migration on load + multi-provider SaveTask
- `internal/core/provider_config.go` — Schema v2 + MigrateConfig
- `internal/core/task.go` — MigrateTasks batch helper
- Tests: `task_pool_test.go`, `aggregator_test.go`, `source_ref_test.go`, `provider_config_test.go`

## Test plan

- [x] `make fmt` passes
- [x] `make lint` passes with zero warnings
- [x] `make test` passes — all tests green
- [x] `go test -race ./internal/core/` — no race conditions
- [x] Backward compatibility verified: empty SourceRefs works like before
- [x] Config migration tested: v1 → v2 auto-upgrade