### PR TITLE
feat: BMAD planning — Expand/Fork Key Implementations epic and stories

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,6 +63,18 @@ Linear as task source via GraphQL API. Best task model alignment of all evaluate
 | 30.3 | Bidirectional Sync & WAL Integration | Not Started | P2 | 30.2 |
 | 30.4 | Contract Tests & Integration Testing | Not Started | P2 | 30.2 |
 
+### Epic 31: Expand/Fork Key Implementations (P2) — 0/5 stories done
+
+Complete Expand (manual sub-task creation) and Fork (variant creation) TUI features per Design Decision H9.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 31.1 | Task Model ParentID Extension | Not Started | P2 | None |
+| 31.2 | Enhanced Expand — Sequential Subtask Creation | Not Started | P2 | 31.1 |
+| 31.3 | Subtask List Rendering in Detail View | Not Started | P2 | 31.1, 31.2 |
+| 31.4 | Enhanced Fork — Variant Creation with ForkTask Factory | Not Started | P2 | None |
+| 31.5 | Design Decision H9 Status Update | Not Started | P2 | 31.1-31.4 |
+
 ## Completed Epics
 
 | Epic | Title | Stories |

--- a/_bmad-output/planning-artifacts/architecture-expand-fork.md
+++ b/_bmad-output/planning-artifacts/architecture-expand-fork.md
@@ -1,0 +1,253 @@
+# Architecture: Expand/Fork Key Implementations (Epic 31)
+
+**Date:** 2026-03-08
+**Status:** Proposed
+**Decision Source:** Design Decision H9, Party Mode 2026-03-08
+
+---
+
+## Overview
+
+This document defines the technical architecture for completing the Expand (manual sub-task creation) and Fork (variant creation) features in the ThreeDoors TUI detail view. Both features have basic stub implementations that need enhancement to fulfill the specifications from Design Decision H9.
+
+---
+
+## 1. Task Model Extension: ParentID
+
+### Decision: Native Field on Task Struct
+
+The `ParentID` field belongs on the `core.Task` struct, not in the enrichment DB's `CrossReference` system.
+
+**Rationale:**
+- Parent-child is a core domain relationship, not optional metadata
+- `TaskPool` must answer "give me children of X" without enrichment DB dependency
+- Maintains clean separation: `internal/core` has zero imports on enrichment
+- Backward-compatible: optional YAML field with `omitempty`
+
+### Schema Change
+
+```go
+// In internal/core/task.go
+type Task struct {
+    // ... existing fields ...
+    ParentID *string `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
+}
+```
+
+### YAML Format
+
+```yaml
+tasks:
+  - id: parent-uuid
+    text: "Write architecture document"
+    status: todo
+    # no parent_id field — this is a root task
+
+  - id: child-uuid
+    text: "Draft data models section"
+    status: in-progress
+    parent_id: parent-uuid  # links to parent
+```
+
+### TaskPool Extensions
+
+```go
+// GetSubtasks returns all tasks whose ParentID matches the given task ID.
+func (p *TaskPool) GetSubtasks(parentID string) []*Task
+
+// HasSubtasks returns true if any task in the pool has this task as parent.
+func (p *TaskPool) HasSubtasks(taskID string) bool
+```
+
+### Door Selection Filter
+
+`GetAvailableForDoors()` adds a new exclusion rule:
+- If `HasSubtasks(task.ID)` is true, exclude the task from door selection
+- This communicates "you decomposed this task, work the pieces"
+
+---
+
+## 2. Expand Feature Architecture
+
+### Current State
+
+```
+User presses E → DetailModeExpandInput → single text input → Enter creates ExpandTaskMsg → main model creates unlinked task
+```
+
+### Target State
+
+```
+User presses E → DetailModeExpandInput → text input → Enter creates subtask (ParentID set) + stays in expand mode → Esc exits
+```
+
+### Message Types
+
+```go
+// ExpandTaskMsg is emitted when a subtask is created via Expand.
+type ExpandTaskMsg struct {
+    ParentTask  *core.Task
+    NewTaskText string
+}
+```
+
+No new message types needed — the existing `ExpandTaskMsg` is sufficient. The main model handler sets `ParentID` on the new task.
+
+### Main Model Handler
+
+```go
+case ExpandTaskMsg:
+    newTask := core.NewTask(msg.NewTaskText)
+    parentID := msg.ParentTask.ID
+    newTask.ParentID = &parentID
+    // Add to pool, persist...
+```
+
+### Sequential Input Mode
+
+The `handleExpandInput` method changes behavior on Enter:
+- Creates the subtask
+- Clears the input buffer
+- Increments a subtask counter for display
+- Does NOT exit `DetailModeExpandInput`
+- Only Esc exits back to `DetailModeView`
+
+### Detail View Rendering
+
+When viewing a parent task, render subtask list:
+
+```
+Write architecture document
+
+  ├─ [TODO]  Draft high-level overview
+  ├─ [DONE] Data models section
+  └─ [TODO]  Components section
+
+Subtasks: 1/3 complete
+```
+
+Implementation: `DetailView.View()` checks `pool.GetSubtasks(task.ID)` and renders the list between task text and the separator line.
+
+---
+
+## 3. Fork Feature Architecture
+
+### Current State
+
+```
+User presses F → core.NewTask(dv.task.Text) → TaskAddedMsg emitted
+```
+
+### Target State
+
+```
+User presses F → core.ForkTask(dv.task) → TaskForkedMsg emitted → main model creates enrichment cross-ref
+```
+
+### ForkTask Factory
+
+```go
+// ForkTask creates a variant of the given task.
+// Preserves: Text, Context, Effort, Tags
+// Resets: Status (todo), Blocker (""), Notes (empty), timestamps (now)
+// Adds: Note "Forked from: [truncated text]"
+// Does NOT copy: ParentID
+func ForkTask(original *Task) *Task {
+    forked := NewTask(original.Text)
+    forked.Context = original.Context
+    forked.Effort = original.Effort
+    forked.Tags = append([]string{}, original.Tags...)  // defensive copy
+
+    truncated := original.Text
+    if len(truncated) > 60 {
+        truncated = truncated[:57] + "..."
+    }
+    forked.AddNote("Forked from: " + truncated)
+
+    return forked
+}
+```
+
+### New Message Type
+
+```go
+// TaskForkedMsg is emitted when a task variant is created via Fork.
+type TaskForkedMsg struct {
+    Original *core.Task
+    Variant  *core.Task
+}
+```
+
+### Cross-Reference (Enrichment Layer)
+
+The main model's `TaskForkedMsg` handler creates a cross-reference:
+
+```go
+case TaskForkedMsg:
+    // Add variant to pool and persist
+    // Then create enrichment cross-reference
+    ref := &enrichment.CrossReference{
+        SourceTaskID: msg.Original.ID,
+        TargetTaskID: msg.Variant.ID,
+        SourceSystem: "local",
+        Relationship: "forked-from",
+    }
+    enrichDB.AddCrossReference(ref)
+```
+
+This keeps `internal/core` free of enrichment DB awareness.
+
+---
+
+## 4. Component Changes Summary
+
+| Component | Change | Blast Radius |
+|-----------|--------|-------------|
+| `core.Task` | Add `ParentID *string` field | Low — optional field, backward-compatible |
+| `core.TaskPool` | Add `GetSubtasks()`, `HasSubtasks()` methods | Low — new methods only |
+| `core.TaskPool.GetAvailableForDoors()` | Add parent exclusion filter | Low — additive filter |
+| `core.ForkTask()` | New factory function | None — new code |
+| `tui.DetailView` | Sequential expand mode, subtask rendering | Medium — modifies existing view |
+| `tui.DetailView` | Fork uses ForkTask + TaskForkedMsg | Low — replaces 2 lines |
+| `tui.MainModel` | Handle TaskForkedMsg, set ParentID on expand | Low — new message handler |
+| YAML schema | Add `parent_id` field | Low — optional, omitempty |
+
+---
+
+## 5. Testing Strategy
+
+### Unit Tests
+- `TestForkTask` — verifies field preservation/reset semantics
+- `TestGetSubtasks` — returns correct children, empty for no children
+- `TestHasSubtasks` — returns true/false correctly
+- `TestGetAvailableForDoors_ExcludesParents` — parents with children excluded
+
+### Integration Tests
+- Expand creates subtask with correct ParentID
+- Sequential expand creates multiple subtasks
+- Fork creates variant with correct field values
+- YAML round-trip with parent_id field (backward compatibility)
+
+### TUI Tests
+- DetailView renders subtask list correctly
+- Expand mode stays open after Enter, exits on Esc
+- Fork emits TaskForkedMsg (not TaskAddedMsg)
+
+---
+
+## 6. Design Constraints
+
+1. **Single-level nesting only** — subtasks cannot have their own subtasks (v1 simplification)
+2. **No property inheritance** — subtasks are independent work items
+3. **No auto-completion** — parent never auto-completes when all children finish
+4. **Completion ratio is display-only** — no enforcement of "complete all subtasks first"
+5. **ParentID is immutable** — once set, a subtask cannot be re-parented
+
+---
+
+## 7. Migration & Backward Compatibility
+
+- Existing tasks without `parent_id` field load correctly (nil pointer = no parent)
+- No schema version bump needed — field is additive with `omitempty`
+- No migration script required
+- Existing `ExpandTaskMsg` handling remains compatible (ParentID set in handler, not in message)

--- a/_bmad-output/planning-artifacts/epic-31-expand-fork.md
+++ b/_bmad-output/planning-artifacts/epic-31-expand-fork.md
@@ -1,0 +1,191 @@
+# Epic 31: Expand/Fork Key Implementations
+
+**Priority:** P2
+**Status:** Backlog
+**Dependencies:** Epic 3 (Enhanced Interaction) — complete, Epic 13 (Multi-Source Aggregation) — complete
+**Estimated Effort:** 3-5 days across all stories
+**Design Decision:** H9 (Expand = manual sub-tasks, Fork = variant creation)
+
+## Epic Summary
+
+Complete the Expand (`[E]`) and Fork (`[F]`) key actions in the TUI detail view. Expand enables manual sub-task creation with parent-child relationship tracking. Fork enables variant creation that copies relevant fields while resetting status for a fresh start. Both features have basic stub implementations that need enhancement to fulfill the specifications from Design Decision H9.
+
+## Stories
+
+---
+
+### Story 31.1: Task Model ParentID Extension
+
+**Priority:** P2
+**Status:** Not Started
+**Depends On:** None (foundational)
+**Estimated Effort:** Small (1-2 hours)
+
+#### Description
+
+Add a native `ParentID` field to the `core.Task` struct to support parent-child relationships between tasks. Extend `TaskPool` with methods to query subtasks and check parent status. Update `GetAvailableForDoors()` to exclude parent tasks that have children.
+
+#### Acceptance Criteria
+
+- [ ] `core.Task` has `ParentID *string` field with `yaml:"parent_id,omitempty"` tag
+- [ ] `TaskPool.GetSubtasks(parentID string) []*Task` returns all tasks whose ParentID matches
+- [ ] `TaskPool.HasSubtasks(taskID string) bool` returns true if any task has this ID as parent
+- [ ] `GetAvailableForDoors()` excludes tasks that have one or more subtasks
+- [ ] YAML round-trip preserves `parent_id` field when present
+- [ ] Existing tasks without `parent_id` load correctly (nil = no parent)
+- [ ] Table-driven tests for GetSubtasks, HasSubtasks, and door exclusion
+- [ ] `make lint && make test` pass with zero warnings
+
+#### Technical Notes
+
+- ParentID is a `*string` (pointer) — nil means no parent, non-nil means subtask
+- No schema version bump needed — field is additive with omitempty
+- Single-level nesting only: no validation that parent itself has no parent (v1 simplification)
+- Use existing `TaskPool.GetAllTasks()` to iterate for subtask queries
+
+---
+
+### Story 31.2: Enhanced Expand — Sequential Subtask Creation
+
+**Priority:** P2
+**Status:** Not Started
+**Depends On:** 31.1
+
+#### Description
+
+Enhance the Expand feature to create subtasks with `ParentID` set to the parent task's ID. Implement sequential subtask creation mode: after submitting one subtask (Enter), the input stays open for the next subtask. Only Esc exits expand mode. Show a running subtask count during input.
+
+#### Acceptance Criteria
+
+- [ ] Pressing `E` in detail view enters expand mode with prompt "New subtask (Enter to add, Esc to finish):"
+- [ ] Enter creates a new task with `ParentID` set to the current task's ID
+- [ ] After Enter, expand mode stays active with cleared input and updated count: "Subtask N added. Next subtask (Esc to finish):"
+- [ ] Esc exits expand mode and returns to detail view
+- [ ] Empty input on Enter shows flash message "Subtask text cannot be empty" and stays in expand mode
+- [ ] `ExpandTaskMsg` handler in main model sets `ParentID` on the new task
+- [ ] Table-driven tests for sequential subtask creation
+- [ ] `make lint && make test` pass
+
+#### Technical Notes
+
+- Add `expandCount int` field to DetailView to track subtasks added in current session
+- `handleExpandInput` on Enter: emit ExpandTaskMsg, clear input, increment count, do NOT change mode
+- `handleExpandInput` on Esc: reset count, change mode to DetailModeView
+- Main model handler: `newTask.ParentID = &msg.ParentTask.ID`
+
+---
+
+### Story 31.3: Subtask List Rendering in Detail View
+
+**Priority:** P2
+**Status:** Not Started
+**Depends On:** 31.1, 31.2
+
+#### Description
+
+Render a subtask list in the detail view when the viewed task has children. Show each subtask's status icon and text in an indented tree format with a completion ratio summary.
+
+#### Acceptance Criteria
+
+- [ ] Detail view shows subtask list between task text/notes and the separator line when task has children
+- [ ] Subtask list uses tree characters: `├─` for non-last items, `└─` for last item
+- [ ] Each subtask shows status in brackets: `[TODO]`, `[DONE]`, `[BLOCKED]`, `[IN-PROGRESS]`
+- [ ] Completion ratio displayed: "Subtasks: N/M complete"
+- [ ] Subtask text truncated to fit terminal width minus indent
+- [ ] No subtask section rendered for tasks without children
+- [ ] Status colors applied to subtask status brackets (reuse existing StatusColor)
+- [ ] Table-driven tests for rendering with 0, 1, and multiple subtasks
+- [ ] `make lint && make test` pass
+
+#### Technical Notes
+
+- Use `dv.pool.GetSubtasks(dv.task.ID)` to fetch children
+- Render between notes section and separator line in `View()`
+- Use `lipgloss` for status coloring — reuse `StatusColor()` function
+- Truncate subtask text to `w - 10` (accounting for indent + status)
+
+---
+
+### Story 31.4: Enhanced Fork — Variant Creation with ForkTask Factory
+
+**Priority:** P2
+**Status:** Not Started
+**Depends On:** None (can be implemented in parallel with 31.1-31.3)
+
+#### Description
+
+Replace the current Fork implementation (simple `NewTask` copy) with a `ForkTask` factory method that creates a proper variant: preserving Text, Context, Effort, and Tags while resetting Status to todo, clearing Blocker and Notes, and adding a "Forked from" note. Emit a `TaskForkedMsg` so the main model can create an enrichment DB cross-reference.
+
+#### Acceptance Criteria
+
+- [ ] `core.ForkTask(original *Task) *Task` factory method exists
+- [ ] ForkTask preserves: Text, Context, Effort, Tags (defensive copy of Tags slice)
+- [ ] ForkTask resets: Status to `todo`, Blocker to `""`, Notes to empty
+- [ ] ForkTask sets fresh timestamps (CreatedAt, UpdatedAt = time.Now().UTC())
+- [ ] ForkTask generates new UUID (not copied from original)
+- [ ] ForkTask adds note: "Forked from: [text truncated to 60 chars]"
+- [ ] ForkTask does NOT copy ParentID (fork is independent)
+- [ ] `TaskForkedMsg{Original, Variant}` message type exists
+- [ ] Detail view `F` key emits `TaskForkedMsg` instead of `TaskAddedMsg`
+- [ ] Main model handles `TaskForkedMsg`: adds variant to pool, persists, creates enrichment cross-reference with `forked-from` relationship
+- [ ] Flash message displayed: "Forked! Variant added to pool"
+- [ ] Table-driven tests for ForkTask field semantics
+- [ ] Integration test: fork creates cross-reference in enrichment DB
+- [ ] `make lint && make test` pass
+
+#### Technical Notes
+
+- `ForkTask` lives in `internal/core/task.go` alongside `NewTask`
+- Tags defensive copy: `forked.Tags = append([]string{}, original.Tags...)`
+- Cross-reference creation in main model handler, NOT in core package
+- Enrichment DB cross-reference: `SourceTaskID=original.ID`, `TargetTaskID=variant.ID`, `Relationship="forked-from"`
+- If enrichment DB is nil, skip cross-reference (fork still works without it)
+
+---
+
+### Story 31.5: Design Decision H9 Status Update
+
+**Priority:** P2
+**Status:** Not Started
+**Depends On:** 31.1-31.4
+
+#### Description
+
+Update `docs/design-decisions-needed.md` to mark Decision H9 as implemented (Epic 31). Update story file statuses as implementation progresses.
+
+#### Acceptance Criteria
+
+- [ ] H9 entry updated: "Implementation: Epic 31 (Expand/Fork Key Implementations)"
+- [ ] H9 blocked status updated: "Blocked: None — Epic 31 created"
+- [ ] All story files (31.1-31.5) have correct status reflecting implementation state
+- [ ] No other changes to design-decisions-needed.md
+
+---
+
+## Epic Dependencies Diagram
+
+```
+31.1 (ParentID) ──→ 31.2 (Expand) ──→ 31.3 (Rendering)
+                                    └──→ 31.5 (Docs)
+31.4 (Fork) ─────────────────────────┘
+```
+
+Stories 31.1 and 31.4 can be implemented in parallel. Story 31.2 depends on 31.1. Story 31.3 depends on both 31.1 and 31.2. Story 31.5 is a documentation update after implementation.
+
+## ROADMAP Integration
+
+Add to ROADMAP.md under Active Epics:
+
+```markdown
+### Epic 31: Expand/Fork Key Implementations (P2) — 0/5 stories done
+
+Complete Expand (manual sub-task creation) and Fork (variant creation) TUI features.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 31.1 | Task Model ParentID Extension | Not Started | P2 | None |
+| 31.2 | Enhanced Expand — Sequential Subtask Creation | Not Started | P2 | 31.1 |
+| 31.3 | Subtask List Rendering in Detail View | Not Started | P2 | 31.1, 31.2 |
+| 31.4 | Enhanced Fork — Variant Creation with ForkTask Factory | Not Started | P2 | None |
+| 31.5 | Design Decision H9 Status Update | Not Started | P2 | 31.1-31.4 |
+```

--- a/_bmad-output/planning-artifacts/party-mode-expand-fork-2026-03-08.md
+++ b/_bmad-output/planning-artifacts/party-mode-expand-fork-2026-03-08.md
@@ -1,0 +1,65 @@
+# Party Mode Session: Expand/Fork Key Implementations
+
+**Date:** 2026-03-08
+**Topic:** Epic 31 — Expand/Fork Key Implementations Design Decisions
+**Participants:** Winston (Architect), Sally (UX Designer), Amelia (Dev), John (PM)
+
+---
+
+## Design Decisions Resolved
+
+### 1. ParentID Location: Native to Task Struct
+
+**Decision:** Add `ParentID *string` as a native field on `core.Task` (YAML: `parent_id,omitempty`).
+
+**Rationale (Winston):** Parent-child is a core domain relationship, not optional metadata. The enrichment DB's CrossReference system is designed for optional metadata (link discovery, dedup). If ParentID lives in enrichment, you can't query subtasks without the enrichment DB, breaking clean separation. A native field works across all providers and lets TaskPool answer "give me children of X" without external dependencies.
+
+**CrossReference usage:** The enrichment DB's `parent-of`/`child-of` types (Decision M8) remain for cross-provider relationships. Fork relationships use the enrichment DB since they're optional metadata.
+
+### 2. Fork Semantics: Variant Creation
+
+**Decision:** `core.ForkTask(original *Task) *Task` factory method.
+
+**Preserves:** Text, Context, Effort, Tags
+**Resets:** Status → todo, Blocker → "", Notes → empty, Timestamps → now (UTC)
+**Adds:** Note "Forked from: [truncated original text]"
+**Does NOT copy:** ParentID (fork is independent)
+**Cross-reference:** Main model creates enrichment DB cross-reference (forked-from) in `TaskForkedMsg` handler. Core package stays free of enrichment DB awareness.
+
+### 3. Property Inheritance: None
+
+**Decision:** Subtasks do NOT inherit effort, tags, or context from parent.
+
+**Rationale (John):** Each subtask is its own unit of work. Auto-inheriting effort=3 from a parent to 5 subtasks quintuples the total effort estimate — misleading. Parent's context explains why the breakdown exists, but subtasks need their own sizing.
+
+### 4. Subtask Completion → Parent: No Auto-Completion
+
+**Decision:** Never auto-complete a parent when all subtasks complete. Show completion ratio "3/5 subtasks complete" in detail view.
+
+**Additional:** Parent tasks with children are excluded from door rotation via `GetAvailableForDoors()` filter. This communicates "you broke this down, now work the pieces."
+
+### 5. Sequential Expand Mode (Bonus)
+
+**Decision (Sally):** After pressing Enter on one subtask, stay in `DetailModeExpandInput` for the next one. Show running count: "Subtask N added. Next subtask (Esc to finish):". Only Esc exits expand mode.
+
+---
+
+## Implementation Notes (Amelia)
+
+- `ParentID *string` on `core.Task`, `yaml:"parent_id,omitempty"`
+- `TaskPool.GetSubtasks(parentID string) []*Task` method
+- `ExpandTaskMsg` handler sets `newTask.ParentID = &parentTask.ID`
+- `ForkTask` returns `*Task`, main model handles cross-reference
+- `handleExpandInput` stays in expand mode on Enter, only exits on Esc
+- Subtask rendering in detail view: indented list with status icons
+
+## Detail View Subtask Rendering (Sally)
+
+```
+Write architecture document
+  ├─ [TODO] Draft high-level overview
+  ├─ [DONE] Data models section
+  └─ [TODO] Components section
+
+Subtasks: 1/3 complete
+```

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-expand-fork.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-expand-fork.md
@@ -1,0 +1,194 @@
+# Sprint Change Proposal: Expand/Fork Key Implementations
+
+**Date:** 2026-03-08
+**Proposed by:** BMAD Pipeline (fancy-bear worker)
+**Change Scope:** Minor — Direct implementation by development team
+
+---
+
+## Section 1: Issue Summary
+
+**Problem Statement:** The ThreeDoors TUI detail view has two key actions — `[E]xpand` (manual sub-task creation) and `[F]ork` (variant creation) — that have basic stub implementations but lack the full feature depth specified in Design Decision H9. Expand currently provides only a single-line text input that creates an unlinked new task. Fork creates a simple copy with `NewTask(text)` but doesn't implement the "variant creation" semantics (stripping assignee, resetting status, adding context about the original task). Neither feature tracks parent-child relationships, shows subtask lists, or provides the user experience described in the PRD.
+
+**Context:** Decision H9 in `docs/design-decisions-needed.md` has been resolved:
+- **Expand = Option A (manual sub-task creation):** Opens a form to add sub-tasks manually, with parent-child relationship tracking
+- **Fork = Option B (variant creation):** Creates a copy with some fields stripped (no assignee, reset status) for exploring a new direction
+- **LLM decomposition stays separate** under the `[G]enerate` key (Epic 14, already complete)
+
+**Evidence:**
+- `internal/tui/detail_view.go` lines 147-152: Expand opens a basic text input, emits `ExpandTaskMsg` but creates an unlinked task
+- `internal/tui/detail_view.go` lines 150-152: Fork calls `core.NewTask(dv.task.Text)` — a flat copy with no variant semantics
+- The `core.Task` struct has no `ParentID` or `SubtaskIDs` fields for parent-child tracking
+- No subtask rendering in the detail view or doors view
+- The `ExpandTaskMsg` and `TaskAddedMsg` are handled in the main model but don't establish relationships
+- PRD (`docs/prd/user-interface-design-goals.md`) lists both `[E]xpand` and `[F]ork` as core task actions
+
+---
+
+## Section 2: Impact Analysis
+
+### Epic Impact
+- **No existing epics affected.** This is a purely additive new epic (proposed: Epic 31).
+- **Dependencies:** All prerequisite infrastructure is complete:
+  - Epic 3 (Enhanced Interaction) — detail view foundation
+  - Epic 13 (Multi-Source Aggregation) — cross-reference/linking patterns exist via enrichment DB
+  - The `enrichment.CrossReference` system provides a model for parent-child relationships
+- **No blocking relationships** with remaining active work (Epics 23, 24, 25, 26, 30).
+
+### Story Impact
+- No current or future stories require changes.
+- New stories to be created within the new epic.
+- Decision M8 (Link Relationship Types) adds `parent-of` and `child-of` relationship types which directly support this feature.
+
+### Artifact Conflicts
+
+| Artifact | Impact | Change Needed |
+|----------|--------|---------------|
+| PRD (`docs/prd/user-interface-design-goals.md`) | Lists E/F as core actions but no detailed spec | Add Expand/Fork feature specifications |
+| PRD (`docs/prd/requirements.md`) | No specific requirements for Expand/Fork behavior | Add FR requirements for subtask/variant features |
+| Architecture (`docs/architecture/data-models.md`) | Task struct lacks ParentID/SubtaskIDs | Add parent-child fields to Task model |
+| Architecture (`docs/architecture/components.md`) | DetailView component spec doesn't mention subtask UI | Update DetailView component description |
+| ROADMAP.md | Expand/Fork not listed | Add Epic 31 to Active Epics |
+| Epics document | No Expand/Fork epic exists | Add Epic 31 with stories |
+| `docs/design-decisions-needed.md` | H9 decided but not yet implemented | Mark H9 as "Implementation Planned (Epic 31)" |
+
+### Technical Impact
+- **Task model extension:** Add `ParentID *string` and computed subtask list to `core.Task`
+- **Enrichment DB:** Use existing `CrossReference` with `parent-of`/`child-of` relationship types OR add native parent-child to Task struct
+- **Detail view:** Enhanced expand flow with multi-subtask creation, subtask list rendering, fork with variant semantics
+- **Doors view:** Optionally show subtask count badge on parent tasks
+- **YAML persistence:** Add `parent_id` field to task YAML schema (backward-compatible — optional field)
+- **Minimal blast radius:** Changes are additive to existing code paths
+
+---
+
+## Section 3: Recommended Approach
+
+**Selected Path:** Direct Adjustment — Add new Epic 31 (Expand/Fork Key Implementations) with 4-5 stories.
+
+**Rationale:**
+- Both features are already stubbed in the codebase, reducing implementation risk
+- The enrichment DB's cross-reference system provides infrastructure for relationship tracking
+- Decision M8 already adds the `parent-of`/`child-of` relationship types needed
+- The detail view's existing mode-based input system (`DetailModeExpandInput`) provides the UX pattern
+- Estimated effort: 3-5 days total across all stories
+- No architectural changes required — extends existing patterns
+
+**Effort estimate:** Low-Medium
+**Risk level:** Low
+**Timeline impact:** None — parallel to other active work
+
+---
+
+## Section 4: Detailed Change Proposals
+
+### 4.1 Task Model Changes
+
+**File:** `internal/core/task.go`
+
+```
+OLD:
+(no ParentID field)
+
+NEW:
+- ParentID  *string  `yaml:"parent_id,omitempty"`
+
+Rationale: Track parent-child relationships natively in the task model.
+Allow tasks to reference their parent, enabling subtask queries.
+```
+
+### 4.2 Expand Enhancement
+
+**File:** `internal/tui/detail_view.go`
+
+```
+OLD:
+- Single text input creates unlinked task via ExpandTaskMsg
+- No subtask list rendering in detail view
+
+NEW:
+- Expand creates subtask with ParentID set to current task's ID
+- Detail view shows subtask list when task has children
+- Subtask count visible in status line
+- User can add multiple subtasks in sequence
+
+Rationale: Fulfill H9 Decision A — manual sub-task creation with parent-child tracking
+```
+
+### 4.3 Fork Enhancement
+
+**File:** `internal/tui/detail_view.go`
+
+```
+OLD (line 150-152):
+case "f", "F":
+    forked := core.NewTask(dv.task.Text)
+    return func() tea.Msg { return TaskAddedMsg{Task: forked} }
+
+NEW:
+case "f", "F":
+    forked := core.ForkTask(dv.task)  // New factory method
+    return func() tea.Msg { return TaskForkedMsg{Original: dv.task, Variant: forked} }
+
+Rationale: ForkTask creates a variant by copying text+context but resetting
+status to todo, clearing blocker, preserving effort, and adding a note
+"Forked from: [original task text]". TaskForkedMsg allows the main model
+to establish a cross-reference between original and variant.
+```
+
+### 4.4 PRD Updates
+
+**File:** `docs/prd/requirements.md`
+
+```
+NEW requirements to add:
+- FR-EXPAND-1: User can press [E] in detail view to create a subtask linked to the current task
+- FR-EXPAND-2: Subtasks appear in the parent task's detail view with their status
+- FR-EXPAND-3: Subtasks are eligible for door selection independently
+- FR-FORK-1: User can press [F] in detail view to create a variant of the current task
+- FR-FORK-2: Variants reset status to todo and clear blockers
+- FR-FORK-3: Variants are cross-referenced to the original task via enrichment DB
+```
+
+### 4.5 Architecture Updates
+
+**File:** `docs/architecture/data-models.md`
+
+```
+NEW: Add ParentID field to Task model
+NEW: Document subtask query patterns (get children by ParentID)
+NEW: Document ForkTask factory method semantics
+```
+
+---
+
+## Section 5: Implementation Handoff
+
+**Change Scope Classification:** Minor — Direct implementation by development team
+
+**Handoff Plan:**
+- **Development team:** Implement Epic 31 stories via standard story-driven workflow
+- **No PO/SM coordination needed** — purely additive feature completion
+- **No architect involvement needed** — extends existing patterns
+
+**Implementation Order:**
+1. Story 31.1: Task model ParentID extension + subtask query methods
+2. Story 31.2: Enhanced Expand — subtask creation with parent-child linking
+3. Story 31.3: Subtask list rendering in detail view + doors view badge
+4. Story 31.4: Enhanced Fork — variant creation with ForkTask factory
+5. Story 31.5: Cross-reference integration for fork variants (optional — may fold into 31.4)
+
+**Success Criteria:**
+- `[E]xpand` creates subtasks linked to parent via ParentID
+- Subtasks visible in parent's detail view
+- `[F]ork` creates variant with reset status, cross-referenced to original
+- All new features have table-driven tests
+- Backward-compatible YAML schema (existing tasks load without ParentID)
+- `make lint && make test` pass with zero warnings
+
+---
+
+## Approval
+
+**Status:** Approved (automated pipeline — YOLO mode)
+**Next Steps:** Proceed to Party Mode for multi-agent discussion, then PRD updates, architecture, and epic/story creation.

--- a/docs/prd/product-scope.md
+++ b/docs/prd/product-scope.md
@@ -117,6 +117,25 @@
 
 ---
 
+## Phase 3.5+: Expand/Fork Key Implementations
+
+**In Scope:**
+- Enhanced Expand action: sequential subtask creation mode (E key in detail view)
+- Native `parent_id` field on Task model for parent-child relationships
+- Subtask list rendering in detail view with completion ratio
+- Parent tasks excluded from door selection when they have children
+- Enhanced Fork action: variant creation with field preservation/reset semantics
+- `ForkTask` factory method copying Text/Context/Effort/Tags, resetting Status/Blocker/Notes
+- Fork cross-references via enrichment DB (`forked-from` relationship)
+
+**Out of Scope for this Phase:**
+- Drag-and-drop subtask reordering (TUI limitation)
+- Recursive subtask nesting (v1 supports single-level parent-child only)
+- CLI `threedoors task expand/fork` commands (deferred to Epic 23 extension)
+- MCP `expand_task` / `fork_task` tools (deferred to Epic 24 extension)
+
+---
+
 ## Phase 4: Task Source Integration & Sync Hardening
 
 **In Scope:**

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -434,6 +434,30 @@ These non-functional requirements establish code quality gates that all contribu
 
 ---
 
+## Phase 6+ - Expand/Fork Key Implementations (Accepted)
+
+*The following requirements complete the Expand and Fork key actions in the TUI detail view, based on Design Decision H9.*
+
+**Expand (Manual Sub-Task Creation):**
+
+**FR120:** The system shall provide an Expand action via the `E` key in the detail view that enters a sequential subtask creation mode — after submitting one subtask (Enter), the input stays open for the next subtask until the user presses Esc to exit expand mode
+
+**FR121:** Subtasks created via Expand shall have their `parent_id` field set to the parent task's ID, establishing a native parent-child relationship in the core task model — the `parent_id` field is an optional string pointer (`*string`) stored as `parent_id` in YAML, backward-compatible with existing tasks
+
+**FR122:** The detail view shall display a subtask list below the task text when the viewed task has children, showing each subtask's status icon and text in an indented tree format, with a completion ratio summary (e.g., "Subtasks: 2/5 complete")
+
+**FR123:** Parent tasks that have one or more subtasks shall be excluded from door selection by `GetAvailableForDoors()` — the user has decomposed the task, so only the subtasks should appear as doors
+
+**FR124:** Subtasks shall NOT inherit effort, tags, or context from their parent — each subtask is an independent work item with its own metadata
+
+**Fork (Variant Creation):**
+
+**FR125:** The system shall provide a Fork action via the `F` key in the detail view that creates a variant of the current task by copying Text, Context, Effort, and Tags while resetting Status to `todo`, clearing Blocker and Notes, setting fresh timestamps, and adding a note "Forked from: [truncated original text]"
+
+**FR126:** Fork variants shall be cross-referenced to the original task via the enrichment DB using a `forked-from` relationship type — the core `ForkTask` factory returns a concrete `*Task` and the main model establishes the cross-reference
+
+---
+
 ## Phase 6+ - Task Dependencies & Blocked-Task Filtering (Accepted)
 
 *The following requirements add a native dependency graph for tasks, ensuring the Three Doors only present genuinely actionable tasks by automatically filtering those whose prerequisites are incomplete.*


### PR DESCRIPTION
## Summary

- Ran full BMAD planning pipeline (course correction → party mode → PRD → architecture → epics & stories) for implementing enhanced Expand and Fork key actions in the TUI detail view
- Created Epic 31 with 5 stories based on Design Decision H9
- Updated PRD requirements (FR120-FR126), product scope, and ROADMAP.md

## Key Design Decisions (Party Mode Consensus)

| Decision | Resolution |
|----------|-----------|
| ParentID location | **Native to Task struct** (`ParentID *string`), not enrichment DB |
| Fork semantics | Copy Text/Context/Effort/Tags, reset Status/Blocker/Notes, add "Forked from" note |
| Property inheritance | **None** — subtasks are independent work items |
| Subtask completion → parent | **No auto-completion**, show completion ratio, parent excluded from doors |
| Sequential expand | Stay in expand mode after Enter, Esc exits |

## Artifacts Created

- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-expand-fork.md`
- `_bmad-output/planning-artifacts/party-mode-expand-fork-2026-03-08.md`
- `_bmad-output/planning-artifacts/architecture-expand-fork.md`
- `_bmad-output/planning-artifacts/epic-31-expand-fork.md`

## Epic 31 Stories

| Story | Title | Depends On |
|-------|-------|------------|
| 31.1 | Task Model ParentID Extension | None |
| 31.2 | Enhanced Expand — Sequential Subtask Creation | 31.1 |
| 31.3 | Subtask List Rendering in Detail View | 31.1, 31.2 |
| 31.4 | Enhanced Fork — Variant Creation with ForkTask Factory | None |
| 31.5 | Design Decision H9 Status Update | 31.1-31.4 |

## Test plan

- [x] All artifacts follow existing BMAD pipeline format conventions
- [x] ROADMAP.md includes Epic 31 in Active Epics
- [x] PRD requirements are numbered sequentially (FR120-FR126)
- [x] Architecture document references correct code paths
- [x] Stories have clear acceptance criteria and dependency chains