### PR TITLE
feat: BMAD planning — GitHub Issues Integration epic and stories

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,28 @@ Expose task management to LLMs via Model Context Protocol.
 | 24.5 | TUI Proposal Review View | Not Started | P1 | 24.4 (done) |
 | 24.8 | MCP Prompt Templates & Advanced Interaction Patterns | Not Started | P1 | 24.6 (done), 24.7 (done) |
 
+### Epic 25: Todoist Integration (P1) — 0/4 stories done
+
+Todoist as task source via REST API v1. Thin HTTP client, read-only then bidirectional sync.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 25.1 | Todoist HTTP Client & Auth Configuration | Not Started | P1 | Epic 7 (done) |
+| 25.2 | Read-Only Todoist Adapter with Field Mapping | Not Started | P1 | 25.1 |
+| 25.3 | Bidirectional Sync & WAL Integration | Not Started | P1 | 25.2 |
+| 25.4 | Contract Tests & Integration Testing | Not Started | P1 | 25.2 |
+
+### Epic 26: GitHub Issues Integration (P1) — 0/4 stories done
+
+GitHub Issues as task source for developer workflows. Official go-github SDK.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 26.1 | GitHub SDK Client & Auth Configuration | Not Started | P1 | Epic 7 (done) |
+| 26.2 | Read-Only GitHub Provider with Field Mapping | Not Started | P1 | 26.1 |
+| 26.3 | Bidirectional Sync & WAL Integration | Not Started | P1 | 26.2 |
+| 26.4 | Contract Tests & Integration Testing | Not Started | P1 | 26.2 |
+
 ## Completed Epics
 
 | Epic | Title | Stories |

