### PR TITLE
feat: BMAD planning — Undo Task Completion epic and stories

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,6 +75,16 @@ Complete Expand (manual sub-task creation) and Fork (variant creation) TUI featu
 | 31.4 | Enhanced Fork — Variant Creation with ForkTask Factory | Not Started | P2 | None |
 | 31.5 | Design Decision H9 Status Update | Not Started | P2 | 31.1-31.4 |
 
+### Epic 32: Undo Task Completion (P1) — 0/3 stories done
+
+Allow reversing accidental task completion via `complete → todo` transition. Validated pain point from Phase 1 gate.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 32.1 | Status Model — Complete-to-Todo Transition | Not Started | P1 | None |
+| 32.2 | Session Metrics — Undo Complete Event Logging | Not Started | P1 | 32.1 |
+| 32.3 | TUI & CLI Undo Experience | Not Started | P1 | 32.1, 32.2 |
+
 ## Completed Epics
 
 | Epic | Title | Stories |

--- a/_bmad-output/planning-artifacts/architecture-undo-task-completion.md
+++ b/_bmad-output/planning-artifacts/architecture-undo-task-completion.md
@@ -1,0 +1,192 @@
+# Architecture: Undo Task Completion (Epic 32)
+
+**Date:** 2026-03-08
+**Status:** Approved via Party Mode consensus
+**PRD Requirements:** FR127–FR131
+
+---
+
+## Overview
+
+Enable reversing task completion (`complete → todo`) by extending the existing status transition model. This is a minimal, surgical change to the table-driven transition system — no new packages, interfaces, or persistence formats required.
+
+## Design Decisions
+
+### DD-32.1: Reverse Transition Target
+
+**Decision:** Only `complete → todo` is supported. Not `complete → in-progress` or `complete → blocked`.
+
+**Rationale:** Undo returns the task to the beginning of its lifecycle. The user can then transition to `in-progress` via normal flow. Supporting multiple reverse targets adds complexity without value — the user's intent is "this task isn't actually done," not "this task is in a specific non-done state."
+
+### DD-32.2: CompletedAt Handling
+
+**Decision:** Clear `CompletedAt` to `nil` when transitioning from `complete` to `todo`.
+
+**Rationale:** `CompletedAt` represents the factual state "this task is done at this time." When undoing completion, maintaining the old `CompletedAt` would violate the data model invariant that `CompletedAt` is only set when `status == complete`. The original completion timestamp is preserved in the `undo_complete` session metrics event for historical analysis.
+
+### DD-32.3: Completed Log Immutability
+
+**Decision:** The `completed.txt` file remains append-only. Undo does NOT remove entries.
+
+**Rationale:** `completed.txt` is an audit trail. Modifying it on undo would break the append-only guarantees relied upon by analysis scripts (`scripts/daily_completions.sh`, `scripts/analyze_sessions.sh`). The session metrics `undo_complete` event provides the correction signal — any reporting tool can correlate completion and undo events for accurate counts.
+
+### DD-32.4: No Time Limit
+
+**Decision:** Undo is available regardless of when the task was completed.
+
+**Rationale:** Accidental completion can be discovered at any time. Time-limited undo (e.g., "undo within 30 seconds") adds UX complexity (countdown timers, ephemeral UI) without meaningful benefit. The status menu approach requires deliberate user action (select task → open status menu → choose todo), which provides sufficient friction to prevent accidental undo.
+
+### DD-32.5: Dependency Re-evaluation
+
+**Decision:** When a completed task is undone and other tasks depend on it (FR113), dependent tasks are re-checked and may return to blocked state.
+
+**Rationale:** The dependency system (Epic 29) uses `GetAvailableForDoors()` to filter tasks whose dependencies are not all complete. When a dependency is undone, any task that was unblocked by that completion must be re-evaluated. The existing dependency check logic handles this naturally — no special undo-aware code is needed in the dependency filter, because it already checks live status on every refresh.
+
+---
+
+## Component Changes
+
+### internal/core/task_status.go
+
+**Change:** Add `StatusTodo` to `validTransitions[StatusComplete]`
+
+```go
+// BEFORE
+StatusComplete:   {},
+
+// AFTER
+StatusComplete:   {StatusTodo},
+```
+
+**Impact:** Enables `complete → todo` across all surfaces (TUI, CLI, MCP, adapters) automatically because all status change operations go through `IsValidTransition()`.
+
+### internal/core/task.go — UpdateStatus()
+
+**Change:** Clear `CompletedAt` when leaving complete status
+
+```go
+// Add before existing CompletedAt setting logic:
+if t.Status == StatusComplete && newStatus != StatusComplete {
+    t.CompletedAt = nil
+}
+```
+
+**Impact:** Maintains data model invariant that `CompletedAt` is only set when status is complete or archived.
+
+### internal/core/session_tracker.go
+
+**Change:** Add `RecordUndoComplete()` method to log undo events
+
+```go
+func (st *SessionTracker) RecordUndoComplete(taskID string, originalCompletedAt time.Time) {
+    // Log undo_complete event to JSONL session metrics
+}
+```
+
+**Impact:** Enables behavioral analysis of accidental completions.
+
+### internal/tui/ — StatusUpdateMenu
+
+**Change:** None required. The status menu already reads from `GetValidTransitions()`, which will automatically include `todo` when the current status is `complete`.
+
+**Impact:** The UX "just works" — users see `todo` as a valid option when viewing a completed task.
+
+### internal/tui/ — Detail View
+
+**Change:** Show confirmation message after undo completion (toast/status bar message).
+
+### internal/cli/ — Status Command
+
+**Change:** None required for existing `threedoors task status <id> <status>` command — it already validates transitions via the same `IsValidTransition()` function.
+
+### Adapters (all)
+
+**Change:** Ensure adapters handle tasks transitioning from `complete → todo` gracefully. For bidirectional sync adapters (Todoist, GitHub, Linear, Jira), the reverse sync (reopening a closed/completed item) is deferred to individual adapter epics. The core undo feature focuses on local state only.
+
+---
+
+## State Machine (Updated)
+
+```mermaid
+stateDiagram-v2
+    [*] --> todo
+    todo --> in-progress
+    todo --> blocked
+    todo --> complete
+    todo --> deferred
+    todo --> archived
+    blocked --> todo
+    blocked --> in-progress
+    blocked --> complete
+    in-progress --> blocked
+    in-progress --> in-review
+    in-progress --> complete
+    in-review --> in-progress
+    in-review --> complete
+    complete --> todo : undo
+    deferred --> todo
+```
+
+**Change from current:** Added `complete → todo` transition (labeled "undo").
+
+---
+
+## Data Flow
+
+```
+User Action: Select completed task → Status menu → Choose "todo"
+    │
+    ├─ IsValidTransition(complete, todo) → true (NEW)
+    │
+    ├─ Task.UpdateStatus(todo)
+    │   ├─ Set status = todo
+    │   ├─ Clear CompletedAt = nil
+    │   ├─ Set UpdatedAt = now
+    │   └─ Clear Blocker = ""
+    │
+    ├─ SessionTracker.RecordUndoComplete(taskID, originalCompletedAt)
+    │   └─ Append undo_complete event to sessions.jsonl
+    │
+    ├─ TaskPool.UpdateTask(task)
+    │   └─ Task now eligible for GetAvailableForDoors()
+    │
+    ├─ FileManager.SaveTasks() → atomic write to tasks.yaml
+    │
+    └─ TUI: Show confirmation toast, refresh doors view
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `TestIsValidTransition_CompleteToTodo` — verify transition is now valid
+- `TestIsValidTransition_CompleteToOthers` — verify only `todo` is valid target from complete (not `in-progress`, `blocked`, etc.)
+- `TestUpdateStatus_UndoComplete_ClearsCompletedAt` — verify `CompletedAt` is nil after undo
+- `TestUpdateStatus_UndoComplete_SetsUpdatedAt` — verify timestamp is updated
+- `TestUpdateStatus_UndoComplete_ClearsBlocker` — verify blocker is cleared
+- Regression: all existing transition tests pass unchanged
+
+### Integration Tests
+
+- TUI: Status menu shows `todo` for completed tasks
+- CLI: `threedoors task status <id> todo` succeeds for completed tasks
+- Session metrics: `undo_complete` event is logged correctly
+
+### Edge Cases
+
+- Undo a task completed weeks ago
+- Undo a task that is a dependency for other tasks (re-blocks dependents)
+- Undo a task from a bidirectional sync adapter (local undo only, no remote API call)
+- Undo a task with notes — notes should be preserved
+
+---
+
+## Non-Goals
+
+- General undo system (undo any action) — out of scope
+- Undo history / undo stack — out of scope
+- Time-limited undo with countdown UI — rejected in party mode
+- Adapter-level "reopen" API calls — deferred to individual adapter epics
+- Removing entries from completed.txt — rejected (immutable audit trail)

--- a/_bmad-output/planning-artifacts/epic-32-undo-task-completion.md
+++ b/_bmad-output/planning-artifacts/epic-32-undo-task-completion.md
@@ -1,0 +1,160 @@
+# Epic 32: Undo Task Completion
+
+**Priority:** P1
+**Status:** Backlog
+**PRD Requirements:** FR127–FR131
+**Architecture:** architecture-undo-task-completion.md
+**Party Mode:** party-mode-undo-task-completion-2026-03-08.md
+**Sprint Change Proposal:** sprint-change-proposal-2026-03-08-undo-task-completion.md
+
+---
+
+## Epic Summary
+
+Enable users to reverse accidental task completion by adding a `complete → todo` status transition. Addresses a validated pain point from the Phase 1 Validation Gate review: "No undo for task completion. Once a task is marked done, recovery requires manual file editing."
+
+## Design Decisions
+
+- **DD-32.1:** Only `complete → todo` transition supported (not `complete → in-progress`)
+- **DD-32.2:** `CompletedAt` cleared to nil on undo
+- **DD-32.3:** `completed.txt` remains immutable; undo tracked via session metrics
+- **DD-32.4:** No time limit on undo
+- **DD-32.5:** Dependency re-evaluation triggers automatically via existing filters
+
+## Stories
+
+### Story 32.1: Status Model — Complete-to-Todo Transition
+
+**Priority:** P1
+**Depends On:** None
+**Estimated Effort:** Small
+
+#### Description
+
+Add `complete → todo` to the status transition model and handle `CompletedAt` clearing when a task is un-completed. This is the foundational change that enables undo across all surfaces.
+
+#### Acceptance Criteria
+
+1. `IsValidTransition(StatusComplete, StatusTodo)` returns `true`
+2. `IsValidTransition(StatusComplete, StatusInProgress)` returns `false` (no other reverse transitions added)
+3. `IsValidTransition(StatusComplete, StatusBlocked)` returns `false`
+4. `Task.UpdateStatus(StatusTodo)` succeeds when current status is `complete`
+5. After undo, `CompletedAt` is `nil`
+6. After undo, `UpdatedAt` is set to current UTC time
+7. After undo, `Blocker` is empty string
+8. After undo, `Status` is `todo`
+9. Task notes are preserved through the undo transition
+10. All existing status transition tests pass unchanged (regression)
+11. `GetValidTransitions(StatusComplete)` returns `[StatusTodo]`
+
+#### Technical Notes
+
+- Modify `validTransitions` map in `internal/core/task_status.go`
+- Add `CompletedAt` clearing logic in `Task.UpdateStatus()` in `internal/core/task.go`
+- Add table-driven tests for the new transition in `internal/core/task_status_test.go`
+- Add tests for `CompletedAt` clearing in `internal/core/task_test.go`
+
+#### Tasks
+
+- [ ] Add `StatusTodo` to `validTransitions[StatusComplete]` in `task_status.go`
+- [ ] Add `CompletedAt` clearing logic when leaving complete status in `task.go`
+- [ ] Add unit tests for `complete → todo` transition validity
+- [ ] Add unit tests for `CompletedAt` clearing on undo
+- [ ] Add unit tests verifying other reverse transitions remain invalid
+- [ ] Verify all existing tests pass (regression)
+- [ ] Run `make fmt && make lint && make test`
+
+---
+
+### Story 32.2: Session Metrics — Undo Complete Event Logging
+
+**Priority:** P1
+**Depends On:** 32.1
+**Estimated Effort:** Small
+
+#### Description
+
+Log `undo_complete` events in session metrics when a task completion is reversed. Capture the task ID, original completion timestamp, and time elapsed since completion for behavioral analysis of accidental completions.
+
+#### Acceptance Criteria
+
+1. When a task transitions from `complete` to `todo`, an `undo_complete` event is appended to the JSONL session log
+2. The event includes: task ID, original `CompletedAt` timestamp, time elapsed since completion, and current session timestamp
+3. The event type is `undo_complete` (consistent with existing event naming: `snooze`, `snooze_return`)
+4. The `completed.txt` file is NOT modified when undo occurs
+5. Session metrics reader (`ReadAll`, `ReadSince`, `ReadLast`) correctly parse `undo_complete` events
+6. Event logging does not block the TUI update loop (async via `tea.Cmd`)
+
+#### Technical Notes
+
+- Add `RecordUndoComplete(taskID string, originalCompletedAt time.Time)` to `SessionTracker`
+- Follow existing event logging patterns in `internal/core/session_tracker.go`
+- The session tracker's JSONL format is append-only, matching `completed.txt` immutability
+- Test with existing metrics reader infrastructure
+
+#### Tasks
+
+- [ ] Add `undo_complete` event type constant
+- [ ] Add `RecordUndoComplete()` method to `SessionTracker`
+- [ ] Wire up undo event logging in the TUI status change handler
+- [ ] Add unit tests for event logging
+- [ ] Verify `completed.txt` is not modified on undo
+- [ ] Run `make fmt && make lint && make test`
+
+---
+
+### Story 32.3: TUI & CLI Undo Experience
+
+**Priority:** P1
+**Depends On:** 32.1, 32.2
+**Estimated Effort:** Small
+
+#### Description
+
+Ensure the TUI and CLI surfaces provide a smooth undo experience. The TUI status menu should automatically show `todo` as a valid option when viewing completed tasks (this happens naturally via `GetValidTransitions`). Add a confirmation toast message after undo. Ensure the CLI `task status` command supports the transition.
+
+#### Acceptance Criteria
+
+1. In TUI detail view of a completed task, pressing `S` (status menu) shows `todo` as a valid transition option
+2. After selecting `todo` from the status menu of a completed task, the task returns to `todo` status
+3. A brief confirmation message is shown: "Task uncompleted — returned to todo"
+4. After undo, the doors view refreshes and the uncompleted task is eligible for door selection
+5. CLI command `threedoors task status <id> todo` succeeds when the task is currently `complete`
+6. CLI outputs confirmation message when undo succeeds
+7. If the undone task was a dependency for other tasks, those dependents are re-evaluated (tested with dependency filter)
+
+#### Technical Notes
+
+- TUI StatusUpdateMenu reads from `GetValidTransitions()` — no menu code changes needed
+- Add toast/status bar message to TUI after undo
+- CLI `status` subcommand already validates via `IsValidTransition` — should work automatically
+- Test dependency re-evaluation: complete task A (unblocks B), undo task A (re-blocks B)
+
+#### Tasks
+
+- [ ] Verify TUI status menu shows `todo` for completed tasks (may need no code change)
+- [ ] Add confirmation toast/message after undo in TUI
+- [ ] Verify CLI `task status` command handles undo
+- [ ] Add TUI integration test for undo flow
+- [ ] Add dependency re-evaluation test (if Epic 29 is implemented)
+- [ ] Run `make fmt && make lint && make test`
+
+---
+
+## Story Dependency Graph
+
+```
+32.1 (Status Model)
+  ├── 32.2 (Session Metrics)
+  │     └── 32.3 (TUI & CLI)
+  └── 32.3 (TUI & CLI)
+```
+
+## Epic Completion Criteria
+
+1. Users can undo task completion from both TUI and CLI
+2. `CompletedAt` is properly cleared on undo
+3. Session metrics capture `undo_complete` events
+4. `completed.txt` remains immutable
+5. All existing tests pass (no regressions)
+6. Dependency re-evaluation works correctly when a dependency is undone

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -1207,3 +1207,68 @@ So that Epic 4's learning algorithm is evidence-informed.
 **And** evidence assessment for "progress over perfection"
 **And** actionable recommendations for Epic 4
 **And** bibliography with accessible references
+
+---
+
+## Epic 32: Undo Task Completion (P1 — FR127–FR131)
+
+**Priority:** P1
+**Status:** Backlog
+**Stories:** 3
+
+Enable users to reverse accidental task completion by adding a `complete → todo` status transition. Addresses a validated pain point from the Phase 1 Validation Gate: "No undo for task completion."
+
+**Design Decisions:**
+- DD-32.1: Only `complete → todo` supported (not `complete → in-progress`)
+- DD-32.2: `CompletedAt` cleared to nil on undo
+- DD-32.3: `completed.txt` remains immutable; undo tracked via session metrics
+- DD-32.4: No time limit on undo
+- DD-32.5: Dependency re-evaluation triggers automatically
+
+### Story 32.1: Status Model — Complete-to-Todo Transition
+
+As a user who accidentally completed a task,
+I want the status model to support reversing completion,
+So that I can undo my mistake without manually editing files.
+
+**Acceptance Criteria:**
+
+**Given** a task with status `complete`
+**When** the user requests a status change to `todo`
+**Then** `IsValidTransition(complete, todo)` returns `true`
+**And** `CompletedAt` is cleared to nil
+**And** `UpdatedAt` is set to current UTC time
+**And** `Status` is set to `todo`
+**And** task notes are preserved
+**And** all existing status transition tests pass unchanged
+
+### Story 32.2: Session Metrics — Undo Complete Event Logging
+
+As a product analyst,
+I want undo-complete events logged to session metrics,
+So that I can analyze accidental completion patterns.
+
+**Acceptance Criteria:**
+
+**Given** a task transitions from `complete` to `todo`
+**When** the undo is executed
+**Then** an `undo_complete` event is appended to the JSONL session log
+**And** the event includes task ID, original completion timestamp, and time elapsed
+**And** the `completed.txt` file is NOT modified
+**And** session metrics reader correctly parses the new event type
+
+### Story 32.3: TUI & CLI Undo Experience
+
+As a user viewing a completed task,
+I want to undo the completion from both TUI and CLI,
+So that I have a smooth, friction-free correction experience.
+
+**Acceptance Criteria:**
+
+**Given** a completed task is viewed in the TUI detail view
+**When** the user opens the status menu (`S` key)
+**Then** `todo` appears as a valid transition option
+**And** selecting `todo` returns the task to todo status
+**And** a confirmation message is shown: "Task uncompleted — returned to todo"
+**And** the doors view refreshes to include the uncompleted task
+**And** CLI `threedoors task status <id> todo` succeeds for completed tasks

--- a/_bmad-output/planning-artifacts/party-mode-undo-task-completion-2026-03-08.md
+++ b/_bmad-output/planning-artifacts/party-mode-undo-task-completion-2026-03-08.md
@@ -1,0 +1,78 @@
+# Party Mode: Undo Task Completion Discussion
+
+**Date:** 2026-03-08
+**Topic:** Epic 32 — Undo Task Completion
+**Participants:** PM, Architect, Dev, QA, UX Designer, SM
+
+---
+
+## Discussion Summary
+
+### PM (Product Manager)
+
+The undo feature was explicitly flagged in our Phase 1 Validation Gate as a pain point. Users accidentally marking tasks complete is a real friction source. I support adding this as Epic 32 with P1 priority. The scope is intentionally minimal — `complete → todo` only. We don't need a general undo system or undo history. Keep it simple.
+
+**Recommendation:** Approve as proposed. FR127 captures the requirement cleanly.
+
+### Architect
+
+From an architecture perspective, this is one of the cleanest changes we can make. The status transition model is table-driven — adding one entry to `validTransitions[StatusComplete]` enables the feature across all surfaces (TUI, CLI, MCP). The only subtlety is clearing `CompletedAt` when undoing, which is a 3-line addition to `UpdateStatus()`.
+
+**Key design decisions:**
+1. Only `complete → todo` is supported (not `complete → in-progress`). The task returns to the start of its lifecycle.
+2. `CompletedAt` must be cleared to maintain data model invariants.
+3. The completed.txt log is append-only — we should NOT remove entries from it. Instead, log an `undo_complete` event in session metrics so the behavioral data tells the full story.
+4. No time limit on undo — if a user completed a task last week and realizes the mistake, they should still be able to undo it.
+
+**Architecture impact:** Minimal. No new packages, no new interfaces, no new persistence formats.
+
+### Dev
+
+Implementation is straightforward:
+1. Story 32.1: Status model change (transition table + CompletedAt clearing + tests) — trivial
+2. Story 32.2: TUI integration (status menu already shows valid transitions, need confirmation UX + session metrics) — low effort
+3. Story 32.3: Adapter awareness (ensure adapters handle `complete → todo` gracefully for bidirectional sync adapters) — low effort
+
+The existing table-driven test infrastructure in `task_status_test.go` makes adding test coverage for the new transition very clean.
+
+### QA
+
+Test coverage requirements:
+- Unit tests for `complete → todo` transition
+- Unit tests for `CompletedAt` clearing
+- Verify all other transitions remain unchanged (regression)
+- TUI test for undo flow
+- Contract test update ensuring adapters handle re-opened tasks
+- Edge case: undo a task that was completed and then its file was modified externally
+
+### UX Designer
+
+The undo experience should be seamless:
+- In the detail view of a completed task, the status menu should show "todo" as a valid option
+- Consider showing a brief confirmation: "Task uncompleted. Returned to todo."
+- No additional keybinding needed — the existing `S` (status) menu handles this naturally
+- The doors view should immediately include the uncompleted task in the eligible pool
+- No time limit on undo — accidental completion can happen any time
+
+### SM (Scrum Master)
+
+Sprint impact is minimal. This is 2-3 stories, low complexity, no dependencies on other active epics. Can be parallelized with Epic 23 and 24 remaining work.
+
+---
+
+## Consensus
+
+All agents **unanimously approve** the Sprint Change Proposal for Epic 32: Undo Task Completion.
+
+### Adopted Recommendations
+
+1. **Simple reverse transition only:** `complete → todo` — no general undo history system
+2. **No time limit:** Undo should work regardless of when the task was completed
+3. **Append-only completed log:** Don't modify completed.txt; log undo events separately in session metrics
+4. **Natural TUI integration:** Use existing status menu mechanism; add brief confirmation toast
+5. **Session metrics event:** Log `undo_complete` events with task ID and original completion timestamp
+6. **Adapter graceful handling:** Ensure adapters don't crash when a task transitions from complete back to todo; full "reopen" API support is deferred to individual adapter epics
+
+### Priority
+
+P1 — Validated user pain point, minimal effort, high quality-of-life impact.

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-undo-task-completion.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-undo-task-completion.md
@@ -1,0 +1,180 @@
+# Sprint Change Proposal: Undo Task Completion
+
+**Date:** 2026-03-08
+**Triggered By:** Validation Gate Results (docs/validation-gate-results.md) — "No undo for task completion"
+**Change Type:** New Epic Proposal
+**Scope Classification:** Minor
+
+---
+
+## Section 1: Issue Summary
+
+### Problem Statement
+
+Once a task is marked as complete in ThreeDoors, there is no way to reverse it through the application. The status transition model (`internal/core/task_status.go`) defines `StatusComplete` as a terminal state with zero valid outgoing transitions (`StatusComplete: {}`). Users who accidentally complete a task must manually edit the YAML file to recover it — a process that breaks the friction-free philosophy of the product.
+
+### Discovery Context
+
+This limitation was formally documented during the Phase 1 Validation Gate review (2026-03-03) in the "What Needs Improvement" section: "No undo for task completion. Once a task is marked done, recovery requires manual file editing. The status transition model validates forward progress but doesn't support correction."
+
+The validation gate classified this as an "implementation issue, not a concept flaw" and recommended it be addressed via "status transition history."
+
+### Evidence
+
+- `internal/core/task_status.go:24` — `StatusComplete: {}` (empty transition list)
+- `docs/validation-gate-results.md:141-142` — Explicit pain point identification
+- `docs/architecture/data-models.md:46` — State machine shows `complete → [*]` as terminal
+
+---
+
+## Section 2: Impact Analysis
+
+### Epic Impact
+
+- **No existing epics affected** — This is a new capability
+- **New Epic 32 required** — Undo Task Completion
+- **Future integration epics (25, 26, 30)** — Todoist, GitHub Issues, and Linear adapters will eventually need "uncomplete" API operations, but this can be addressed incrementally within those epics
+
+### Story Impact
+
+- No current stories require modification
+- 3-4 new stories needed in Epic 32
+
+### Artifact Conflicts
+
+| Artifact | Conflict | Action Needed |
+|----------|----------|---------------|
+| PRD (requirements.md) | No undo requirement exists | Add new FR for undo capability |
+| Architecture (data-models.md) | State machine shows complete as terminal | Update state diagram to include `complete → todo` |
+| Architecture (components.md) | StatusManager docs don't mention undo | Update component docs |
+| Code (task_status.go) | `StatusComplete: {}` | Add `StatusTodo` to valid transitions |
+| Code (task.go) | `UpdateStatus()` doesn't clear `CompletedAt` on reverse | Add logic to clear `CompletedAt` when leaving complete |
+
+### Technical Impact
+
+- **Core change:** One line in `validTransitions` map + `CompletedAt` clearing logic
+- **TUI:** StatusUpdateMenu will automatically surface `todo` as valid target when viewing completed tasks
+- **CLI (Epic 23):** `threedoors task status <id> todo` will work once transition is valid
+- **Adapters:** Each adapter's `MarkComplete` has no reverse; adapter-level uncomplete is a separate concern
+- **Session metrics:** Should log undo events for behavioral analysis
+
+---
+
+## Section 3: Recommended Approach
+
+### Selected Path: Direct Adjustment (New Epic)
+
+Create a focused Epic 32: Undo Task Completion with 3 stories:
+
+1. **Status model change** — Add `complete → todo` transition, clear `CompletedAt`, add session event logging
+2. **TUI undo experience** — Confirmation dialog, visual feedback, undo from detail view and doors view
+3. **Adapter undo support** — Ensure adapters handle re-opened tasks correctly in bidirectional sync
+
+### Rationale
+
+- **Minimal code change:** The transition table is the single source of truth — adding one entry enables the feature across all surfaces
+- **Zero architectural risk:** Uses existing infrastructure (status transitions, TUI status menu, session metrics)
+- **Validated need:** Explicitly identified in validation gate review
+- **Low effort, high value:** Quality-of-life improvement that prevents data loss from accidental completion
+
+### Effort & Risk
+
+- **Effort:** Low (2-3 stories, ~1-2 days of implementation)
+- **Risk:** Low (well-understood change, isolated impact, comprehensive existing tests)
+- **Timeline impact:** None — can be parallelized with other active work
+
+---
+
+## Section 4: Detailed Change Proposals
+
+### 4.1: Status Transition Model
+
+```
+File: internal/core/task_status.go
+Section: validTransitions map
+
+OLD:
+StatusComplete:   {},
+
+NEW:
+StatusComplete:   {StatusTodo},
+```
+
+**Rationale:** Enable reverse transition from complete to todo. Only `todo` is allowed (not `in-progress` or other states) to keep the undo semantic clean — the task returns to the beginning of its lifecycle.
+
+### 4.2: Task.UpdateStatus() — CompletedAt Clearing
+
+```
+File: internal/core/task.go
+Section: UpdateStatus method
+
+ADD (after existing CompletedAt setting logic):
+if t.Status == StatusComplete && newStatus != StatusComplete {
+    t.CompletedAt = nil
+}
+```
+
+**Rationale:** When a task is un-completed, the `CompletedAt` timestamp should be cleared to maintain data model integrity.
+
+### 4.3: PRD — New Functional Requirement
+
+```
+Section: Phase 6+ / Quality of Life
+
+ADD:
+**FR127:** The system shall support undoing task completion by transitioning
+completed tasks back to `todo` status, clearing the `CompletedAt` timestamp,
+removing the task from the completed log display, and logging an `undo_complete`
+event in session metrics
+```
+
+### 4.4: Architecture — State Machine Update
+
+```
+File: docs/architecture/data-models.md
+Section: Valid Transitions
+
+OLD:
+complete → [*]
+
+NEW:
+complete → todo (undo)
+```
+
+---
+
+## Section 5: Implementation Handoff
+
+### Change Scope: Minor
+
+This change can be implemented directly by the development team without PO/SM or PM/Architect involvement beyond standard review.
+
+### Handoff Plan
+
+| Role | Responsibility |
+|------|---------------|
+| Dev (Worker Agent) | Implement Epic 32 stories via `/implement-story` |
+| Merge Queue | Standard review and merge process |
+| PR Shepherd | Standard rebase/conflict resolution |
+
+### Success Criteria
+
+1. `complete → todo` transition works in TUI, CLI, and programmatic API
+2. `CompletedAt` is cleared when undoing completion
+3. All existing status transition tests pass
+4. New tests cover the undo transition path
+5. Session metrics log `undo_complete` events
+6. Adapters gracefully handle re-opened tasks (at minimum, don't crash)
+
+---
+
+## Approval
+
+**Recommendation:** Proceed with Epic 32: Undo Task Completion as a P1 addition to the roadmap.
+
+**Next Steps:**
+1. Update PRD with FR127
+2. Create architecture document for undo feature
+3. Create Epic 32 with stories
+4. Update ROADMAP.md
+5. Begin implementation via worker agents

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -478,6 +478,24 @@ These non-functional requirements establish code quality gates that all contribu
 
 ---
 
+## Phase 6+ - Undo Task Completion (Accepted)
+
+*The following requirements allow users to reverse accidental task completion, addressing a validated pain point from the Phase 1 Validation Gate review.*
+
+**Undo Task Completion:**
+
+**FR127:** The system shall support undoing task completion by allowing the `complete → todo` status transition — when a user reverses a completed task, the `CompletedAt` timestamp is cleared, the task status is set to `todo`, and the task immediately becomes eligible for door selection again
+
+**FR128:** The system shall log an `undo_complete` event in the JSONL session metrics when a task completion is reversed, capturing the task ID, original completion timestamp, and time elapsed since completion — enabling behavioral analysis of accidental completions
+
+**FR129:** The system shall NOT modify the append-only completed task log (`completed.txt`) when a task completion is undone — the completed log remains an immutable audit trail; the undo is tracked separately via session metrics
+
+**FR130:** The undo operation shall have no time limit — users can reverse a task completion regardless of how much time has elapsed since the task was originally completed
+
+**FR131:** When a completed task is undone and that task was a dependency for other tasks (per FR113), the system shall re-evaluate dependent tasks — any dependents that were unblocked by the original completion shall have their dependency status rechecked, potentially returning to blocked state if the undone task was their only completed prerequisite
+
+---
+
 ## Task Source Integration NFRs
 
 > Requirements specific to API-based and IPC-based task source adapters.

--- a/docs/stories/32.1.story.md
+++ b/docs/stories/32.1.story.md
@@ -1,0 +1,50 @@
+# Story 32.1: Status Model — Complete-to-Todo Transition
+
+**Epic:** 32 — Undo Task Completion
+**Priority:** P1
+**Status:** Not Started
+**Depends On:** None
+**Estimated Effort:** Small
+
+---
+
+## Description
+
+Add `complete → todo` to the status transition model and handle `CompletedAt` clearing when a task is un-completed. This is the foundational change that enables undo across all surfaces.
+
+## Acceptance Criteria
+
+1. `IsValidTransition(StatusComplete, StatusTodo)` returns `true`
+2. `IsValidTransition(StatusComplete, StatusInProgress)` returns `false` (no other reverse transitions added)
+3. `IsValidTransition(StatusComplete, StatusBlocked)` returns `false`
+4. `Task.UpdateStatus(StatusTodo)` succeeds when current status is `complete`
+5. After undo, `CompletedAt` is `nil`
+6. After undo, `UpdatedAt` is set to current UTC time
+7. After undo, `Blocker` is empty string
+8. After undo, `Status` is `todo`
+9. Task notes are preserved through the undo transition
+10. All existing status transition tests pass unchanged (regression)
+11. `GetValidTransitions(StatusComplete)` returns `[StatusTodo]`
+
+## Technical Notes
+
+- Modify `validTransitions` map in `internal/core/task_status.go`
+- Add `CompletedAt` clearing logic in `Task.UpdateStatus()` in `internal/core/task.go`
+- Add table-driven tests for the new transition in `internal/core/task_status_test.go`
+- Add tests for `CompletedAt` clearing in `internal/core/task_test.go`
+
+## Tasks
+
+- [ ] Add `StatusTodo` to `validTransitions[StatusComplete]` in `task_status.go`
+- [ ] Add `CompletedAt` clearing logic when leaving complete status in `task.go`
+- [ ] Add unit tests for `complete → todo` transition validity
+- [ ] Add unit tests for `CompletedAt` clearing on undo
+- [ ] Add unit tests verifying other reverse transitions remain invalid
+- [ ] Verify all existing tests pass (regression)
+- [ ] Run `make fmt && make lint && make test`
+
+## Architecture References
+
+- Design Decision DD-32.1: Only `complete → todo` supported
+- Design Decision DD-32.2: `CompletedAt` cleared to nil on undo
+- Architecture doc: `_bmad-output/planning-artifacts/architecture-undo-task-completion.md`

--- a/docs/stories/32.2.story.md
+++ b/docs/stories/32.2.story.md
@@ -1,0 +1,43 @@
+# Story 32.2: Session Metrics — Undo Complete Event Logging
+
+**Epic:** 32 — Undo Task Completion
+**Priority:** P1
+**Status:** Not Started
+**Depends On:** 32.1
+**Estimated Effort:** Small
+
+---
+
+## Description
+
+Log `undo_complete` events in session metrics when a task completion is reversed. Capture the task ID, original completion timestamp, and time elapsed since completion for behavioral analysis of accidental completions.
+
+## Acceptance Criteria
+
+1. When a task transitions from `complete` to `todo`, an `undo_complete` event is appended to the JSONL session log
+2. The event includes: task ID, original `CompletedAt` timestamp, time elapsed since completion, and current session timestamp
+3. The event type is `undo_complete` (consistent with existing event naming: `snooze`, `snooze_return`)
+4. The `completed.txt` file is NOT modified when undo occurs
+5. Session metrics reader (`ReadAll`, `ReadSince`, `ReadLast`) correctly parse `undo_complete` events
+6. Event logging does not block the TUI update loop (async via `tea.Cmd`)
+
+## Technical Notes
+
+- Add `RecordUndoComplete(taskID string, originalCompletedAt time.Time)` to `SessionTracker`
+- Follow existing event logging patterns in `internal/core/session_tracker.go`
+- The session tracker's JSONL format is append-only, matching `completed.txt` immutability
+- Test with existing metrics reader infrastructure
+
+## Tasks
+
+- [ ] Add `undo_complete` event type constant
+- [ ] Add `RecordUndoComplete()` method to `SessionTracker`
+- [ ] Wire up undo event logging in the TUI status change handler
+- [ ] Add unit tests for event logging
+- [ ] Verify `completed.txt` is not modified on undo
+- [ ] Run `make fmt && make lint && make test`
+
+## Architecture References
+
+- Design Decision DD-32.3: `completed.txt` remains immutable
+- Architecture doc: `_bmad-output/planning-artifacts/architecture-undo-task-completion.md`

--- a/docs/stories/32.3.story.md
+++ b/docs/stories/32.3.story.md
@@ -1,0 +1,45 @@
+# Story 32.3: TUI & CLI Undo Experience
+
+**Epic:** 32 — Undo Task Completion
+**Priority:** P1
+**Status:** Not Started
+**Depends On:** 32.1, 32.2
+**Estimated Effort:** Small
+
+---
+
+## Description
+
+Ensure the TUI and CLI surfaces provide a smooth undo experience. The TUI status menu should automatically show `todo` as a valid option when viewing completed tasks (this happens naturally via `GetValidTransitions`). Add a confirmation toast message after undo. Ensure the CLI `task status` command supports the transition.
+
+## Acceptance Criteria
+
+1. In TUI detail view of a completed task, pressing `S` (status menu) shows `todo` as a valid transition option
+2. After selecting `todo` from the status menu of a completed task, the task returns to `todo` status
+3. A brief confirmation message is shown: "Task uncompleted — returned to todo"
+4. After undo, the doors view refreshes and the uncompleted task is eligible for door selection
+5. CLI command `threedoors task status <id> todo` succeeds when the task is currently `complete`
+6. CLI outputs confirmation message when undo succeeds
+7. If the undone task was a dependency for other tasks, those dependents are re-evaluated (tested with dependency filter)
+
+## Technical Notes
+
+- TUI StatusUpdateMenu reads from `GetValidTransitions()` — no menu code changes needed
+- Add toast/status bar message to TUI after undo
+- CLI `status` subcommand already validates via `IsValidTransition` — should work automatically
+- Test dependency re-evaluation: complete task A (unblocks B), undo task A (re-blocks B)
+
+## Tasks
+
+- [ ] Verify TUI status menu shows `todo` for completed tasks (may need no code change)
+- [ ] Add confirmation toast/message after undo in TUI
+- [ ] Verify CLI `task status` command handles undo
+- [ ] Add TUI integration test for undo flow
+- [ ] Add dependency re-evaluation test (if Epic 29 is implemented)
+- [ ] Run `make fmt && make lint && make test`
+
+## Architecture References
+
+- Design Decision DD-32.4: No time limit on undo
+- Design Decision DD-32.5: Dependency re-evaluation triggers automatically
+- Architecture doc: `_bmad-output/planning-artifacts/architecture-undo-task-completion.md`


### PR DESCRIPTION
## Summary

- Add Epic 32: Undo Task Completion (P1) with 3 stories addressing a validated pain point from the Phase 1 Validation Gate review
- Enables `complete → todo` status transition so users can reverse accidental task completion without manually editing YAML files
- Full BMAD pipeline: sprint change proposal, party mode consensus, architecture, PRD updates (FR127–FR131), epic/story breakdown

## Artifacts Created

| Artifact | Path |
|----------|------|
| Sprint Change Proposal | `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-undo-task-completion.md` |
| Party Mode Consensus | `_bmad-output/planning-artifacts/party-mode-undo-task-completion-2026-03-08.md` |
| Architecture | `_bmad-output/planning-artifacts/architecture-undo-task-completion.md` |
| Epic 32 | `_bmad-output/planning-artifacts/epic-32-undo-task-completion.md` |
| Story 32.1 | `docs/stories/32.1.story.md` — Status model change |
| Story 32.2 | `docs/stories/32.2.story.md` — Session metrics event logging |
| Story 32.3 | `docs/stories/32.3.story.md` — TUI & CLI undo experience |

## Key Design Decisions

- **DD-32.1:** Only `complete → todo` transition (not `complete → in-progress`)
- **DD-32.2:** `CompletedAt` cleared to nil on undo
- **DD-32.3:** `completed.txt` remains immutable (append-only audit trail)
- **DD-32.4:** No time limit on undo
- **DD-32.5:** Dependency re-evaluation triggers automatically via existing filters

## Modified Files

- `ROADMAP.md` — Added Epic 32 to active epics
- `docs/prd/requirements.md` — Added FR127–FR131
- `_bmad-output/planning-artifacts/epics.md` — Added Epic 32 stories

## Test plan

- [x] No code changes — planning artifacts only
- [x] PRD requirements are consistent with architecture
- [x] Story acceptance criteria are specific and testable
- [x] ROADMAP.md updated with new epic