### PR TITLE
feat: BMAD planning — Daily Planning Mode epic and stories

### DIFF
--- a/_bmad-output/planning-artifacts/architecture-daily-planning-mode.md
+++ b/_bmad-output/planning-artifacts/architecture-daily-planning-mode.md
@@ -1,0 +1,276 @@
+# Architecture: Daily Planning Mode (Epic 27)
+
+**Date:** 2026-03-07
+**Status:** Approved via Party Mode Consensus
+**Dependencies:** Epic 1 (session tracking), Epic 3 (mood/values flows), Epic 4 (task categorization), Epic 12 (calendar awareness)
+
+---
+
+## Overview
+
+Daily Planning Mode adds a guided morning planning ritual to ThreeDoors. It is a pure **TUI + Core Domain** feature — no adapter, sync, or intelligence layer changes required. The feature follows existing architectural patterns (multi-step Bubbletea flows, session metrics, tag-based task metadata).
+
+## Architecture Decision Records
+
+### ADR-27.1: Focus State via Session-Scoped Tags
+
+**Decision:** Use existing `+focus` tag convention for today's focus tasks rather than adding a new field to the Task model.
+
+**Rationale:**
+- Tags are already first-class in the task model and parsed inline
+- No task model migration or schema change needed
+- Focus state is inherently transient (daily) — tags can be cleared on next planning session
+- Consistent with existing tag patterns (`#type`, `@effort`, `+location`)
+
+**Implementation:**
+- Planning session adds `+focus` tag to selected tasks
+- Next planning session clears `+focus` from all tasks before new selection
+- Focus expiry: planning session timestamp + 16 hours, or next planning session
+
+### ADR-27.2: Energy Level as Time-of-Day Default
+
+**Decision:** Infer energy level from time of day as default, with user override.
+
+**Rationale:**
+- Reduces prompts (one fewer question in the planning flow)
+- Research shows morning = high energy, post-lunch = medium, evening = low as a reasonable default
+- Override available for users whose energy patterns differ
+- Leverages existing `TimeContext` from calendar awareness (Epic 12)
+
+**Mapping:**
+```
+06:00-11:59 → High (deep-work tasks preferred)
+12:00-16:59 → Medium (medium-effort tasks preferred)
+17:00-05:59 → Low (quick-win tasks preferred)
+```
+
+### ADR-27.3: Soft Progress Indicator
+
+**Decision:** Use a soft progress indicator (step counter + elapsed time) rather than a hard timer.
+
+**Rationale:**
+- Hard timers in TUI tools feel hostile and create anxiety
+- Soft nudge at 10 minutes ("You've been planning for 10 minutes") is sufficient
+- No forced session termination — user ends when ready
+- Progress bar shows Step 1/3, 2/3, 3/3 for flow awareness
+
+---
+
+## Component Design
+
+### New Components
+
+#### PlanningView (`internal/tui/planning_view.go`)
+
+**Responsibility:** Orchestrate the three-step planning flow as a Bubbletea model.
+
+**Pattern:** Composite model with sub-views (same pattern as onboarding wizard).
+
+```go
+type PlanningView struct {
+    step        PlanningStep  // review | select | confirm
+    reviewView  ReviewView    // Step 1: yesterday's incomplete tasks
+    selectView  SelectView    // Step 2: focus task selection
+    confirmView ConfirmView   // Step 3: summary and start
+    startTime   time.Time     // For elapsed time tracking
+    session     PlanningSession // Metrics accumulator
+}
+
+type PlanningStep int
+
+const (
+    StepReview  PlanningStep = iota
+    StepSelect
+    StepConfirm
+)
+```
+
+**Key Interfaces:**
+
+```go
+// Exposed
+func NewPlanningView(pool *TaskPool, previousSession *SessionSummary) *PlanningView
+func (v *PlanningView) Update(msg tea.Msg) (tea.Model, tea.Cmd)
+func (v *PlanningView) View() string
+
+// Consumed
+TaskPool.GetIncompleteTasks() []*Task           // Yesterday's incomplete
+TaskPool.GetAvailableForDoors() []*Task         // Full pool for selection
+TaskPool.AddTag(taskID string, tag string) error // Apply +focus tag
+TaskPool.RemoveTag(tag string) error            // Clear all +focus tags
+```
+
+**State Managed:**
+- `incompleteTasks` — yesterday's unfinished tasks with continue/defer/drop decisions
+- `focusTasks` — selected focus tasks (max 5, default target 3)
+- `energyLevel` — inferred or user-set (high/medium/low)
+- `elapsed` — planning session duration
+- `step` — current planning step (1-3)
+
+#### ReviewView (`internal/tui/planning_review.go`)
+
+**Responsibility:** Present yesterday's incomplete tasks for quick triage.
+
+**Interactions:**
+- `C` — Continue (leave in pool with focus priority consideration)
+- `D` — Defer (leave in pool, no special treatment)
+- `X` — Drop (mark as deferred status)
+- `Enter` — Next task / proceed to Step 2 when all reviewed
+
+**Visual:** Lipgloss-styled task card with action keys highlighted. Progress counter: "Task 2/5".
+
+#### SelectView (`internal/tui/planning_select.go`)
+
+**Responsibility:** Present task pool filtered by energy level for focus selection.
+
+**Interactions:**
+- `Space` — Toggle task as focus (add/remove `+focus`)
+- `E` — Cycle energy level (high → medium → low → all)
+- `Enter` — Confirm selection, proceed to Step 3
+- Arrow keys — Navigate task list
+
+**Visual:** Scrollable task list with energy-level filter indicator. Selected count: "Focus: 2/3 selected". Tasks sorted by energy match score.
+
+#### ConfirmView (`internal/tui/planning_confirm.go`)
+
+**Responsibility:** Show summary of planning decisions and start the session.
+
+**Visual:** Three focus tasks displayed as three doors (brand consistency). Elapsed time. "Press Enter to start your day."
+
+### Modified Components
+
+#### DoorSelector (`internal/tasks/selection.go`)
+
+**Change:** Add `FocusBoost` scoring coefficient for tasks tagged `+focus`.
+
+```go
+const FocusBoost = 5.0 // Significant but not absolute — user can still see non-focus tasks
+
+func (s *DoorSelector) ScoreTask(task *Task, ctx SelectionContext) float64 {
+    score := s.diversityScore(task) + s.timeContextScore(task, ctx)
+    if task.HasTag("+focus") && !s.isFocusExpired(ctx.PlanningTimestamp) {
+        score += FocusBoost
+    }
+    return score
+}
+```
+
+#### SessionMetrics (`internal/tasks/metrics.go`)
+
+**Change:** Add `planning_session` event type to JSONL schema.
+
+```go
+type PlanningSessionEvent struct {
+    Type            string    `json:"type"`            // "planning_session"
+    Timestamp       time.Time `json:"timestamp"`
+    Duration        int       `json:"duration_seconds"`
+    TasksReviewed   int       `json:"tasks_reviewed"`
+    TasksContinued  int       `json:"tasks_continued"`
+    TasksDeferred   int       `json:"tasks_deferred"`
+    TasksDropped    int       `json:"tasks_dropped"`
+    FocusTaskCount  int       `json:"focus_task_count"`
+    EnergyLevel     string    `json:"energy_level"`
+    EnergyOverridden bool    `json:"energy_overridden"`
+}
+```
+
+#### CLI Entry Point (`cmd/threedoors/`)
+
+**Change:** Add `plan` subcommand that launches PlanningView directly (bypasses doors view, enters planning flow).
+
+---
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as cmd/threedoors
+    participant PV as PlanningView
+    participant RV as ReviewView
+    participant SV as SelectView
+    participant CV as ConfirmView
+    participant TP as TaskPool
+    participant SM as SessionMetrics
+    participant DS as DoorSelector
+
+    User->>CLI: threedoors plan
+    CLI->>TP: Load tasks
+    CLI->>SM: Get previous session summary
+    CLI->>PV: NewPlanningView(pool, summary)
+
+    PV->>TP: GetIncompleteTasks()
+    PV->>RV: Show incomplete tasks
+
+    loop For each incomplete task
+        User->>RV: Continue/Defer/Drop
+        RV->>TP: Apply decision
+    end
+
+    RV-->>PV: Review complete
+    PV->>TP: RemoveTag("+focus")
+    PV->>SV: Show task pool
+
+    Note over SV: Energy inferred from time of day
+    SV->>TP: GetAvailableForDoors() filtered by energy
+
+    loop Select focus tasks (target 3, max 5)
+        User->>SV: Space to toggle focus
+        SV->>TP: AddTag(taskID, "+focus")
+    end
+
+    SV-->>PV: Selection complete
+    PV->>CV: Show confirmation (3 doors format)
+    User->>CV: Enter to start
+
+    CV->>SM: Log PlanningSessionEvent
+    CV-->>CLI: Return to doors view
+
+    Note over DS: Door selection now boosts +focus tasks
+    DS->>TP: SelectDoors with FocusBoost
+```
+
+## File Structure
+
+```
+internal/tui/
+  planning_view.go          # PlanningView composite model
+  planning_view_test.go     # Table-driven state machine tests
+  planning_review.go        # ReviewView sub-model
+  planning_review_test.go
+  planning_select.go        # SelectView sub-model
+  planning_select_test.go
+  planning_confirm.go       # ConfirmView sub-model
+  planning_confirm_test.go
+
+internal/tasks/
+  selection.go              # Modified: add FocusBoost scoring
+  selection_test.go         # Modified: test focus boost
+  metrics.go                # Modified: add PlanningSessionEvent
+  metrics_test.go           # Modified: test planning event logging
+```
+
+## Testing Strategy
+
+- **Unit tests:** Table-driven tests for PlanningView state machine (step transitions, edge cases)
+- **Golden file tests:** PlanningView rendering at each step (review, select, confirm)
+- **Integration tests:** Full planning flow — run session, verify `+focus` tags applied, verify door selection boost
+- **Edge cases:**
+  - Zero incomplete tasks (skip review step, go directly to select)
+  - Task pool smaller than 3 (allow fewer focus tasks)
+  - Energy level with no matching tasks (fall back to showing all tasks)
+  - Planning session with no focus selected (warn but allow)
+
+## Security & Privacy
+
+- No new external data access
+- Planning sessions stored in local JSONL only (existing metrics pattern)
+- No new configuration secrets or credentials
+- Focus tags are local task metadata (no sync implications for external providers)
+
+## Performance
+
+- PlanningView renders are pure string manipulation — sub-millisecond
+- Task filtering by energy level uses existing in-memory TaskPool — no I/O
+- Session metrics write is a single JSONL append — same as existing pattern
+- No new background processes, timers only for elapsed time display via `tea.Tick`

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-07.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-07.md
@@ -1,0 +1,198 @@
+# Sprint Change Proposal: Daily Planning Mode
+
+**Date:** 2026-03-07
+**Proposed By:** BMAD Course Correction Workflow
+**Change Scope:** Major — New Epic Proposal
+**Status:** Approved for Planning
+
+---
+
+## Section 1: Issue Summary
+
+### Problem Statement
+
+ThreeDoors currently operates as a **reactive** tool — users open it, pick a door, close it. It lacks the **proactive rituals and rhythms** that make productivity tools sticky. Without a daily planning engagement hook, the tool misses the strongest retention mechanism in productivity software: morning planning rituals.
+
+Research shows daily planning rituals are the primary driver behind Sunsama's 95% retention rate. ThreeDoors has all the infrastructure for this (session tracking, mood capture, task pool management, calendar awareness) but no guided planning flow.
+
+### Context
+
+- Identified during UX & Workflow Improvements Research (`docs/research/ux-workflow-improvements-research.md`)
+- Ranked **P0 priority** with **High impact** and **Medium effort**
+- Part of "Phase 1: Daily Engagement Loop" in the research recommendations
+- Research identifies this as addressing abandonment reason #3 (maintenance burden) by creating a daily rhythm
+
+### Evidence
+
+1. **Sunsama retention data**: 95% retention attributed to daily planning ritual
+2. **Abandonment research**: 73% task manager churn within 30 days; daily rituals directly counter this
+3. **Existing infrastructure**: Session metrics, mood capture, calendar awareness, values/goals display all exist but aren't connected into a planning flow
+4. **User behavior gap**: No guided "what am I committing to today?" flow exists — users only get reactive "what should I do next?"
+
+---
+
+## Section 2: Impact Analysis
+
+### Epic Impact
+
+**No existing epics are affected.** This is a net-new epic proposal that builds on completed infrastructure:
+
+| Dependency | Epic | Status | What It Provides |
+|-----------|------|--------|-----------------|
+| Session tracking | Epic 1 (Story 1.5) | Complete | Session metrics, daily engagement data |
+| Mood capture | Epic 3 | Complete | Energy-adjacent UX, mood state tracking |
+| Values/goals display | Epic 3 | Complete | Guided multi-step TUI flow patterns |
+| Calendar awareness | Epic 12 | Complete | Available time blocks for planning |
+| Task categorization | Epic 4 | Complete | Task type, effort level, context tags |
+| Onboarding flow | Epic 10 | Complete | Multi-step wizard UX patterns |
+
+**No existing epics need modification, removal, or resequencing.**
+
+### Story Impact
+
+- No current or future stories require changes
+- New stories will be created within the new epic
+- No dependency conflicts with in-progress work (Epics 23, 24, 25, 26)
+
+### Artifact Updates Required
+
+| Artifact | Change Needed |
+|----------|--------------|
+| **PRD** | Add new functional requirements (FR97-FR103) for daily planning mode |
+| **Architecture** | Add PlanningView component to TUI layer, "today's focus" concept to core domain |
+| **Epic List** | Add Epic 27: Daily Planning Mode |
+| **ROADMAP.md** | Add Epic 27 to active epics |
+
+### Technical Impact
+
+- New TUI view (`PlanningView`) following existing Bubbletea MVU patterns
+- New "today's focus" transient state on tasks (tag-based or session-scoped)
+- Energy level prompt (extends existing mood capture patterns)
+- Planning session timer (reuses `tea.Tick` pattern from existing codebase)
+- No infrastructure, deployment, or breaking changes
+
+---
+
+## Section 3: Recommended Approach
+
+### Selected Path: Direct Adjustment (Add New Epic)
+
+**Rationale:**
+- This is a clean addition — no existing work needs modification
+- All prerequisite infrastructure is complete
+- The feature is self-contained within a new epic
+- Medium effort with high retention impact
+- No timeline risk to in-progress epics (23, 24, 25, 26)
+
+**Effort Estimate:** Medium (4-6 stories, 2-3 weeks at 2-4 hrs/week)
+**Risk Level:** Low — builds on proven patterns and existing infrastructure
+**Timeline Impact:** None on current work; adds to roadmap as parallel/sequential P1 epic
+
+### Alternatives Considered
+
+- **Rollback**: N/A (new feature, nothing to revert)
+- **MVP Review**: Not needed (post-MVP feature that doesn't affect current scope)
+- **Defer**: Not recommended — research shows this is the highest-impact retention feature available
+
+---
+
+## Section 4: Detailed Change Proposals
+
+### 4.1 PRD Changes
+
+**Add new requirements section: Daily Planning Mode**
+
+```
+NEW:
+FR97: The system shall provide a daily planning mode accessible via `threedoors plan` CLI command
+or `:plan` TUI command that guides users through a structured morning planning ritual
+
+FR98: The planning mode shall present yesterday's incomplete tasks with options to continue,
+defer, or drop each task
+
+FR99: The planning mode shall allow users to select 3-5 tasks as "today's focus" from the
+full task pool, with focused tasks receiving priority in door selection
+
+FR100: The planning mode shall prompt for current energy level (high/medium/low) and use
+this to filter focus task suggestions to match available energy
+
+FR101: The planning session shall be time-boxed (5-10 minutes) with a visible progress
+indicator showing completion percentage
+
+FR102: Today's focus tasks shall receive elevated priority in door selection scoring,
+appearing more frequently as doors until completed or the day ends
+
+FR103: The system shall track planning session completion as a daily engagement metric
+in session logs
+
+Rationale: Daily planning rituals are the strongest retention mechanism in productivity
+tools. This addresses the gap between ThreeDoors' reactive usage pattern and the proactive
+daily engagement that drives long-term retention.
+```
+
+### 4.2 Architecture Changes
+
+**Add to TUI Layer (`internal/tui`):**
+- `PlanningView` — new Bubbletea model implementing the planning flow
+- Follows existing multi-step flow patterns (onboarding wizard, values setup)
+- Sub-views: ReviewView (yesterday's tasks), SelectView (focus picker), EnergyView (energy prompt)
+
+**Add to Core Domain (`internal/core` or `internal/tasks`):**
+- "Today's focus" concept — either transient session state or tag-based (`+focus`)
+- Planning session metrics — extends existing JSONL session logging
+- Focus-aware door selection scoring — boost for focus-tagged tasks
+
+**No changes to:**
+- Adapter layer (planning is UI + core domain only)
+- Sync engine (focus state is local/session-scoped)
+- Intelligence layer (calendar awareness already exists, can be consumed)
+
+### 4.3 Epic Addition
+
+**Add Epic 27: Daily Planning Mode** to the epic list and ROADMAP.md with 4-6 stories covering:
+1. Planning data model and focus state
+2. Review incomplete tasks flow
+3. Focus selection flow
+4. Energy level matching
+5. Planning session metrics
+6. CLI `plan` subcommand
+
+---
+
+## Section 5: Implementation Handoff
+
+### Change Scope Classification: Moderate
+
+**Requires:**
+- Product Owner/SM: Backlog addition and prioritization
+- Architect: Architecture doc updates (minimal — follows existing patterns)
+- Development team: Story implementation
+
+### Handoff Plan
+
+| Role | Responsibility |
+|------|---------------|
+| **PM (BMAD)** | Update PRD with FR97-FR103, update epic list |
+| **Architect (BMAD)** | Define architecture for PlanningView and focus state |
+| **SM (BMAD)** | Create epic and stories, add to ROADMAP.md |
+| **Dev workers** | Implement stories in dependency order |
+
+### Success Criteria
+
+1. Daily planning flow accessible via `:plan` command in TUI
+2. Users can review yesterday's incomplete tasks (continue/defer/drop)
+3. Users can select 3-5 focus tasks for the day
+4. Energy level prompt filters focus suggestions
+5. Planning session is time-boxed with progress indicator
+6. Focus tasks appear with elevated priority in door selection
+7. Planning completion tracked in session metrics
+
+---
+
+## Approval
+
+**Approved for planning pipeline execution.** Proceeding to:
+1. Party Mode discussion for agent consensus
+2. PRD update with new requirements
+3. Architecture definition
+4. Epic and story creation

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -310,9 +310,26 @@
 - **NFRs covered:** NFR24, NFR25, NFR26, NFR27
 - **Research:** See `docs/research/self-driving-development-pipeline.md`
 
-**Epic 23+: Additional Integrations** (Todoist, Linear, GitHub Issues, ClickUp, etc.)
-**Epic 24+: Cross-Computer Sync** (Implement alternative to monolithic SQLite on cloud storage)
-**Epic 25+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 27: Daily Planning Mode** (P1)
+- **Goal:** Add a guided daily planning ritual that transforms ThreeDoors from a reactive task picker into a proactive morning engagement tool, driving long-term retention through structured planning sessions
+- **Prerequisites:** Epic 1 (session tracking), Epic 3 (mood capture, values/goals flow patterns), Epic 4 (task categorization)
+- **Status:** Not Started
+- **Deliverables:**
+  - Planning data model with session-scoped `+focus` tag and energy level constants
+  - Review incomplete tasks flow (continue/defer/drop quick triage)
+  - Focus selection flow (pick 3-5 tasks from pool, filtered by energy)
+  - Energy level matching with time-of-day inference and user override
+  - Planning session metrics (JSONL `planning_session` event type)
+  - Focus-aware door selection scoring boost
+  - CLI `threedoors plan` subcommand and TUI `:plan` command
+- **Stories:** 27.1-27.5 (5 stories)
+- **Estimated Effort:** 2-3 weeks at 2-4 hrs/week
+- **FRs covered:** FR97, FR98, FR99, FR100, FR101, FR102, FR103
+- **Research:** See `docs/research/ux-workflow-improvements-research.md` (Improvement #2: Daily Planning Mode)
+
+**Epic 28+: Additional UX Improvements** (Quick Capture CLI, Snooze/Defer, Focus Timer, Batch Triage — see `docs/research/ux-workflow-improvements-research.md`)
+**Epic 29+: Cross-Computer Sync** (Implement alternative to monolithic SQLite on cloud storage)
+**Epic 30+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -346,6 +363,7 @@
 | Epic 20: Apple Reminders Integration | 4 | Partial (1/4) |
 | Epic 21: Sync Protocol Hardening | 4 | Partial (3/4) |
 | Epic 22: Self-Driving Dev Pipeline | 8 | Not Started |
-| **Total** | **119** | **97 complete, 3 partial, 19 remaining** |
+| Epic 27: Daily Planning Mode | 5 | Not Started |
+| **Total** | **124** | **97 complete, 3 partial, 24 remaining** |
 
 ---

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -380,6 +380,28 @@ These non-functional requirements establish code quality gates that all contribu
 
 ---
 
+## Phase 6+ - Daily Planning Mode (Accepted)
+
+*The following requirements add a guided daily planning ritual to ThreeDoors, creating a proactive morning engagement loop that drives long-term retention.*
+
+**Daily Planning Mode:**
+
+**FR97:** The system shall provide a daily planning mode accessible via `threedoors plan` CLI command or `:plan` TUI command that guides users through a structured morning planning ritual with three sequential steps: review, select, and confirm
+
+**FR98:** The planning mode shall present yesterday's incomplete tasks with options to continue (leave in pool with focus priority), defer (leave in pool without priority), or drop (mark as deferred status) each task — this is a quick triage step, not a snooze-with-date mechanism
+
+**FR99:** The planning mode shall allow users to select up to 5 tasks as "today's focus" from the full task pool, defaulting to 3 focus tasks (consistent with the Three Doors brand), using the session-scoped `+focus` tag convention so focus state resets on the next planning session
+
+**FR100:** The planning mode shall infer current energy level from time of day as a default (morning = high, afternoon = medium, evening = low) and display it with an option to override, using the energy level to filter and sort focus task suggestions by matching effort level
+
+**FR101:** The planning session shall display a soft progress indicator (step counter and elapsed time) without enforcing a hard time limit — showing a gentle nudge message after 10 minutes but never forcibly ending the session
+
+**FR102:** Today's focus tasks (tagged `+focus`) shall receive an elevated scoring boost in door selection, appearing more frequently as doors until completed or until the focus session expires (planning session timestamp + 16 hours, or next planning session, whichever comes first)
+
+**FR103:** The system shall track planning session completion, duration, number of tasks reviewed, and number of focus tasks selected as a `planning_session` event type in the JSONL session metrics log
+
+---
+
 ## Task Source Integration NFRs
 
 > Requirements specific to API-based and IPC-based task source adapters.

--- a/docs/stories/27.1.story.md
+++ b/docs/stories/27.1.story.md
@@ -1,0 +1,67 @@
+# Story 27.1: Planning Data Model & Focus Tag
+
+## Story Info
+
+- **Epic:** 27 — Daily Planning Mode
+- **Priority:** P1
+- **Status:** Not Started
+- **Estimated Effort:** Small
+- **Dependencies:** None (all prerequisite infrastructure exists)
+
+## User Story
+
+As a ThreeDoors user, I want a data foundation for daily planning so that focus tasks and energy levels can be tracked and used by the planning flow and door selection.
+
+## Acceptance Criteria
+
+### AC 27.1.1: Focus Tag Convention
+- [ ] Tasks can be tagged with `+focus` using existing tag infrastructure
+- [ ] A utility function `ClearFocusTags()` removes `+focus` from all tasks in the pool
+- [ ] A utility function `GetFocusTasks()` returns all tasks currently tagged `+focus`
+- [ ] Focus tag is recognized by existing inline tag parsing
+
+### AC 27.1.2: Energy Level Type
+- [ ] `EnergyLevel` type defined with constants: `EnergyHigh`, `EnergyMedium`, `EnergyLow`
+- [ ] `InferEnergyFromTime(t time.Time) EnergyLevel` function maps time of day to energy:
+  - 06:00-11:59 -> High
+  - 12:00-16:59 -> Medium
+  - 17:00-05:59 -> Low
+- [ ] `MatchesEnergy(task *Task, energy EnergyLevel) bool` filters tasks by effort tag vs energy level:
+  - High energy -> prefer deep-work tasks
+  - Medium energy -> prefer medium-effort tasks
+  - Low energy -> prefer quick-win tasks
+
+### AC 27.1.3: Planning Session Metrics
+- [ ] `PlanningSessionEvent` struct added to metrics with fields: timestamp, duration_seconds, tasks_reviewed, tasks_continued, tasks_deferred, tasks_dropped, focus_task_count, energy_level, energy_overridden
+- [ ] `LogPlanningSession(event PlanningSessionEvent) error` appends to JSONL session log
+- [ ] Event type is `"planning_session"` in the JSONL output
+
+### AC 27.1.4: Focus Boost in Door Selection
+- [ ] `FocusBoost` constant (5.0) added to door selection scoring
+- [ ] Tasks tagged `+focus` receive the boost in `SelectDoors()` scoring
+- [ ] Focus boost expires after 16 hours from planning session timestamp or on next planning session (whichever comes first)
+- [ ] `IsFocusExpired(planningTimestamp time.Time) bool` function handles expiry check
+
+### AC 27.1.5: Get Incomplete Tasks
+- [ ] `GetIncompleteTasks(since time.Time) []*Task` returns tasks that were in todo/in-progress/blocked status as of the given timestamp
+- [ ] Used by the review step to show "yesterday's incomplete tasks"
+
+## Technical Notes
+
+- Energy level constants and matching go in `internal/tasks/` (or `internal/core/`)
+- Focus boost integrates into existing `SelectDoors()` scoring in `internal/tasks/selection.go`
+- Planning session event extends existing JSONL metrics in `internal/tasks/metrics.go`
+- All functions must have table-driven tests
+- Use `time.Now().UTC()` for all timestamps
+
+## Tasks
+
+- [ ] Define `EnergyLevel` type and constants
+- [ ] Implement `InferEnergyFromTime()` with tests
+- [ ] Implement `MatchesEnergy()` with tests
+- [ ] Add `ClearFocusTags()` and `GetFocusTasks()` utilities with tests
+- [ ] Add `GetIncompleteTasks()` with tests
+- [ ] Define `PlanningSessionEvent` struct and `LogPlanningSession()` with tests
+- [ ] Add `FocusBoost` constant and integrate into `SelectDoors()` scoring with tests
+- [ ] Add `IsFocusExpired()` with tests
+- [ ] Run `make fmt && make lint && make test`

--- a/docs/stories/27.2.story.md
+++ b/docs/stories/27.2.story.md
@@ -1,0 +1,60 @@
+# Story 27.2: Review Incomplete Tasks Flow
+
+## Story Info
+
+- **Epic:** 27 — Daily Planning Mode
+- **Priority:** P1
+- **Status:** Not Started
+- **Estimated Effort:** Medium
+- **Dependencies:** 27.1 (planning data model)
+
+## User Story
+
+As a ThreeDoors user, I want to review yesterday's incomplete tasks at the start of my planning session so that I can decide which tasks to continue, defer, or drop before selecting today's focus.
+
+## Acceptance Criteria
+
+### AC 27.2.1: ReviewView Bubbletea Model
+- [ ] `ReviewView` implements `tea.Model` with `Init()`, `Update()`, `View()` methods
+- [ ] Constructor: `NewReviewView(incompleteTasks []*Task) *ReviewView`
+- [ ] Displays one task at a time with full task text, status, and tags
+- [ ] Shows progress counter: "Task 2/5"
+
+### AC 27.2.2: Review Actions
+- [ ] `C` key — Continue: marks task for continued focus consideration (no status change)
+- [ ] `D` key — Defer: marks task to remain in pool without special treatment (no status change)
+- [ ] `X` key — Drop: transitions task to deferred status
+- [ ] `Enter` — advances to next task after action, or completes review step when all tasks processed
+- [ ] Each action records the decision for metrics (continued/deferred/dropped counts)
+
+### AC 27.2.3: Empty State
+- [ ] When there are zero incomplete tasks, ReviewView displays "No incomplete tasks from yesterday" and auto-advances to the next step after a brief pause (1 second)
+
+### AC 27.2.4: Visual Design
+- [ ] Task displayed in a Lipgloss-styled panel matching existing TUI aesthetic
+- [ ] Action keys clearly displayed at bottom: `[C]ontinue  [D]efer  [X]Drop`
+- [ ] Progress bar or step indicator at bottom: "Step 1/3 - Review"
+- [ ] Elapsed time shown subtly (e.g., top-right corner)
+
+### AC 27.2.5: Navigation
+- [ ] `Esc` key — skips remaining reviews and advances to Step 2 (select)
+- [ ] `?` key — shows help overlay with action descriptions
+- [ ] Review decisions can be undone with `U` (undo) before advancing past a task
+
+## Technical Notes
+
+- Follow existing Bubbletea model patterns (see onboarding flow in `internal/tui/`)
+- Use Lipgloss for all styling — no raw ANSI codes
+- ReviewView is a sub-model composed within PlanningView
+- All user-visible text through `View()` — no `fmt.Println`
+
+## Tasks
+
+- [ ] Create `internal/tui/planning_review.go` with `ReviewView` model
+- [ ] Implement task display with Lipgloss styling
+- [ ] Implement C/D/X action handlers with decision tracking
+- [ ] Implement empty state (zero incomplete tasks)
+- [ ] Implement Esc (skip) and U (undo) navigation
+- [ ] Add table-driven tests for state machine transitions
+- [ ] Add golden file tests for ReviewView rendering
+- [ ] Run `make fmt && make lint && make test`

--- a/docs/stories/27.3.story.md
+++ b/docs/stories/27.3.story.md
@@ -1,0 +1,71 @@
+# Story 27.3: Focus Selection & Energy Matching Flow
+
+## Story Info
+
+- **Epic:** 27 — Daily Planning Mode
+- **Priority:** P1
+- **Status:** Not Started
+- **Estimated Effort:** Medium
+- **Dependencies:** 27.1 (planning data model)
+
+## User Story
+
+As a ThreeDoors user, I want to select my focus tasks for the day filtered by my current energy level so that I commit to tasks that match my capacity and see them prioritized in door selection.
+
+## Acceptance Criteria
+
+### AC 27.3.1: SelectView Bubbletea Model
+- [ ] `SelectView` implements `tea.Model` with `Init()`, `Update()`, `View()` methods
+- [ ] Constructor: `NewSelectView(pool []*Task, energy EnergyLevel) *SelectView`
+- [ ] Displays scrollable task list filtered and sorted by energy match
+- [ ] Shows selection count: "Focus: 2/3 selected" (target 3, max 5)
+
+### AC 27.3.2: Energy Level Display and Override
+- [ ] Energy level auto-inferred from time of day on view initialization
+- [ ] Current energy level displayed prominently: "Energy: High (morning)"
+- [ ] `E` key — cycles through energy levels: High -> Medium -> Low -> All (show everything)
+- [ ] When energy level changes, task list re-filters and re-sorts
+- [ ] Override tracked in metrics (`energy_overridden` field)
+
+### AC 27.3.3: Focus Task Selection
+- [ ] `Space` key — toggles task as focus (adds/removes `+focus` tag)
+- [ ] Visual indicator on selected tasks (checkmark or highlight)
+- [ ] When 3 tasks are selected, show subtle "Target reached!" message but allow up to 5
+- [ ] When 5 tasks are selected, prevent additional selection with "Maximum 5 focus tasks" message
+- [ ] `Enter` — confirms selection and advances to Step 3 (confirm)
+
+### AC 27.3.4: Task List Presentation
+- [ ] Tasks sorted by energy match score (best match first)
+- [ ] Each task shows: text, effort tag, type tag, current status
+- [ ] Arrow keys (Up/Down) navigate the list
+- [ ] List is scrollable when tasks exceed terminal height
+
+### AC 27.3.5: Edge Cases
+- [ ] When task pool has fewer than 3 tasks, allow selection of all available
+- [ ] When no tasks match current energy level, show "No matching tasks" with option to switch to "All" energy filter
+- [ ] When zero tasks are selected and Enter pressed, show warning: "No focus tasks selected. Continue anyway? [Y/N]"
+
+### AC 27.3.6: Navigation
+- [ ] `Esc` key — returns to Step 1 (review) to re-do decisions
+- [ ] `?` key — shows help overlay with key bindings
+- [ ] Step indicator: "Step 2/3 - Select Focus"
+
+## Technical Notes
+
+- Use `MatchesEnergy()` from Story 27.1 for filtering
+- Use `InferEnergyFromTime()` from Story 27.1 for default
+- Apply `+focus` tags via `TaskPool.AddTag()` from Story 27.1
+- Scrollable list can use existing list patterns from TUI codebase
+- All styling via Lipgloss
+
+## Tasks
+
+- [ ] Create `internal/tui/planning_select.go` with `SelectView` model
+- [ ] Implement energy level display with auto-inference and E-key override
+- [ ] Implement task list with energy-based filtering and sorting
+- [ ] Implement Space key toggle for focus selection with count tracking
+- [ ] Implement Enter confirmation with edge case handling
+- [ ] Implement Esc back-navigation and ? help overlay
+- [ ] Add table-driven tests for state machine and selection logic
+- [ ] Add golden file tests for SelectView rendering
+- [ ] Run `make fmt && make lint && make test`

--- a/docs/stories/27.4.story.md
+++ b/docs/stories/27.4.story.md
@@ -1,0 +1,69 @@
+# Story 27.4: Planning Session Metrics & Confirm View
+
+## Story Info
+
+- **Epic:** 27 — Daily Planning Mode
+- **Priority:** P1
+- **Status:** Not Started
+- **Estimated Effort:** Medium
+- **Dependencies:** 27.1 (planning data model), 27.2 (review flow), 27.3 (select flow)
+
+## User Story
+
+As a ThreeDoors user, I want to see a summary of my planning decisions and have my planning session tracked so that I can confirm my day's focus and build a measurable daily planning habit.
+
+## Acceptance Criteria
+
+### AC 27.4.1: ConfirmView Bubbletea Model
+- [ ] `ConfirmView` implements `tea.Model` with `Init()`, `Update()`, `View()` methods
+- [ ] Constructor: `NewConfirmView(focusTasks []*Task, session PlanningSession) *ConfirmView`
+- [ ] Displays focus tasks in a three-doors visual format (brand consistency)
+- [ ] Shows planning session summary: tasks reviewed, decisions made, energy level, elapsed time
+
+### AC 27.4.2: Session Summary Display
+- [ ] "Your plan for today:" header with date
+- [ ] Focus tasks displayed as styled doors (reuse door rendering from DoorsView themes)
+- [ ] Review stats: "Reviewed X tasks: Y continued, Z deferred, W dropped"
+- [ ] Energy level: "Energy: High (inferred)" or "Energy: Medium (override)"
+- [ ] Elapsed time: "Planning time: 3m 42s"
+
+### AC 27.4.3: Session Completion
+- [ ] `Enter` key — confirms plan, logs metrics, transitions to doors view
+- [ ] `Esc` key — returns to Step 2 (select) to adjust focus tasks
+- [ ] On Enter, `LogPlanningSession()` writes the `PlanningSessionEvent` to JSONL
+- [ ] On Enter, clears previous `+focus` tags and applies new selection
+
+### AC 27.4.4: Soft Timer Nudge
+- [ ] Elapsed time displayed throughout all planning steps via `tea.Tick` (1-second intervals)
+- [ ] At 10 minutes elapsed, display a gentle nudge: "You've been planning for 10 minutes - almost there!"
+- [ ] Nudge is non-blocking — user can continue as long as needed
+- [ ] No hard timer cutoff under any circumstances
+
+### AC 27.4.5: PlanningView Orchestration
+- [ ] `PlanningView` composite model manages step transitions: Review -> Select -> Confirm
+- [ ] Step indicator visible on all steps: "Step X/3 - [Step Name]"
+- [ ] Back navigation works across steps (Esc from Select -> Review, Esc from Confirm -> Select)
+- [ ] Forward navigation works (Enter after step completion)
+- [ ] `Ctrl+C` or `Q` exits planning mode entirely (with confirmation if tasks were already reviewed)
+
+## Technical Notes
+
+- PlanningView is the top-level composite, ReviewView/SelectView/ConfirmView are sub-models
+- Follow existing composite model patterns from onboarding wizard
+- Reuse door theme rendering from `internal/tui/themes/` for confirm view display
+- `tea.Tick` at 1-second intervals for elapsed time (same pattern as existing timer usage)
+- All metrics written via existing JSONL append pattern
+
+## Tasks
+
+- [ ] Create `internal/tui/planning_confirm.go` with `ConfirmView` model
+- [ ] Create `internal/tui/planning_view.go` with `PlanningView` composite orchestrator
+- [ ] Implement session summary display with door-themed focus task rendering
+- [ ] Implement elapsed time tracking via `tea.Tick`
+- [ ] Implement 10-minute soft nudge
+- [ ] Implement Enter (confirm + log metrics) and Esc (back) navigation
+- [ ] Implement step transitions in PlanningView (Review -> Select -> Confirm)
+- [ ] Add table-driven tests for PlanningView state transitions
+- [ ] Add golden file tests for ConfirmView rendering
+- [ ] Add integration test: full planning flow end-to-end
+- [ ] Run `make fmt && make lint && make test`

--- a/docs/stories/27.5.story.md
+++ b/docs/stories/27.5.story.md
@@ -1,0 +1,59 @@
+# Story 27.5: CLI `plan` Subcommand & Integration Polish
+
+## Story Info
+
+- **Epic:** 27 — Daily Planning Mode
+- **Priority:** P1
+- **Status:** Not Started
+- **Estimated Effort:** Small
+- **Dependencies:** 27.2 (review flow), 27.3 (select flow), 27.4 (confirm view + orchestration)
+
+## User Story
+
+As a ThreeDoors user, I want to start a planning session from the CLI with `threedoors plan` or from within the TUI with `:plan` so that I can access daily planning from wherever I am.
+
+## Acceptance Criteria
+
+### AC 27.5.1: CLI Subcommand
+- [ ] `threedoors plan` launches the TUI directly into PlanningView (bypasses doors view)
+- [ ] Follows existing Cobra subcommand patterns from Epic 23
+- [ ] Exits cleanly after planning session completes (returns to shell, not doors view)
+- [ ] `threedoors plan --help` shows usage description
+
+### AC 27.5.2: TUI Command
+- [ ] `:plan` command in the TUI command palette triggers PlanningView
+- [ ] After planning session completes, returns to doors view (not exit)
+- [ ] PlanningView accessible from any TUI view state (doors, detail, search)
+
+### AC 27.5.3: Integration with Doors View
+- [ ] After planning session, doors view refreshes and shows focus-boosted doors
+- [ ] Focus tasks appear with a visual indicator in doors view (e.g., small "focus" badge or color)
+- [ ] If no planning session has been run today, doors view works normally (no focus boost active)
+
+### AC 27.5.4: Planning State Persistence
+- [ ] Planning session timestamp persisted (for focus expiry calculation)
+- [ ] Focus tags survive TUI process restarts (tags are in task YAML)
+- [ ] On next planning session, previous `+focus` tags are cleared before new selection
+
+### AC 27.5.5: First-Time Planning Guidance
+- [ ] On first-ever planning session, show a brief one-time explanation: "Welcome to Daily Planning! This 3-step flow helps you focus your day." (dismissible with any key)
+- [ ] Subsequent sessions skip the explanation
+
+## Technical Notes
+
+- CLI subcommand follows Cobra patterns established in Epic 23 (`internal/cli/`)
+- TUI command registration follows existing `:command` pattern in command palette
+- Focus badge in doors view: small Lipgloss-styled indicator, minimal visual weight
+- Planning timestamp can be stored in session state file or derived from latest `planning_session` event in JSONL
+
+## Tasks
+
+- [ ] Add `plan` Cobra subcommand in `cmd/threedoors/` or `internal/cli/`
+- [ ] Register `:plan` command in TUI command palette
+- [ ] Implement doors view focus badge for `+focus` tagged tasks
+- [ ] Implement planning state persistence (timestamp for expiry)
+- [ ] Implement first-time planning guidance (one-time overlay)
+- [ ] Add integration test: CLI `plan` subcommand launches planning flow
+- [ ] Add integration test: `:plan` TUI command triggers planning flow
+- [ ] Add test: focus boost active in doors after planning session
+- [ ] Run `make fmt && make lint && make test`


### PR DESCRIPTION
## Summary

- Adds **Epic 27: Daily Planning Mode** — a guided morning ritual for task review and focus selection
- Full BMAD pipeline: course correction -> party mode -> PRD update -> architecture -> stories
- 5 stories (27.1-27.5) with detailed acceptance criteria and technical notes

## What This Adds

### PRD Updates (`docs/prd/`)
- **FR97-FR103**: Daily Planning Mode requirements in `requirements.md`
- **Epic 27** entry in `epic-list.md` with story count summary update

### Architecture (`_bmad-output/planning-artifacts/`)
- Sprint Change Proposal documenting the course correction analysis
- Architecture document with 3 ADRs, component design, data flow diagram, testing strategy

### Stories (`docs/stories/27.*.story.md`)
| Story | Title | Effort | Dependencies |
|-------|-------|--------|-------------|
| 27.1 | Planning Data Model & Focus Tag | Small | None |
| 27.2 | Review Incomplete Tasks Flow | Medium | 27.1 |
| 27.3 | Focus Selection & Energy Matching | Medium | 27.1 |
| 27.4 | Planning Session Metrics & Confirm View | Medium | 27.1, 27.2, 27.3 |
| 27.5 | CLI `plan` Subcommand & Integration Polish | Small | 27.2, 27.3, 27.4 |

### Key Design Decisions (Party Mode Consensus)
- **P1 priority** — high value but doesn't block current work (Epics 23-26)
- **Focus state via `+focus` tag** — session-scoped, no task model migration
- **Energy matching** — time-of-day inference with user override
- **Soft progress indicator** — no hard timer cutoff
- **Default 3 focus tasks** (brand consistency), allow up to 5
- **Defer = leave in pool** — no snooze-with-date infrastructure

### Research Source
- `docs/research/ux-workflow-improvements-research.md` — ranked P0 High Impact, Medium Effort

## Opportunities (Not Implemented)
- Quick Capture CLI (Improvement #1 from research) — separate epic
- Snooze/Defer with date picking (Improvement #3) — separate epic
- Focus Timer / Pomodoro (Improvement #5) — complementary to planning mode
- ROADMAP.md update pending supervisor approval

## Test Plan
- [ ] No code changes — documentation/planning only
- [ ] Story files have consistent formatting and cross-references
- [ ] PRD requirements are numbered sequentially (FR97-FR103)
- [ ] Architecture ADRs reference correct story numbers