--- a/_bmad-output/planning-artifacts/party-mode-github-issues-2026-03-07.md
+++ b/_bmad-output/planning-artifacts/party-mode-github-issues-2026-03-07.md
@@ -1,0 +1,28 @@
+# Party Mode Consensus: GitHub Issues Integration (Epic 26)
+
+**Date:** 2026-03-07
+**Participants:** Winston (Architect), John (PM), Amelia (Dev), Quinn (QA), Bob (SM), Murat (Test Architect)
+
+## Unanimous Decisions
+
+1. **Epic 26** — GitHub Issues Integration, 4 stories following established adapter pattern
+2. **Use `go-github` SDK** (google/go-github) — official, well-maintained, handles pagination/auth/rate-limiting natively
+3. **Label-based conventions** for priority mapping (`priority:critical/high/medium/low` labels to Effort) and status enrichment (`in-progress` label maps to in-progress status)
+4. **Explicit repo list** in config.yaml (`repos: ["owner/repo1", "owner/repo2"]`) — org-level queries deferred
+5. **Read-only first** (Story 26.2 delivers 80% value), then bidirectional sync (Story 26.3)
+6. **Schedule after Epic 25** (Todoist) to leverage learnings from first raw-HTTP adapter
+7. **Source badge:** `[GH]`
+8. **Package:** `internal/adapters/github/`
+9. **Assignee filter:** Default `@me` — only show issues assigned to the authenticated user
+10. **Mock strategy:** Interface-based mocking of go-github client for unit tests, httptest.NewServer for integration tests
+
+## Key Technical Decisions
+
+- `go-github` SDK adds a dependency — acceptable (Google-maintained, Apache-2.0, no transitive concerns)
+- Reuse `RateLimitError` pattern from Jira adapter, wrapping go-github's native rate limit errors
+- Contract test coverage target: 80%+ for github package
+- Config: PAT token via `GITHUB_TOKEN` env var or `config.yaml` settings
+
+## No Dissenting Opinions
+
+All agents agree this is a well-understood, low-risk integration following proven patterns.

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-07-github-issues.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-07-github-issues.md
@@ -1,0 +1,154 @@
+# Sprint Change Proposal: GitHub Issues Integration
+
+**Date:** 2026-03-07
+**Change Type:** New Epic Proposal (Additive)
+**Scope Classification:** Minor — Direct implementation by dev team
+
+---
+
+## Section 1: Issue Summary
+
+**Problem Statement:** ThreeDoors currently lacks integration with GitHub Issues, the primary task tracker for its target audience (developers). The task source expansion research (docs/research/task-source-expansion-research.md) identifies GitHub Issues as Tier 1 priority due to maximum developer audience overlap (100M+ developers), an excellent official Go SDK (google/go-github), and 2-3 day estimated implementation effort.
+
+**Discovery Context:** Identified during systematic evaluation of task source expansion candidates. The Adapter SDK (Epic 7), Multi-Source Aggregation (Epic 13), and Sync Protocol Hardening (Epic 21) are all complete, meaning all infrastructure prerequisites are in place.
+
+**Evidence:**
+- GitHub Issues is the #2 Tier 1 integration (after Todoist, which is Epic 25)
+- Official `google/go-github` SDK — actively maintained, excellent quality
+- PAT authentication — simple, low friction for developers
+- 5,000 requests/hour rate limit — generous
+- `assignee` filter enables user-scoped issue queries across repositories
+
+---
+
+## Section 2: Impact Analysis
+
+### Epic Impact
+- **No existing epics affected** — this is a purely additive new epic (Epic 26)
+- **Dependencies satisfied:** Epic 7 (Adapter SDK), Epic 13 (Multi-Source Aggregation), Epic 21 (Sync Protocol Hardening) are all COMPLETE
+- **Pattern established:** Follows identical adapter pattern as Epic 19 (Jira), Epic 20 (Apple Reminders), and Epic 25 (Todoist)
+
+### Story Impact
+- No current or future stories require modification
+- New stories follow the proven 4-story integration pattern:
+  1. HTTP Client / SDK wrapper & auth config
+  2. Read-only provider with field mapping
+  3. Bidirectional sync & WAL integration
+  4. Contract tests & integration testing
+
+### Artifact Conflicts
+- **PRD:** Needs new functional requirements (FR93-FR96) for GitHub Issues integration
+- **Architecture:** No structural changes needed — adapter layer is designed for this
+- **UI/UX:** No changes — existing source badge pattern applies (`[GH]` badge)
+- **ROADMAP.md:** Needs new Epic 26 entry
+
+### Technical Impact
+- New package: `internal/adapters/github/`
+- New dependency: `github.com/google/go-github/v68` (official SDK)
+- Config additions: `github` provider settings in `~/.threedoors/config.yaml`
+- No changes to existing code — pure addition
+
+---
+
+## Section 3: Recommended Approach
+
+**Selected Path:** Direct Adjustment — Add new Epic 26 within existing plan
+
+**Rationale:**
+- All infrastructure is in place (adapter registry, contract tests, WAL, circuit breaker)
+- Proven 4-story pattern from Jira/Reminders/Todoist integrations
+- No impact on active work (Epics 23, 24, 25)
+- 2-3 days estimated effort — low risk
+- High value: developer audience overlap is maximum
+
+**Effort Estimate:** Low (2-3 days)
+**Risk Level:** Low — official SDK, proven pattern, no architectural changes
+**Timeline Impact:** None — parallel track, no blocking dependencies
+
+---
+
+## Section 4: Detailed Change Proposals
+
+### 4.1 PRD Requirements (New)
+
+```
+ADD to docs/prd/requirements.md — Phase 4+ Task Source Integration section:
+
+FR93: The system shall integrate with GitHub Issues as a task source using the
+official go-github SDK, reading issues with structured field mapping (title to
+Text, body to Context, labels to Tags, state to Status), filtering by assignee
+and repository scope.
+
+FR94: The system shall support GitHub authentication via Personal Access Token
+(PAT) configured in ~/.threedoors/config.yaml, with configurable repository
+list (repos) and assignee filter (default: @me) for scoping which issues to
+import.
+
+FR95: The system shall map GitHub Issues fields to ThreeDoors task model:
+open state maps to todo, closed state maps to complete, labels matching
+"priority:*" convention map to Effort, milestone.due_on maps to due date,
+and "in progress" label maps to in-progress status.
+
+FR96: The system shall support bidirectional GitHub sync by closing issues via
+the GitHub API when tasks are marked complete in ThreeDoors, with offline
+queuing via WALProvider.
+```
+
+### 4.2 Epics & Stories (New)
+
+```
+ADD Epic 26: GitHub Issues Integration
+
+4 stories following established adapter pattern:
+- 26.1: GitHub SDK Client & Auth Configuration
+- 26.2: Read-Only GitHub Provider with Field Mapping
+- 26.3: Bidirectional Sync & WAL Integration
+- 26.4: Contract Tests & Integration Testing
+```
+
+### 4.3 ROADMAP.md (New Entry)
+
+```
+ADD to Active Epics section:
+
+### Epic 26: GitHub Issues Integration (P1) -- 0/4 stories done
+
+GitHub Issues as task source for developer workflows. Official go-github SDK.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 26.1 | GitHub SDK Client & Auth Configuration | Not Started | P1 | Epic 7 (done) |
+| 26.2 | Read-Only GitHub Provider | Not Started | P1 | 26.1 |
+| 26.3 | Bidirectional Sync & WAL Integration | Not Started | P1 | 26.2 |
+| 26.4 | Contract Tests & Integration Testing | Not Started | P1 | 26.2 |
+```
+
+---
+
+## Section 5: Implementation Handoff
+
+**Change Scope:** Minor — Direct implementation by development team
+
+**Handoff Recipients:**
+- **PM agent:** Update PRD with FR93-FR96
+- **Architect agent:** No architecture changes needed (existing adapter pattern)
+- **Dev workers:** Implement Epic 26 stories (4 stories, 2-3 days)
+
+**Success Criteria:**
+- All 4 stories implemented and merged
+- Contract tests pass
+- GitHub Issues appear as doors in TUI with `[GH]` badge
+- Completing a GitHub issue in ThreeDoors closes it on GitHub
+- Offline queuing works via WALProvider
+
+**Recommended Implementation Order:**
+1. Epic 25 (Todoist) first — already planned, validates the pattern for non-Atlassian/Apple APIs
+2. Epic 26 (GitHub Issues) second — leverages learnings from Todoist implementation
+
+---
+
+## Approval
+
+**Approved by:** BMAD workflow (autonomous pipeline)
+**Scope:** Minor — no existing work affected, purely additive
+**Next Steps:** Proceed with PRD updates, architecture documentation, and epic/story creation

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -461,6 +461,60 @@ type ChangeEvent struct {
 - `github.com/fsnotify/fsnotify` — filesystem watching
 - Markdown parser for task extraction
 
+#### Component: GitHubAdapter (Epic 26)
+
+**Responsibility:** Read/write tasks from GitHub Issues using the official `go-github` SDK, mapping issues to ThreeDoors tasks with label-based priority conventions.
+
+**Implements:** `TaskProvider`
+
+**Key Interfaces:**
+
+```go
+// GitHubProvider implements core.TaskProvider for GitHub Issues.
+type GitHubProvider struct {
+    client *GitHubClient
+    config *GitHubConfig
+    cache  *TaskCache
+}
+
+func NewGitHubProvider(config *GitHubConfig) *GitHubProvider
+```
+
+**Key Behaviors:**
+- Load issues via `go-github` SDK filtered by assignee and repo list
+- Map fields: `title` -> Text, `body` -> Context, `labels` -> Tags, `state` -> Status
+- Label conventions: `priority:critical/high/medium/low` -> Effort, `in-progress` -> in-progress status
+- `MarkComplete()` closes the issue via GitHub API
+- `HealthCheck()` verifies API connectivity via authenticated user endpoint
+- `Watch()` polls for issue changes at configurable intervals
+- Local cache at `~/.threedoors/github-cache.yaml` with configurable TTL
+- Source badge: `[GH]`
+
+**Dependencies:**
+- `github.com/google/go-github/v68` -- official GitHub SDK
+- `internal/adapters/contract.go` -- contract test suite
+- `internal/sync/` -- WALProvider for offline queuing
+
+**Configuration:**
+
+```yaml
+providers:
+  - name: github
+    settings:
+      token: "ghp_xxx"           # or GITHUB_TOKEN env var
+      repos:
+        - "owner/repo1"
+        - "owner/repo2"
+      assignee: "@me"            # default: authenticated user
+      poll_interval: "5m"        # default: 5 minutes
+      priority_labels:           # optional label-to-effort mapping
+        critical: "priority:critical"
+        high: "priority:high"
+        medium: "priority:medium"
+        low: "priority:low"
+      in_progress_label: "in-progress"  # label indicating active work
+```
+
 #### Component: PluginSDK (Epic 7)
 
 **Responsibility:** Provide developer-facing tools and documentation for third-party adapter development.
@@ -759,6 +813,7 @@ graph TB
         TextAdapter[TextFileAdapter]
         NotesAdapter[AppleNotesAdapter]
         ObsidianAdapter[ObsidianAdapter]
+        GitHubAdapter[GitHubAdapter]
     end
 
     subgraph Sync[Sync Engine - internal/sync]
@@ -799,6 +854,7 @@ graph TB
     Registry --> TextAdapter
     Registry --> NotesAdapter
     Registry --> ObsidianAdapter
+    Registry --> GitHubAdapter
 
     SyncEngine --> Queue
     SyncEngine --> Conflicts

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -221,6 +221,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 | FR73-FR80 | Epic 22 ✅ | Self-Driving Development Pipeline (COMPLETE) |
 | FR81-FR88 | Epic 24 | MCP/LLM Integration Server (NOT STARTED) |
 | FR89-FR92 | Epic 25 | Todoist Integration (NOT STARTED) |
+| FR93-FR96 | Epic 26 | GitHub Issues Integration (NOT STARTED) |
 
 ## Epic List
 
@@ -355,6 +356,18 @@ Expose ThreeDoors task management to LLMs via Model Context Protocol. Read-only 
 **FRs covered:** FR81-FR88
 **Prerequisites:** Epic 13 ✅ (Multi-Source Aggregation), Epic 6 ✅ (Enrichment DB)
 **Status:** Not Started. 8 stories planned (24.1-24.8). Research at `docs/research/llm-integration-mcp.md`.
+
+### Epic 25: Todoist Integration — NOT STARTED
+Todoist as a task source with thin HTTP client against REST API v1, read-only adapter, bidirectional sync.
+**FRs covered:** FR89-FR92
+**Prerequisites:** Epic 7 ✅ (Adapter SDK), Epic 13 ✅ (Multi-Source Aggregation), Epic 21 ✅ (Sync Protocol Hardening)
+**Status:** Not Started. 4 stories planned (25.1-25.4). Research at `docs/research/task-source-expansion-research.md`.
+
+### Epic 26: GitHub Issues Integration — NOT STARTED
+GitHub Issues as a task source for developer workflows using the official go-github SDK. Label-based priority/status conventions.
+**FRs covered:** FR93-FR96
+**Prerequisites:** Epic 7 ✅ (Adapter SDK), Epic 13 ✅ (Multi-Source Aggregation), Epic 21 ✅ (Sync Protocol Hardening)
+**Status:** Not Started. 4 stories planned (26.1-26.4). Research at `docs/research/task-source-expansion-research.md`.
 
 ---
 
@@ -2943,3 +2956,118 @@ As a developer, I want the Todoist adapter to pass the contract test suite with 
 - **Priority inversion:** Todoist 4 (critical) maps to highest effort; Todoist 0/1 maps to lowest
 - **Read-only first:** Story 25.2 delivers 80% of user value; 25.3 completes the loop
 - **Config:** Mutually exclusive `project_ids` and `filter` options for task scoping
+
+---
+
+## Epic 26: GitHub Issues Integration
+
+**Priority:** P1 — High value, all infrastructure in place
+**Status:** Not Started (0/4 stories)
+**Dependencies:** Epic 7 (Adapter SDK) COMPLETE, Epic 13 (Multi-Source Aggregation) COMPLETE, Epic 21 (Sync Protocol Hardening) COMPLETE
+
+### Epic Goal
+
+Integrate GitHub Issues as a task source adapter using the official `go-github` SDK, enabling ThreeDoors users to view and manage their GitHub issues through the Three Doors decision-friction interface. Target audience overlap is maximum — developers already track work in GitHub Issues.
+
+### Requirements Coverage
+
+| Requirement | Story | Description |
+|------------|-------|-------------|
+| FR93 | 26.1, 26.2 | GitHub Issues integration with field mapping via go-github SDK |
+| FR94 | 26.1 | PAT auth with repo list and assignee filter config |
+| FR95 | 26.2 | Label-based priority/status mapping conventions |
+| FR96 | 26.3 | Bidirectional sync with WAL queuing |
+
+### Stories
+
+#### Story 26.1: GitHub SDK Client & Auth Configuration
+
+**Status:** Not Started | **Priority:** P1 | **Depends On:** Epic 7 (done)
+
+As a developer, I want a GitHub API client using the official go-github SDK, so that the GitHubProvider can read and close issues with proper authentication and rate limit handling.
+
+**Acceptance Criteria:**
+- AC1: `GitHubClient` struct in `internal/adapters/github/github_client.go` wrapping `go-github` SDK
+- AC2: PAT authentication via `GITHUB_TOKEN` env var or config.yaml settings
+- AC3: `ListIssues(ctx, repo, assignee) ([]GitHubIssue, error)` method using go-github SDK
+- AC4: `CloseIssue(ctx, repo, issueNumber) error` method for issue completion
+- AC5: `GetAuthenticatedUser(ctx) (string, error)` method for health check
+- AC6: Rate limit handling wrapping go-github's native `*github.RateLimitError` into adapter `RateLimitError` pattern
+- AC7: `GitHubConfig` struct with `Token`, `Repos`, `Assignee`, `PollInterval`, `PriorityLabels`, `InProgressLabel` fields
+- AC8: Config validation: `repos` list required, `assignee` defaults to `@me`
+- AC9: Unit tests using `httptest.NewServer` with canned GitHub API responses
+
+**File:** `docs/stories/26.1.story.md`
+
+---
+
+#### Story 26.2: Read-Only GitHub Provider with Field Mapping
+
+**Status:** Not Started | **Priority:** P1 | **Depends On:** 26.1
+
+As a ThreeDoors user who tracks work in GitHub Issues, I want my assigned issues to appear as doors in the Three Doors TUI.
+
+**Acceptance Criteria:**
+- AC1: `GitHubProvider` implementing full `TaskProvider` interface
+- AC2: Field mapping: title->Text, body->Context, state->Status, labels->Tags
+- AC3: Status mapping: `open`->`todo`, `closed`->`complete`, `in-progress` label->`in-progress`
+- AC4: Label-to-Effort mapping: `priority:critical`->deep-work, `priority:high`->deep-work, `priority:medium`->medium, `priority:low`->quick-win
+- AC5: Write methods return `core.ErrReadOnly`
+- AC6: `HealthCheck()` verifies API connectivity via `GetAuthenticatedUser()`
+- AC7: `[GH]` source badge in TUI
+- AC8: Local cache at `~/.threedoors/github-cache.yaml` with configurable TTL
+- AC9: Factory function for adapter registry registration
+- AC10: Multi-repo aggregation — issues from all configured repos merged into single result
+
+**File:** `docs/stories/26.2.story.md`
+
+---
+
+#### Story 26.3: Bidirectional Sync & WAL Integration
+
+**Status:** Not Started | **Priority:** P1 | **Depends On:** 26.2
+
+As a ThreeDoors user, I want completing a GitHub issue in ThreeDoors to close it on GitHub.
+
+**Acceptance Criteria:**
+- AC1: `MarkComplete(taskID)` calls `CloseIssue` via GitHub API
+- AC2: On API failure, change queued via `WALProvider`
+- AC3: WAL replay on connectivity restoration
+- AC4: Rate limit handling with exponential backoff
+- AC5: Circuit breaker integration (5 failures / 2min window)
+- AC6: Unit tests for success, WAL fallback, and rate limit flows
+
+**File:** `docs/stories/26.3.story.md`
+
+---
+
+#### Story 26.4: Contract Tests & Integration Testing
+
+**Status:** Not Started | **Priority:** P1 | **Depends On:** 26.2
+
+As a developer, I want the GitHub adapter to pass the contract test suite with comprehensive edge case coverage.
+
+**Acceptance Criteria:**
+- AC1: `adapters.RunContractTests` passes with mock HTTP server
+- AC2: Table-driven label-to-priority mapping tests (all combinations)
+- AC3: Status mapping tests (open, closed, in-progress label)
+- AC4: Multi-repo aggregation tests
+- AC5: Rate limit handling tests
+- AC6: Empty repo (no issues) edge case test
+- AC7: Special character handling tests (issue titles with unicode, markdown bodies)
+- AC8: Assignee filtering tests
+- AC9: Test coverage >= 80% for github package
+
+**File:** `docs/stories/26.4.story.md`
+
+---
+
+### Implementation Notes
+
+- **Architecture:** Follows the exact same adapter pattern as Jira (Epic 19), Apple Reminders (Epic 20), and Todoist (Epic 25)
+- **Package:** `internal/adapters/github/` — SDK client wrapper, provider, field mapping, config
+- **SDK:** Use official `google/go-github` (unlike Todoist which uses raw HTTP due to deprecated SDK)
+- **Label conventions:** `priority:critical/high/medium/low` for effort mapping; `in-progress` for status enrichment
+- **Read-only first:** Story 26.2 delivers 80% of user value; 26.3 completes the loop
+- **Config:** Explicit repo list required; org-level queries deferred to future enhancement
+- **Schedule:** Recommended after Epic 25 (Todoist) to leverage learnings

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -286,6 +286,16 @@
 
 **FR92:** The system shall support bidirectional Todoist sync by completing tasks via the REST API when tasks are marked complete in ThreeDoors, with offline queuing via WALProvider
 
+**GitHub Issues Integration:**
+
+**FR93:** The system shall integrate with GitHub Issues as a task source using the official go-github SDK, reading issues with structured field mapping (title to Text, body to Context, labels to Tags, state to Status), filtering by assignee and configurable repository scope
+
+**FR94:** The system shall support GitHub authentication via Personal Access Token (PAT) configured in `~/.threedoors/config.yaml` or `GITHUB_TOKEN` environment variable, with a configurable repository list (`repos`) and assignee filter (default: `@me`) for scoping which issues to import
+
+**FR95:** The system shall map GitHub Issues fields to ThreeDoors task model: `open` state maps to `todo`, `closed` state maps to `complete`, labels matching `priority:*` convention map to Effort values, `milestone.due_on` maps to due date, and `in-progress` label maps to `in-progress` status
+
+**FR96:** The system shall support bidirectional GitHub sync by closing issues via the GitHub API when tasks are marked complete in ThreeDoors, with offline queuing via WALProvider
+
 **Sync Protocol Hardening:**
 
 **FR70:** The system shall provide a sync scheduler with per-provider independent sync loops, supporting hybrid push (Watch channel) and polling with adaptive intervals (backoff on failure, reset on success)

--- a/docs/stories/26.1.story.md
+++ b/docs/stories/26.1.story.md
@@ -1,0 +1,77 @@
+# Story 26.1: GitHub SDK Client & Auth Configuration
+
+**Status:** Not Started
+**Epic:** 26 — GitHub Issues Integration
+**Blocks:** Stories 26.2, 26.3, 26.4
+
+## User Story
+
+As a developer,
+I want a GitHub API client using the official go-github SDK,
+So that the GitHubProvider can read and close issues with proper authentication and rate limit handling.
+
+## Acceptance Criteria
+
+**Given** the need for GitHub API access
+**When** the SDK client wrapper is implemented
+**Then:**
+
+- AC1: `GitHubClient` struct in `internal/adapters/github/github_client.go` with `NewGitHubClient(config *GitHubConfig) *GitHubClient`
+- AC2: PAT authentication via `GITHUB_TOKEN` env var (preferred) or `token` in config.yaml settings
+- AC3: `ListIssues(ctx, owner, repo, assignee) ([]*GitHubIssue, error)` method wrapping go-github SDK's `IssuesService.ListByRepo`
+- AC4: `CloseIssue(ctx, owner, repo, issueNumber) error` method using go-github SDK's `IssuesService.Edit` to set state to "closed"
+- AC5: `GetAuthenticatedUser(ctx) (string, error)` method wrapping `UsersService.Get` for health check and `@me` resolution
+- AC6: Rate limit handling: wrap go-github's `*github.RateLimitError` into adapter `RateLimitError` pattern (reuse from Jira adapter)
+- AC7: `GitHubConfig` struct with `Token`, `Repos` ([]string, required), `Assignee` (default "@me"), `PollInterval` (default "5m"), `PriorityLabels` (map), `InProgressLabel` (default "in-progress") fields
+- AC8: Config validation: `repos` list must be non-empty, repos must be in `owner/repo` format
+- AC9: `GitHubIssue` struct mapping relevant go-github `Issue` fields for internal use
+- AC10: Unit tests using `httptest.NewServer` with canned GitHub API JSON responses
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- Use `github.com/google/go-github/v68` — official Google-maintained SDK
+- Auth: `github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})))`
+- Rate limits: 5,000 requests/hour (authenticated) — go-github exposes `Rate` on responses
+- go-github handles pagination natively via `ListOptions`
+- Accept interfaces, return concrete types: `NewGitHubClient(config *GitHubConfig) *GitHubClient`
+- Context as first parameter on all methods
+- Reuse `RateLimitError` pattern from `internal/adapters/jira/`
+
+## Dependencies
+
+- None — this is the foundation story for Epic 26
+- External: `github.com/google/go-github/v68` (new dependency)
+- External: `golang.org/x/oauth2` (for token-based auth with go-github)
+
+## Tasks
+
+1. Create `internal/adapters/github/` package directory
+2. Add `go-github` and `oauth2` dependencies via `go get`
+3. Define `GitHubConfig`, `GitHubClient`, `GitHubIssue` types
+4. Implement PAT auth with env var and config.yaml support
+5. Implement `ListIssues` wrapping go-github SDK
+6. Implement `CloseIssue` for issue completion
+7. Implement `GetAuthenticatedUser` for health check
+8. Implement rate limit error wrapping
+9. Implement config validation
+10. Write unit tests with httptest server
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] go-github dependency added cleanly (go.mod, go.sum updated)
+- [ ] No `init()` functions used
+- [ ] All errors wrapped with `%w` and context
+- [ ] Timestamps use `time.Now().UTC()`

