### PR TITLE
feat: health, version commands and exit code enforcement (Story 23.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 THREEDOORS_DIR ?= $(HOME)/.threedoors
 VERSION ?= dev
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS := -X main.version=$(VERSION) \
+           -X github.com/arcaven/ThreeDoors/internal/cli.Version=$(VERSION) \
+           -X github.com/arcaven/ThreeDoors/internal/cli.Commit=$(COMMIT) \
+           -X github.com/arcaven/ThreeDoors/internal/cli.BuildDate=$(BUILD_DATE)
 
 .PHONY: build build-mcp run clean fmt lint test test-docker bench analyze test-scripts sign pkg release-local test-dist
 
 build:
-	go build -ldflags "-X main.version=$(VERSION)" -o bin/threedoors ./cmd/threedoors
+	go build -ldflags "$(LDFLAGS)" -o bin/threedoors ./cmd/threedoors
 
 build-mcp:
-	go build -ldflags "-X main.version=$(VERSION)" -o bin/threedoors-mcp ./cmd/threedoors-mcp
+	go build -ldflags "$(LDFLAGS)" -o bin/threedoors-mcp ./cmd/threedoors-mcp
 
 run: build
 	./bin/threedoors

--- a/docs/stories/23.5.story.md
+++ b/docs/stories/23.5.story.md
@@ -1,6 +1,6 @@
 # Story 23.5: Health, Version Commands and Exit Code Enforcement
 
-**Status:** Draft
+**Status:** Done
 **Epic:** 23 — CLI Interface
 **Depends on:** Story 23.1
 

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/arcaven/ThreeDoors/internal/core"
+	"github.com/spf13/cobra"
+)
+
+// healthCheckJSON is the JSON representation of a single health check item.
+type healthCheckJSON struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// healthResultJSON is the JSON envelope data for the health command.
+type healthResultJSON struct {
+	Overall    string            `json:"overall"`
+	DurationMs int64             `json:"duration_ms"`
+	Checks     []healthCheckJSON `json:"checks"`
+}
+
+// newHealthCmd creates the "health" subcommand.
+func newHealthCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Run system health checks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runHealth()
+		},
+	}
+	return cmd
+}
+
+func runHealth() error {
+	formatter := NewOutputFormatter(os.Stdout, jsonOutput)
+
+	ctx, err := bootstrap()
+	if err != nil {
+		if jsonOutput {
+			_ = formatter.WriteJSONError("health", ExitProviderError, err.Error(), "")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		os.Exit(ExitProviderError)
+	}
+
+	hc := core.NewHealthChecker(ctx.provider)
+	result := hc.RunAll()
+
+	if jsonOutput {
+		checks := make([]healthCheckJSON, 0, len(result.Items))
+		for _, item := range result.Items {
+			checks = append(checks, healthCheckJSON{
+				Name:    item.Name,
+				Status:  string(item.Status),
+				Message: item.Message,
+			})
+		}
+		data := healthResultJSON{
+			Overall:    string(result.Overall),
+			DurationMs: result.Duration.Milliseconds(),
+			Checks:     checks,
+		}
+		_ = formatter.WriteJSON("health", data, nil)
+	} else {
+		tw := formatter.TableWriter()
+		_, _ = fmt.Fprintf(tw, "CHECK\tSTATUS\tMESSAGE\n")
+		for _, item := range result.Items {
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\n", item.Name, item.Status, item.Message)
+		}
+		_ = tw.Flush()
+		_ = formatter.Writef("\nOverall: %s (%dms)\n", result.Overall, result.Duration.Milliseconds())
+	}
+
+	if result.Overall == core.HealthFail {
+		os.Exit(ExitProviderError)
+	}
+	return nil
+}

--- a/internal/cli/health_test.go
+++ b/internal/cli/health_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/arcaven/ThreeDoors/internal/core"
+)
+
+func TestHealthCommandRegistered(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "health" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("health command not registered on root")
+	}
+}
+
+func TestHealthCheckerResultsJSON(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockProvider{}
+	hc := core.NewHealthChecker(provider)
+	result := hc.RunAll()
+
+	checks := make([]healthCheckJSON, 0, len(result.Items))
+	for _, item := range result.Items {
+		checks = append(checks, healthCheckJSON{
+			Name:    item.Name,
+			Status:  string(item.Status),
+			Message: item.Message,
+		})
+	}
+	data := healthResultJSON{
+		Overall:    string(result.Overall),
+		DurationMs: result.Duration.Milliseconds(),
+		Checks:     checks,
+	}
+
+	var buf bytes.Buffer
+	formatter := NewOutputFormatter(&buf, true)
+	err := formatter.WriteJSON("health", data, nil)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+
+	var env JSONEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	if env.Command != "health" {
+		t.Errorf("command = %q, want %q", env.Command, "health")
+	}
+
+	envData, ok := env.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("data is not a map: %T", env.Data)
+	}
+
+	if _, ok := envData["overall"]; !ok {
+		t.Error("missing 'overall' field in data")
+	}
+	if _, ok := envData["duration_ms"]; !ok {
+		t.Error("missing 'duration_ms' field in data")
+	}
+	checksRaw, ok := envData["checks"]
+	if !ok {
+		t.Fatal("missing 'checks' field in data")
+	}
+	checksArr, ok := checksRaw.([]interface{})
+	if !ok {
+		t.Fatalf("checks is not an array: %T", checksRaw)
+	}
+	if len(checksArr) == 0 {
+		t.Error("expected at least one health check")
+	}
+}
+
+func TestHealthCheckerTableOutput(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockProvider{}
+	hc := core.NewHealthChecker(provider)
+	result := hc.RunAll()
+
+	var buf bytes.Buffer
+	formatter := NewOutputFormatter(&buf, false)
+
+	tw := formatter.TableWriter()
+	for _, item := range result.Items {
+		_, _ = tw.Write([]byte(item.Name + "\t" + string(item.Status) + "\t" + item.Message + "\n"))
+	}
+	_ = tw.Flush()
+
+	output := buf.String()
+	if !strings.Contains(output, "Database") {
+		t.Errorf("table output missing 'Database', got:\n%s", output)
+	}
+}
+
+func TestExitCodeConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code int
+		want int
+	}{
+		{"success", ExitSuccess, 0},
+		{"general error", ExitGeneralError, 1},
+		{"not found", ExitNotFound, 2},
+		{"validation", ExitValidation, 3},
+		{"provider error", ExitProviderError, 4},
+		{"ambiguous input", ExitAmbiguousInput, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.code != tt.want {
+				t.Errorf("exit code %s = %d, want %d", tt.name, tt.code, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,6 +24,8 @@ launch the interactive TUI, or use subcommands for scriptable access.`,
 
 	cmd.AddCommand(newTaskCmd())
 	cmd.AddCommand(NewDoorsCmd())
+	cmd.AddCommand(newHealthCmd())
+	cmd.AddCommand(newVersionCmd())
 
 	return cmd
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// Build-time variables set via -ldflags.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+// versionData holds structured version info for JSON output.
+type versionData struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildDate string `json:"build_date"`
+	GoVersion string `json:"go_version"`
+}
+
+// newVersionCmd creates the "version" subcommand.
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show version information",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runVersion()
+		},
+	}
+	return cmd
+}
+
+func runVersion() error {
+	return writeVersion(os.Stdout, jsonOutput)
+}
+
+func writeVersion(w io.Writer, isJSON bool) error {
+	formatter := NewOutputFormatter(w, isJSON)
+
+	data := versionData{
+		Version:   Version,
+		Commit:    Commit,
+		BuildDate: BuildDate,
+		GoVersion: runtime.Version(),
+	}
+
+	if isJSON {
+		return formatter.WriteJSON("version", data, nil)
+	}
+
+	_ = formatter.Writef("ThreeDoors %s\n", data.Version)
+	_ = formatter.Writef("Commit:     %s\n", data.Commit)
+	_ = formatter.Writef("Built:      %s\n", data.BuildDate)
+	return formatter.Writef("Go version: %s\n", data.GoVersion)
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestVersionHumanOutput(t *testing.T) {
+	t.Parallel()
+
+	oldVersion, oldCommit, oldBuildDate := Version, Commit, BuildDate
+	Version, Commit, BuildDate = "1.2.3", "abc1234", "2025-01-15T10:00:00Z"
+	t.Cleanup(func() {
+		Version, Commit, BuildDate = oldVersion, oldCommit, oldBuildDate
+	})
+
+	var buf bytes.Buffer
+	err := writeVersion(&buf, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	checks := []string{"ThreeDoors 1.2.3", "abc1234", "2025-01-15T10:00:00Z", runtime.Version()}
+	for _, want := range checks {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func TestVersionJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	oldVersion, oldCommit, oldBuildDate := Version, Commit, BuildDate
+	Version, Commit, BuildDate = "2.0.0", "def5678", "2025-06-01T00:00:00Z"
+	t.Cleanup(func() {
+		Version, Commit, BuildDate = oldVersion, oldCommit, oldBuildDate
+	})
+
+	var buf bytes.Buffer
+	err := writeVersion(&buf, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var env JSONEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	if env.Command != "version" {
+		t.Errorf("command = %q, want %q", env.Command, "version")
+	}
+	if env.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", env.SchemaVersion)
+	}
+
+	data, ok := env.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("data is not a map: %T", env.Data)
+	}
+	if data["version"] != "2.0.0" {
+		t.Errorf("version = %v, want %q", data["version"], "2.0.0")
+	}
+	if data["commit"] != "def5678" {
+		t.Errorf("commit = %v, want %q", data["commit"], "def5678")
+	}
+	if data["build_date"] != "2025-06-01T00:00:00Z" {
+		t.Errorf("build_date = %v, want %q", data["build_date"], "2025-06-01T00:00:00Z")
+	}
+	if data["go_version"] != runtime.Version() {
+		t.Errorf("go_version = %v, want %q", data["go_version"], runtime.Version())
+	}
+}
+
+func TestVersionCommandRegistered(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "version" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("version command not registered on root")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `threedoors health` command that runs all health checks via `HealthChecker.RunAll()` and displays results as a table (Check, Status, Message) or JSON envelope with `--json`
- Adds `threedoors version` command showing version, commit, build date, Go version in human or JSON format
- Updates Makefile to inject `Version`, `Commit`, `BuildDate` via `-ldflags` into `internal/cli` package variables
- Health command exits 0 on all-pass, exit code 4 on any FAIL
- All CLI commands use consistent exit code scheme (0-5) defined in `exitcodes.go`

## Story

Implements [Story 23.5](docs/stories/23.5.story.md) — Health, Version Commands and Exit Code Enforcement

## Acceptance Criteria

- [x] AC1: `threedoors health` runs checks and displays table
- [x] AC2: `threedoors health --json` outputs JSON envelope with overall, duration_ms, checks[]
- [x] AC3: Health exits 0 if all pass, exit 4 if any fail
- [x] AC4: `threedoors version` shows version, commit, build date, Go version
- [x] AC5: `threedoors version --json` outputs JSON envelope
- [x] AC6: Version info populated via ldflags (Makefile updated)
- [x] AC7: All CLI commands use exit code scheme (0-5)
- [x] AC8: Unit tests verify exit codes and output formats

## Quality Gates

- [x] `make fmt` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all green)
- [x] Rebased on latest upstream/main

## Test Plan

- `TestVersionHumanOutput` — verifies version, commit, build date, go version in text output
- `TestVersionJSONOutput` — verifies JSON envelope structure and field values
- `TestVersionCommandRegistered` — verifies command registration
- `TestHealthCommandRegistered` — verifies command registration
- `TestHealthCheckerResultsJSON` — verifies JSON envelope with overall, duration_ms, checks[]
- `TestHealthCheckerTableOutput` — verifies table contains expected check names
- `TestExitCodeConstants` — verifies all 6 exit codes have correct values (0-5)

## Files Changed

| File | Change |
|------|--------|
| `internal/cli/health.go` | New health command |
| `internal/cli/health_test.go` | Health command tests |
| `internal/cli/version.go` | New version command with ldflags vars |
| `internal/cli/version_test.go` | Version command tests |
| `internal/cli/root.go` | Register health + version commands |
| `Makefile` | Add commit/build-date ldflags |
| `docs/stories/23.5.story.md` | Status → Done |