### PR TITLE
feat: task list and task show commands (Story 23.2)

### DIFF
--- a/docs/stories/23.2.story.md
+++ b/docs/stories/23.2.story.md
@@ -1,6 +1,6 @@
 # Story 23.2: Task List and Task Show Commands with Prefix Matching
 
-**Status:** Draft
+**Status:** Done
 **Epic:** 23 — CLI Interface
 **Depends on:** Story 23.1
 

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/arcaven/ThreeDoors/internal/core"
 	"github.com/spf13/cobra"
@@ -16,6 +17,8 @@ func newTaskCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newTaskAddCmd())
 	cmd.AddCommand(newTaskCompleteCmd())
+	cmd.AddCommand(newTaskListCmd())
+	cmd.AddCommand(newTaskShowCmd())
 	return cmd
 }
 
@@ -210,4 +213,192 @@ func completeOneTask(ctx *cliContext, idPrefix string) completeResult {
 		Success:  true,
 		ExitCode: ExitSuccess,
 	}
+}
+
+// listMetadata holds metadata for JSON list output.
+type listMetadata struct {
+	Total    int               `json:"total"`
+	Filtered int               `json:"filtered"`
+	Filters  map[string]string `json:"filters"`
+}
+
+// newTaskListCmd creates the "task list" subcommand.
+func newTaskListCmd() *cobra.Command {
+	var (
+		statusFilter string
+		typeFilter   string
+		effortFilter string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tasks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTaskList(cmd, statusFilter, typeFilter, effortFilter)
+		},
+	}
+
+	cmd.Flags().StringVar(&statusFilter, "status", "", "filter by status (todo, in-progress, blocked, etc.)")
+	cmd.Flags().StringVar(&typeFilter, "type", "", "filter by type (creative, administrative, technical, physical)")
+	cmd.Flags().StringVar(&effortFilter, "effort", "", "filter by effort (quick-win, medium, deep-work)")
+
+	return cmd
+}
+
+func runTaskList(_ *cobra.Command, statusFilter, typeFilter, effortFilter string) error {
+	formatter := NewOutputFormatter(os.Stdout, jsonOutput)
+
+	ctx, err := bootstrap()
+	if err != nil {
+		if jsonOutput {
+			_ = formatter.WriteJSONError("task list", ExitGeneralError, err.Error(), "")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		os.Exit(ExitGeneralError)
+	}
+
+	allTasks := ctx.pool.GetAllTasks()
+	sort.Slice(allTasks, func(i, j int) bool {
+		return allTasks[i].CreatedAt.Before(allTasks[j].CreatedAt)
+	})
+
+	filtered := filterTasks(allTasks, statusFilter, typeFilter, effortFilter)
+
+	if jsonOutput {
+		filters := make(map[string]string)
+		if statusFilter != "" {
+			filters["status"] = statusFilter
+		}
+		if typeFilter != "" {
+			filters["type"] = typeFilter
+		}
+		if effortFilter != "" {
+			filters["effort"] = effortFilter
+		}
+		meta := listMetadata{
+			Total:    len(allTasks),
+			Filtered: len(filtered),
+			Filters:  filters,
+		}
+		return formatter.WriteJSON("task list", filtered, meta)
+	}
+
+	tw := formatter.TableWriter()
+	_, _ = fmt.Fprintf(tw, "ID\tSTATUS\tTYPE\tEFFORT\tTEXT\n")
+	for _, t := range filtered {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			shortID(t.ID),
+			t.Status,
+			t.Type,
+			t.Effort,
+			t.Text,
+		)
+	}
+	_ = tw.Flush()
+	return formatter.Writef("%d tasks found\n", len(filtered))
+}
+
+func filterTasks(tasks []*core.Task, status, taskType, effort string) []*core.Task {
+	result := make([]*core.Task, 0, len(tasks))
+	for _, t := range tasks {
+		if status != "" && string(t.Status) != status {
+			continue
+		}
+		if taskType != "" && string(t.Type) != taskType {
+			continue
+		}
+		if effort != "" && string(t.Effort) != effort {
+			continue
+		}
+		result = append(result, t)
+	}
+	return result
+}
+
+// newTaskShowCmd creates the "task show" subcommand.
+func newTaskShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <id>",
+		Short: "Show task details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTaskShow(cmd, args[0])
+		},
+	}
+	return cmd
+}
+
+func runTaskShow(_ *cobra.Command, idPrefix string) error {
+	formatter := NewOutputFormatter(os.Stdout, jsonOutput)
+
+	ctx, err := bootstrap()
+	if err != nil {
+		if jsonOutput {
+			_ = formatter.WriteJSONError("task show", ExitGeneralError, err.Error(), "")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		os.Exit(ExitGeneralError)
+	}
+
+	matches := ctx.pool.FindByPrefix(idPrefix)
+
+	if len(matches) == 0 {
+		if jsonOutput {
+			_ = formatter.WriteJSONError("task show", ExitNotFound, "task not found", idPrefix)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: no task found with prefix %q\n", idPrefix)
+		}
+		os.Exit(ExitNotFound)
+	}
+
+	if len(matches) > 1 {
+		msg := fmt.Sprintf("ambiguous prefix %q matches %d tasks", idPrefix, len(matches))
+		if jsonOutput {
+			_ = formatter.WriteJSONError("task show", ExitAmbiguousInput, msg, "")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+		}
+		os.Exit(ExitAmbiguousInput)
+	}
+
+	task := matches[0]
+
+	if jsonOutput {
+		return formatter.WriteJSON("task show", task, nil)
+	}
+
+	_ = formatter.Writef("ID:        %s\n", task.ID)
+	_ = formatter.Writef("Text:      %s\n", task.Text)
+	_ = formatter.Writef("Status:    %s\n", task.Status)
+	if task.Context != "" {
+		_ = formatter.Writef("Context:   %s\n", task.Context)
+	}
+	if task.Type != "" {
+		_ = formatter.Writef("Type:      %s\n", task.Type)
+	}
+	if task.Effort != "" {
+		_ = formatter.Writef("Effort:    %s\n", task.Effort)
+	}
+	if task.Location != "" {
+		_ = formatter.Writef("Location:  %s\n", task.Location)
+	}
+	if task.Blocker != "" {
+		_ = formatter.Writef("Blocker:   %s\n", task.Blocker)
+	}
+	_ = formatter.Writef("Created:   %s\n", task.CreatedAt.Format("2006-01-02 15:04:05"))
+	_ = formatter.Writef("Updated:   %s\n", task.UpdatedAt.Format("2006-01-02 15:04:05"))
+	if task.CompletedAt != nil {
+		_ = formatter.Writef("Completed: %s\n", task.CompletedAt.Format("2006-01-02 15:04:05"))
+	}
+	if len(task.Notes) > 0 {
+		_ = formatter.Writef("Notes:\n")
+		for _, n := range task.Notes {
+			_ = formatter.Writef("  [%s] %s\n", n.Timestamp.Format("2006-01-02 15:04"), n.Text)
+		}
+	}
+
+	return nil
 }

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -273,11 +273,10 @@ func TestNewTaskCmd_Structure(t *testing.T) {
 		names[sub.Name()] = true
 	}
 
-	if !names["add"] {
-		t.Error("missing 'add' subcommand")
-	}
-	if !names["complete"] {
-		t.Error("missing 'complete' subcommand")
+	for _, want := range []string{"add", "complete", "list", "show"} {
+		if !names[want] {
+			t.Errorf("missing %q subcommand", want)
+		}
 	}
 }
 
@@ -291,6 +290,91 @@ func TestNewTaskAddCmd_Flags(t *testing.T) {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag %q", name)
 		}
+	}
+}
+
+func TestFilterTasks(t *testing.T) {
+	t.Parallel()
+
+	tasks := []*core.Task{
+		{ID: "1", Text: "A", Status: core.StatusTodo, Type: core.TypeTechnical, Effort: core.EffortQuickWin},
+		{ID: "2", Text: "B", Status: core.StatusInProgress, Type: core.TypeCreative, Effort: core.EffortMedium},
+		{ID: "3", Text: "C", Status: core.StatusTodo, Type: core.TypeTechnical, Effort: core.EffortDeepWork},
+		{ID: "4", Text: "D", Status: core.StatusComplete, Type: core.TypeAdministrative, Effort: core.EffortQuickWin},
+	}
+
+	tests := []struct {
+		name      string
+		status    string
+		taskType  string
+		effort    string
+		wantCount int
+	}{
+		{"no filters", "", "", "", 4},
+		{"filter by status todo", "todo", "", "", 2},
+		{"filter by type technical", "", "technical", "", 2},
+		{"filter by effort quick-win", "", "", "quick-win", 2},
+		{"composable: status+type", "todo", "technical", "", 2},
+		{"composable: status+type+effort", "todo", "technical", "quick-win", 1},
+		{"no matches", "done", "", "", 0},
+		{"in-progress", "in-progress", "", "", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterTasks(tasks, tt.status, tt.taskType, tt.effort)
+			if len(got) != tt.wantCount {
+				t.Errorf("filterTasks() returned %d, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestNewTaskListCmd_Flags(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTaskListCmd()
+	for _, name := range []string{"status", "type", "effort"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing flag %q", name)
+		}
+	}
+}
+
+func TestNewTaskShowCmd_Args(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTaskShowCmd()
+	if cmd.Use != "show <id>" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "show <id>")
+	}
+}
+
+func TestListMetadata_JSON(t *testing.T) {
+	t.Parallel()
+
+	meta := listMetadata{
+		Total:    10,
+		Filtered: 3,
+		Filters:  map[string]string{"status": "todo"},
+	}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded["total"] != float64(10) {
+		t.Errorf("total = %v, want 10", decoded["total"])
+	}
+	if decoded["filtered"] != float64(3) {
+		t.Errorf("filtered = %v, want 3", decoded["filtered"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Implements Story 23.2: Task List and Task Show Commands with Prefix Matching
- Adds `task list` subcommand with composable `--status`, `--type`, `--effort` filters
- Adds `task show <id>` subcommand with ID prefix matching
- Both commands support `--json` output with standard envelope
- Uses existing `FindByPrefix` (returns slice) from `TaskPool` — compatible with Story 23.3's `task complete`

## Acceptance Criteria

- [x] AC1: `task list` displays tabwriter table (ID, STATUS, TYPE, EFFORT, TEXT)
- [x] AC2-AC4: `--status`, `--type`, `--effort` filter flags
- [x] AC5: Filters are composable
- [x] AC6: `--json` output with metadata (total, filtered, filters)
- [x] AC7: `task show <id>` with prefix matching
- [x] AC8: `task show --json` outputs full task
- [x] AC9: Uses existing `FindByPrefix` returning slice (compatible with 23.3 code)
- [x] AC10: Short IDs (first 8 chars) in list output
- [x] AC11: Footer shows "N tasks found"
- [x] AC12: Exit code 2 for not-found, 5 for ambiguous

## Quality Gates

- [x] `make fmt` passes
- [x] `make lint` passes with zero warnings
- [x] `make test` passes — all tests green
- [x] Rebased on latest upstream/main

## Test plan

- Table-driven tests for `filterTasks` covering all filter combinations
- Tests for command structure (list/show subcommands registered)
- Tests for list command flags
- Tests for show command args
- JSON metadata serialization test
- Existing `FindByPrefix` tests in `task_test.go` cover prefix matching