--- a/docs/stories/26.2.story.md
+++ b/docs/stories/26.2.story.md
@@ -1,0 +1,83 @@
+# Story 26.2: Read-Only GitHub Provider with Field Mapping
+
+**Status:** Not Started
+**Epic:** 26 — GitHub Issues Integration
+**Depends On:** Story 26.1
+**Blocks:** Stories 26.3, 26.4
+
+## User Story
+
+As a ThreeDoors user who tracks work in GitHub Issues,
+I want my assigned GitHub issues to appear as doors in the Three Doors TUI,
+So that I can manage my development tasks through the decision-friction interface.
+
+## Acceptance Criteria
+
+**Given** a configured GitHub provider with valid PAT and repos
+**When** the provider loads tasks
+**Then:**
+
+- AC1: `GitHubProvider` struct in `internal/adapters/github/github_provider.go` implementing full `TaskProvider` interface
+- AC2: Field mapping: `title` -> Text, `body` (Markdown) -> Context, `state` -> Status, `labels[].name` -> Tags
+- AC3: Status mapping: `open` -> `todo`, `closed` -> `complete`; if issue has label matching `InProgressLabel` config (default "in-progress"), map to `in-progress`
+- AC4: Label-to-Effort mapping using `PriorityLabels` config: `priority:critical` -> deep-work, `priority:high` -> deep-work, `priority:medium` -> medium, `priority:low` -> quick-win; no matching label -> quick-win (default)
+- AC5: `milestone.due_on` mapped to task due date when present
+- AC6: Write methods (`Save`, `Delete`) return `core.ErrReadOnly`
+- AC7: `HealthCheck()` verifies API connectivity via `GetAuthenticatedUser()`
+- AC8: `Name()` returns `"github"`, source badge `[GH]` in TUI
+- AC9: Local task cache at `~/.threedoors/github-cache.yaml` with configurable TTL (default 5 minutes)
+- AC10: Factory function `NewGitHubProviderFactory()` for adapter registry registration in `cmd/threedoors/main.go`
+- AC11: Multi-repo aggregation: issues from all configured repos merged into a single `[]*Task` result, each tagged with `SourceProvider: "github"` and `Location` set to `owner/repo#number`
+- AC12: Only open issues returned by default (closed issues filtered unless explicitly configured)
+- AC13: `Watch()` returns a channel that emits `ChangeEvent` on polling interval changes
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- Follow exact same provider pattern as `internal/adapters/todoist/todoist_provider.go` and `internal/adapters/jira/jira_provider.go`
+- Task ID format: `github:<owner>/<repo>#<number>` for cross-provider uniqueness
+- go-github returns `*github.Issue` — map to internal `GitHubIssue` then to `*core.Task`
+- Pagination: go-github handles via `ListOptions{PerPage: 100}` — iterate all pages
+- Cache invalidation: on `Load()`, check cache age against TTL; if stale, refresh from API
+- `@me` assignee resolution: use `GetAuthenticatedUser()` result from Story 26.1
+
+## Dependencies
+
+- Story 26.1 (GitHubClient & auth)
+- `internal/core/` (TaskProvider interface, Task model, ErrReadOnly)
+- `internal/adapters/contract.go` (contract test interface)
+- `cmd/threedoors/main.go` (registry registration)
+
+## Tasks
+
+1. Create `GitHubProvider` struct with `GitHubClient` dependency
+2. Implement `Load()` with multi-repo issue fetching and field mapping
+3. Implement status mapping logic (open/closed + in-progress label)
+4. Implement label-to-effort mapping with configurable priority labels
+5. Implement milestone-to-due-date mapping
+6. Implement read-only write stubs returning `ErrReadOnly`
+7. Implement `HealthCheck()` and `Name()`
+8. Implement local cache with TTL
+9. Implement `Watch()` with polling interval
+10. Register factory in adapter registry
+11. Write unit tests for all mapping scenarios
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] Factory registered in adapter registry
+- [ ] `[GH]` source badge displays correctly
+- [ ] No `init()` functions used
+- [ ] All errors wrapped with `%w` and context
+- [ ] Timestamps use `time.Now().UTC()`

--- a/docs/stories/26.3.story.md
+++ b/docs/stories/26.3.story.md
@@ -1,0 +1,70 @@
+# Story 26.3: Bidirectional Sync & WAL Integration
+
+**Status:** Not Started
+**Epic:** 26 — GitHub Issues Integration
+**Depends On:** Story 26.2
+
+## User Story
+
+As a ThreeDoors user,
+I want completing a GitHub issue in ThreeDoors to close it on GitHub,
+So that my task status stays synchronized across both systems.
+
+## Acceptance Criteria
+
+**Given** a GitHub issue displayed as a door in ThreeDoors
+**When** the user marks the task as complete
+**Then:**
+
+- AC1: `MarkComplete(taskID)` calls `CloseIssue(ctx, owner, repo, number)` via GitHub API
+- AC2: On successful API call, issue state changes to "closed" on GitHub
+- AC3: On API failure (network error, rate limit), change queued via `WALProvider` for later replay
+- AC4: WAL replay attempts on next successful connectivity check
+- AC5: Rate limit errors (HTTP 429) handled with exponential backoff respecting `Retry-After` header
+- AC6: Circuit breaker integration: trips Open after 5 consecutive failures within 2-minute window
+- AC7: `Save()` and `Delete()` remain `ErrReadOnly` — only `MarkComplete()` writes back
+- AC8: Unit tests covering: success path, WAL fallback on failure, rate limit handling, circuit breaker trip
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- Follow exact same WAL integration pattern as `internal/adapters/jira/jira_provider.go` and `internal/adapters/todoist/`
+- Parse task ID format `github:<owner>/<repo>#<number>` to extract owner, repo, issue number
+- go-github SDK's `IssuesService.Edit` with `&github.IssueRequest{State: github.Ptr("closed")}`
+- WALProvider wraps the GitHubProvider — queue writes when API unavailable
+- Circuit breaker from `internal/sync/` — reuse existing per-provider circuit breaker
+
+## Dependencies
+
+- Story 26.2 (GitHubProvider with read-only implementation)
+- `internal/sync/wal.go` (WALProvider)
+- `internal/sync/circuit_breaker.go` (CircuitBreaker)
+
+## Tasks
+
+1. Implement `MarkComplete()` with API call to close issue
+2. Parse task ID to extract owner/repo/number
+3. Integrate WALProvider for offline queuing on failure
+4. Add rate limit handling with exponential backoff
+5. Integrate circuit breaker
+6. Write unit tests for all paths (success, WAL, rate limit, circuit breaker)
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] WAL integration tested with mock failure scenarios
+- [ ] Circuit breaker behavior verified
+- [ ] No `init()` functions used
+- [ ] All errors wrapped with `%w` and context
+- [ ] Timestamps use `time.Now().UTC()`

--- a/docs/stories/26.4.story.md
+++ b/docs/stories/26.4.story.md
@@ -1,0 +1,89 @@
+# Story 26.4: Contract Tests & Integration Testing
+
+**Status:** Not Started
+**Epic:** 26 — GitHub Issues Integration
+**Depends On:** Story 26.2
+
+## User Story
+
+As a developer,
+I want the GitHub adapter to pass the contract test suite with comprehensive edge case coverage,
+So that the adapter reliably integrates with the ThreeDoors ecosystem.
+
+## Acceptance Criteria
+
+**Given** the GitHubProvider implementation from Stories 26.1-26.3
+**When** the contract and integration tests are executed
+**Then:**
+
+- AC1: `adapters.RunContractTests` passes with mock HTTP server backing the go-github client
+- AC2: Table-driven label-to-priority mapping tests covering all combinations:
+  - No priority label -> quick-win (default)
+  - `priority:low` -> quick-win
+  - `priority:medium` -> medium
+  - `priority:high` -> deep-work
+  - `priority:critical` -> deep-work
+  - Custom label names via config
+- AC3: Status mapping tests:
+  - `open` state -> `todo`
+  - `closed` state -> `complete`
+  - `open` state + `in-progress` label -> `in-progress`
+  - `open` state + custom in-progress label name via config
+- AC4: Multi-repo aggregation tests: issues from 2+ repos merged correctly with unique IDs
+- AC5: Rate limit handling tests: mock 429 response triggers `RateLimitError` with `Retry-After` value
+- AC6: Empty repo edge case: repo with zero open issues returns empty slice, no error
+- AC7: Special character handling: issue titles with unicode, markdown bodies with code blocks, labels with special chars
+- AC8: Assignee filtering tests: only issues assigned to configured user returned
+- AC9: Test coverage >= 80% for `internal/adapters/github/` package
+- AC10: Pagination test: mock paginated response (2+ pages) returns all issues
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes — all tests green
+- QG4: Rebased on latest main
+- QG5: Scope-checked against this story — no extras
+- QG6: Errors handled with context wrapping (`%w`)
+
+## Technical Notes
+
+- Mock strategy: use `httptest.NewServer` returning canned GitHub API JSON responses
+- go-github client can be pointed at custom base URL for testing: `client.BaseURL = testServer.URL`
+- Contract tests validate `TaskProvider` interface compliance — same suite used for Jira, Reminders, Todoist
+- Table-driven tests for all mapping scenarios (Go testing best practice per CLAUDE.md)
+- Use `t.Parallel()` where tests are independent
+- Use `t.Helper()` in test helper functions
+
+## Dependencies
+
+- Stories 26.1 and 26.2 (GitHubClient and GitHubProvider)
+- `internal/adapters/contract.go` (RunContractTests)
+- `testing` stdlib package (no testify)
+
+## Tasks
+
+1. Create `internal/adapters/github/github_provider_test.go`
+2. Set up `httptest.NewServer` with GitHub API response fixtures
+3. Implement `RunContractTests` integration
+4. Write table-driven label-to-priority mapping tests
+5. Write status mapping tests (open, closed, in-progress)
+6. Write multi-repo aggregation tests
+7. Write rate limit handling tests
+8. Write empty repo edge case test
+9. Write special character handling tests
+10. Write assignee filtering tests
+11. Write pagination tests
+12. Verify >= 80% coverage with `go test -cover`
+
+## Pre-PR Checklist
+
+- [ ] `make fmt` — no formatting changes needed
+- [ ] `make lint` — zero warnings
+- [ ] `make test` — all tests pass
+- [ ] `go test -race ./...` — no race conditions
+- [ ] `go test -cover ./internal/adapters/github/...` >= 80%
+- [ ] Contract tests pass
+- [ ] No `init()` functions used
+- [ ] All errors wrapped with `%w` and context
+- [ ] Test fixtures use realistic GitHub API JSON


### PR DESCRIPTION
## Summary

- Adds **Epic 26: GitHub Issues Integration** to the ThreeDoors roadmap
- Full BMAD pipeline output: course correction, party mode consensus, PRD updates, architecture, epics & stories
- 4 stories following the established adapter pattern (same as Jira/Reminders/Todoist)
- Uses official `go-github` SDK (Google-maintained) — unlike Todoist which uses raw HTTP

## Changes

### PRD (`docs/prd/requirements.md`)
- Added FR93-FR96: GitHub Issues integration functional requirements

### Architecture (`docs/architecture/components.md`)
- Added GitHubAdapter component with full interface spec, config example, and field mapping details
- Added to architecture diagram

### Epics & Stories (`docs/prd/epics-and-stories.md`)
- Added Epic 26 summary to Epic List section
- Added Epic 25 summary (was missing from list)
- Added full Epic 26 detail section with 4 stories:
  - **26.1:** GitHub SDK Client & Auth Configuration
  - **26.2:** Read-Only GitHub Provider with Field Mapping
  - **26.3:** Bidirectional Sync & WAL Integration
  - **26.4:** Contract Tests & Integration Testing

### Story Files
- `docs/stories/26.1.story.md` — SDK client wrapper, PAT auth, config
- `docs/stories/26.2.story.md` — Read-only provider, field/status/priority mapping
- `docs/stories/26.3.story.md` — Bidirectional sync, WAL, circuit breaker
- `docs/stories/26.4.story.md` — Contract tests, edge cases, 80% coverage

### ROADMAP.md
- Added Epic 25 (Todoist) and Epic 26 (GitHub Issues) to Active Epics
- Both at P1 priority with 0/4 stories done

### Planning Artifacts (`_bmad-output/planning-artifacts/`)
- Sprint change proposal documenting impact analysis and recommendations
- Party mode consensus with unanimous agent agreement on approach

## Key Decisions

1. Use `go-github` SDK (official, Google-maintained) — not raw HTTP
2. Label-based priority conventions: `priority:critical/high/medium/low`
3. Label-based status enrichment: `in-progress` label
4. Explicit repo list config (org-level queries deferred)
5. Read-only first (Story 26.2), then bidirectional (Story 26.3)
6. Schedule after Epic 25 (Todoist) for pattern validation

## Test plan

- [ ] No code changes — planning artifacts only
- [ ] Verify story files have consistent AC numbering
- [ ] Verify ROADMAP.md and epics-and-stories.md are consistent
- [ ] Verify FR93-FR96 don't overlap with existing requirements