### PR TITLE
feat: BMAD planning — Seasonal Door Theme Variants epic and stories

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Source of truth for merge-queue scope checks and worker prioritization.
 > Synced periodically by BMAD PM agent from `docs/prd/epics-and-stories.md`.
-> Last updated: 2026-03-07
+> Last updated: 2026-03-08
 
 ## Priority Legend
 
@@ -84,6 +84,17 @@ Allow reversing accidental task completion via `complete → todo` transition. V
 | 32.1 | Status Model — Complete-to-Todo Transition | Not Started | P1 | None |
 | 32.2 | Session Metrics — Undo Complete Event Logging | Not Started | P1 | 32.1 |
 | 32.3 | TUI & CLI Undo Experience | Not Started | P1 | 32.1, 32.2 |
+
+### Epic 33: Seasonal Door Theme Variants (P2) — 0/4 stories done
+
+Time-based seasonal theme variants that auto-switch based on current date. Extends Epic 17's theme infrastructure.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 33.1 | Seasonal Theme Metadata Model and Date-Range Resolver | Not Started | P2 | Epic 17 (done) |
+| 33.2 | Four Seasonal Theme Implementations | Not Started | P2 | 33.1 |
+| 33.3 | Auto-Switch Integration in DoorsView and Config | Not Started | P2 | 33.1 |
+| 33.4 | Seasonal Theme Picker and `:seasonal` Command | Not Started | P2 | 33.2, 33.3 |
 
 ## Completed Epics
 

--- a/_bmad-output/planning-artifacts/architecture-seasonal-themes.md
+++ b/_bmad-output/planning-artifacts/architecture-seasonal-themes.md
@@ -1,0 +1,242 @@
+---
+stepsCompleted: ["step-01-init", "step-02-context", "step-03-decisions", "step-04-components"]
+inputDocuments:
+  - docs/prd/requirements.md (FR132-FR137, NFR28-NFR30)
+  - docs/architecture/components.md (existing theme system architecture)
+  - docs/research/door-themes-analyst-review.md
+  - internal/tui/themes/theme.go (DoorTheme struct)
+  - internal/tui/themes/registry.go (Registry)
+  - internal/tui/themes/modern.go (reference implementation)
+workflowType: 'architecture'
+project_name: 'ThreeDoors'
+user_name: 'arcaven'
+date: '2026-03-08'
+---
+
+# Architecture Decision Document — Seasonal Door Theme Variants (Epic 33)
+
+This document defines the technical architecture for extending the existing Door Theme System (Epic 17) with seasonal theme variants that auto-switch based on the current date.
+
+---
+
+## 1. Project Context
+
+ThreeDoors has a complete door theme system implemented in `internal/tui/themes/`:
+
+- **`DoorTheme` struct** — Name, Description, Render function, ThemeColors, MinWidth
+- **`Registry`** — Map-based theme storage with `Register()`, `Get()`, `Names()`
+- **`NewDefaultRegistry()`** — Pre-populates Classic, Modern, Sci-Fi, Shoji themes
+- **Render functions** — Pure functions: `(content string, width int, selected bool) string`
+- **Config persistence** — `theme: modern` in `~/.threedoors/config.yaml`
+- **Golden file tests** — Multi-width, selected/unselected state verification
+
+The existing architecture is explicitly designed for extensibility. Seasonal themes are additive — no existing code requires modification beyond adding new registrations.
+
+---
+
+## 2. Design Decisions
+
+### DD-S1: Seasonal Themes as Standalone DoorTheme Instances (Replacement Model)
+
+**Decision:** Each seasonal theme is a self-contained `DoorTheme` with its own render function, not an overlay or decorator on existing themes.
+
+**Rationale:**
+- Overlays add complexity (composing render functions, merging color palettes) with marginal benefit
+- Standalone themes are independently testable via golden files
+- Matches the existing pattern — Modern, Sci-Fi, Shoji are all standalone
+- Each seasonal theme can have its own MinWidth, Colors, and Description
+
+**Alternatives Rejected:**
+- Decorator/overlay pattern — too complex for the value, creates coupling between base and seasonal themes
+- CSS-like theme inheritance — not a concept in Go/Lipgloss, would require custom framework
+
+### DD-S2: SeasonalResolver as Pure Function
+
+**Decision:** Season-to-theme mapping is a pure function, not an interface or struct.
+
+```go
+// ResolveSeason returns the season name for the given date,
+// or empty string if seasonal themes are disabled or no match.
+func ResolveSeason(now time.Time, ranges []SeasonRange) string
+```
+
+**Rationale:**
+- Pure function is trivially testable with table-driven tests
+- No state, no I/O, no dependencies
+- Single responsibility: date → season name
+- Caller decides what to do with the result (look up theme, fall back, etc.)
+
+### DD-S3: Season Metadata on DoorTheme Struct
+
+**Decision:** Extend `DoorTheme` with optional seasonal metadata fields.
+
+```go
+type DoorTheme struct {
+    Name        string
+    Description string
+    Render      func(content string, width int, selected bool) string
+    Colors      ThemeColors
+    MinWidth    int
+    // Seasonal metadata (zero values for non-seasonal themes)
+    Season      string // "spring", "summer", "autumn", "winter", or ""
+    SeasonStart MonthDay // {Month: 3, Day: 1} for spring
+    SeasonEnd   MonthDay // {Month: 5, Day: 31} for spring
+}
+
+type MonthDay struct {
+    Month int
+    Day   int
+}
+```
+
+**Rationale:**
+- Zero-value `Season` ("") means non-seasonal — backward compatible
+- `MonthDay` avoids year dependency and timezone complexity
+- Registry can filter by `Season != ""` to list seasonal themes
+- No separate seasonal metadata store needed
+
+### DD-S4: Auto-Switch in DoorsView Initialization
+
+**Decision:** Seasonal theme resolution happens at DoorsView construction time, not on every render.
+
+**Flow:**
+1. App startup reads `config.yaml` for `theme` and `seasonal_themes` settings
+2. If `seasonal_themes: true` (default), call `ResolveSeason(time.Now().UTC(), defaultSeasonRanges)`
+3. If a matching seasonal theme exists in registry, use it instead of configured theme
+4. Store resolved theme reference in DoorsView — no per-render checks
+5. Planning session start also re-checks (handles overnight sessions crossing season boundaries)
+
+**Rationale:**
+- Season doesn't change during a session (sessions are minutes, not months)
+- Avoids per-render overhead (even though it's negligible)
+- Simple to test — mock the time, verify theme selection
+
+### DD-S5: Config Schema Extension
+
+**Decision:** Add `seasonal_themes` boolean to config.yaml.
+
+```yaml
+theme: modern              # base theme (existing)
+seasonal_themes: true      # enable auto-switching (new, default: true)
+```
+
+**Rationale:**
+- Minimal config addition — single boolean
+- Default `true` provides delight out of the box
+- Users who prefer their chosen theme year-round set `false`
+- No date-range configuration in config (use code defaults, configurable date ranges are YAGNI for v1)
+
+### DD-S6: Unicode Character Constraint
+
+**Decision:** All seasonal themes use only characters from NFR17-approved ranges:
+- Box-drawing: `U+2500–U+257F`
+- Block elements: `U+2580–U+259F`
+- Geometric shapes: `U+25A0–U+25FF`
+
+**No emoji. No Unicode symbols outside these ranges.**
+
+Seasonal identity comes from *patterns*, not *symbols*:
+- **Winter:** Dense dot patterns (`·`), crystalline angular frames (`╬`, `╪`)
+- **Spring:** Flowing curved lines (`╭╮╰╯`), light open patterns
+- **Summer:** Radiating lines (`╋`), bold geometric shapes (`◆`, `●`)
+- **Autumn:** Layered block elements (`▒▓`), angular textures
+
+---
+
+## 3. Component Architecture
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `internal/tui/themes/seasonal.go` | `SeasonRange`, `MonthDay`, `ResolveSeason()`, `DefaultSeasonRanges` |
+| `internal/tui/themes/seasonal_test.go` | Table-driven tests for date-range resolution |
+| `internal/tui/themes/winter.go` | `NewWinterTheme() *DoorTheme` |
+| `internal/tui/themes/spring.go` | `NewSpringTheme() *DoorTheme` |
+| `internal/tui/themes/summer.go` | `NewSummerTheme() *DoorTheme` |
+| `internal/tui/themes/autumn.go` | `NewAutumnTheme() *DoorTheme` |
+| `internal/tui/themes/accessibility_test.go` | WCAG contrast ratio validation helpers |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `internal/tui/themes/theme.go` | Add `Season`, `SeasonStart`, `SeasonEnd`, `MonthDay` to `DoorTheme` |
+| `internal/tui/themes/registry.go` | Add `GetBySeason(season string)` method; register seasonal themes in `NewDefaultRegistry()` |
+| `internal/tui/doors_view.go` | Add seasonal theme resolution at construction time |
+| `internal/tui/theme_picker.go` | Add seasonal category to theme picker |
+
+### Data Flow
+
+```
+App Startup
+    │
+    ├─ Load config.yaml → theme: "modern", seasonal_themes: true
+    │
+    ├─ ResolveSeason(time.Now().UTC(), DefaultSeasonRanges) → "winter"
+    │
+    ├─ Registry.GetBySeason("winter") → *DoorTheme{Name: "winter", ...}
+    │
+    └─ DoorsView uses winter theme for this session
+```
+
+### Registry Extension
+
+```go
+// GetBySeason returns the seasonal theme for the given season name, or false.
+func (r *Registry) GetBySeason(season string) (*DoorTheme, bool) {
+    for _, t := range r.themes {
+        if t.Season == season {
+            return t, true
+        }
+    }
+    return nil, false
+}
+```
+
+---
+
+## 4. Testing Strategy
+
+### SeasonalResolver Tests (Table-Driven)
+
+| Test Case | Date | Expected Season |
+|-----------|------|----------------|
+| Spring start | March 1 | spring |
+| Spring end | May 31 | spring |
+| Summer start | June 1 | summer |
+| Winter boundary | December 31 | winter |
+| Winter wrap | January 15 | winter |
+| Leap year | February 29 | winter |
+
+### Golden File Tests
+
+24 golden files: 4 seasons × 3 widths (min, 80, 120) × 2 states (selected, unselected).
+
+### Accessibility Tests
+
+Programmatic WCAG AA contrast ratio validation:
+- Extract foreground/background Lipgloss color values
+- Compute relative luminance per WCAG 2.0 formula
+- Assert ratio >= 4.5:1 for all text elements
+- Test against both dark (background #000000) and light (background #FFFFFF) terminal schemes
+
+---
+
+## 5. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Curved box-drawing chars (`╭╮`) render inconsistently | Spring theme is Tier 2 risk — test across iTerm2, Terminal.app, Alacritty before shipping |
+| Season date ranges don't match user expectations | Default to widely-accepted meteorological seasons; document in help text |
+| Seasonal themes feel gimmicky | Ensure themes are subtle and tasteful, not novelty — patterns, not pictures |
+
+---
+
+## 6. Out of Scope
+
+- Holiday-specific themes (Halloween, Christmas) — future epic
+- User-defined seasonal date ranges in config.yaml — YAGNI for v1
+- Hemisphere-aware season detection — note for future
+- Animated season transitions — not planned
+- Community-contributed seasonal themes — future extensibility

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08.md
@@ -1,0 +1,157 @@
+# Sprint Change Proposal — Seasonal Door Theme Variants
+
+**Date:** 2026-03-08
+**Proposed by:** BMAD Correct Course Workflow
+**Change Scope:** Minor — New epic, no existing work affected
+
+---
+
+## Section 1: Issue Summary
+
+**Problem Statement:** ThreeDoors' door theme system (Epic 17, COMPLETE) currently provides four static themes (Classic, Modern, Sci-Fi, Shoji). The analyst review (2026-03-03) identified seasonal/holiday theme variants as a deferred opportunity. With Epic 17's infrastructure now fully implemented and proven — DoorTheme struct, Registry, render functions, config persistence, golden file testing — the foundation exists to add time-based visual variety.
+
+**Context:** The analyst review explicitly noted seasonal variants as "Fun idea, but pure scope creep for v1. Note as future opportunity." With v1 theme system complete and stable, this proposal creates a new epic to realize that opportunity.
+
+**Evidence:**
+- Epic 17 complete: 6/6 stories merged (PRs #119-#124)
+- Theme infrastructure proven: `DoorTheme` struct, `Registry`, render functions, golden file tests
+- Analyst recommendation: "Proceed post-v1" (Section 6, Q4)
+- Existing themes use only safe Unicode ranges (box-drawing, block elements, geometric shapes)
+
+---
+
+## Section 2: Impact Analysis
+
+### Epic Impact
+- **No existing epics affected.** This is a purely additive new epic (proposed as Epic 33).
+- **Prerequisite:** Epic 17 (Door Theme System) — already COMPLETE.
+- **No blocking dependencies** on any in-progress or planned work.
+
+### Story Impact
+- No current or future stories require changes.
+- New stories will extend the existing `internal/tui/themes/` package.
+
+### Artifact Conflicts
+- **PRD:** Needs new functional requirements (FR132+) for seasonal themes.
+- **Architecture:** Minor extension to components doc — seasonal theme metadata, time-based selection logic.
+- **UI/UX:** Theme picker may need seasonal category; settings view needs auto-switch toggle.
+
+### Technical Impact
+- **Code:** Extend `DoorTheme` struct with optional season/date metadata. Add seasonal theme files. Add auto-switch logic in DoorsView.
+- **Infrastructure:** No changes needed.
+- **Deployment:** No changes needed.
+
+---
+
+## Section 3: Recommended Approach
+
+**Selected Path:** Direct Adjustment — Add new Epic 33 with focused stories.
+
+**Rationale:**
+- Epic 17's architecture was explicitly designed for theme extensibility (registry pattern, render functions)
+- Adding seasonal themes is a natural, low-risk extension
+- No rollback or MVP scope changes needed
+- Effort: Medium (4-5 stories)
+- Risk: Low (building on proven infrastructure)
+- Timeline impact: None on existing P1 work
+
+**Alternatives Considered:**
+- Bundling into Epic 17 — rejected (Epic 17 is complete and merged)
+- Deferring indefinitely — rejected (infrastructure is ready, value is clear)
+
+---
+
+## Section 4: Detailed Change Proposals
+
+### 4.1 PRD Changes
+
+**File:** `docs/prd/requirements.md`
+**Section:** New requirements block after FR62
+
+**NEW Requirements:**
+```
+**Seasonal Door Theme Variants:**
+
+FR132: The system shall provide seasonal door theme variants that apply
+time-appropriate visual styling (e.g., autumn leaves for fall, snowflakes
+for winter, cherry blossoms for spring, sun motifs for summer), using only
+Unicode characters from the safe rendering ranges (NFR17).
+
+FR133: The system shall support automatic seasonal theme switching based
+on the current date, with configurable season date ranges stored in
+config.yaml — defaulting to meteorological seasons (spring: Mar 1,
+summer: Jun 1, autumn: Sep 1, winter: Dec 1).
+
+FR134: The system shall allow users to opt out of automatic seasonal
+switching via a `seasonal_themes: false` setting in config.yaml,
+reverting to their manually selected theme.
+
+FR135: The system shall provide a `:seasonal` command in the TUI that
+previews all seasonal variants and allows manual season override for
+testing or preference.
+
+FR136: All seasonal theme variants shall maintain WCAG AA contrast ratios
+(4.5:1 minimum for text) in both light and dark terminal color schemes,
+ensuring readability is never sacrificed for visual novelty.
+
+FR137: Seasonal themes shall gracefully fall back to the user's base
+theme when the terminal width is below the seasonal variant's declared
+minimum width, consistent with FR61 behavior.
+```
+
+### 4.2 Architecture Changes
+
+**File:** `docs/architecture/components.md`
+**Impact:** Add seasonal theme metadata to DoorTheme struct description. Add SeasonalThemeLoader component.
+
+**NEW:**
+```
+ThemeMetadata extension:
+- Season field (spring/summer/autumn/winter/holiday)
+- DateRange (start month-day, end month-day)
+- BasedOn field linking seasonal variant to its parent theme
+- Auto-switch logic checks current date against registered seasonal themes
+
+SeasonalThemeLoader:
+- On app startup, check date against seasonal theme date ranges
+- If seasonal_themes enabled and a matching seasonal theme exists, override active theme
+- Emit theme_switch event to session metrics
+```
+
+### 4.3 Epics & Stories Changes
+
+**File:** `docs/prd/epics-and-stories.md`
+**Action:** Add Epic 33: Seasonal Door Theme Variants
+
+**NEW Epic 33** with stories covering:
+1. Seasonal theme metadata model and date-range matching
+2. Seasonal theme implementations (4 seasons)
+3. Auto-switch integration in DoorsView
+4. Seasonal theme picker and `:seasonal` command
+5. Accessibility validation and golden file tests
+
+---
+
+## Section 5: Implementation Handoff
+
+**Change Scope Classification:** Minor — Direct implementation by development team.
+
+**Handoff Recipients:**
+- **PM Agent:** Update PRD with new FRs (FR132-FR137)
+- **Architect Agent:** Update architecture docs with seasonal theme components
+- **SM Agent:** Add Epic 33 to ROADMAP.md and sprint planning
+- **Dev Team:** Implement stories once planning artifacts are finalized
+
+**Success Criteria:**
+- New FRs added to PRD
+- Epic 33 created with 4-5 stories
+- Architecture updated with seasonal theme components
+- All seasonal themes pass golden file tests and accessibility checks
+- ROADMAP.md updated with Epic 33
+
+---
+
+## Approval
+
+**Status:** Approved (automated BMAD pipeline)
+**Next Steps:** Proceed to Party Mode discussion, PRD update, architecture design, and epic/story creation.

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -222,6 +222,10 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 | FR81-FR88 | Epic 24 | MCP/LLM Integration Server (NOT STARTED) |
 | FR89-FR92 | Epic 25 | Todoist Integration (NOT STARTED) |
 | FR93-FR96 | Epic 26 | GitHub Issues Integration (NOT STARTED) |
+| FR116-FR119 | Epic 30 | Linear Integration (NOT STARTED) |
+| FR120-FR126 | Epic 31 | Expand/Fork Key Implementations (NOT STARTED) |
+| FR127-FR131 | Epic 32 | Undo Task Completion (NOT STARTED) |
+| FR132-FR137 | Epic 33 | Seasonal Door Theme Variants (NOT STARTED) |
 
 ## Epic List
 
@@ -368,6 +372,12 @@ GitHub Issues as a task source for developer workflows using the official go-git
 **FRs covered:** FR93-FR96
 **Prerequisites:** Epic 7 ✅ (Adapter SDK), Epic 13 ✅ (Multi-Source Aggregation), Epic 21 ✅ (Sync Protocol Hardening)
 **Status:** Not Started. 4 stories planned (26.1-26.4). Research at `docs/research/task-source-expansion-research.md`.
+
+### Epic 33: Seasonal Door Theme Variants — NOT STARTED
+Time-based seasonal theme variants that auto-switch based on the current date, extending the Door Theme System with visual variety.
+**FRs covered:** FR132-FR137
+**Prerequisites:** Epic 17 ✅ (Door Theme System)
+**Status:** Not Started. 4 stories planned (33.1-33.4). Research at `docs/research/door-themes-analyst-review.md`.
 
 ---
 
@@ -2052,6 +2062,193 @@ So that TUI regressions are caught on every PR without relying on manual testing
 ### Story 21.4: Sync Dashboard Enhancements ✅
 
 **Status:** Done (PR #157)
+
+---
+
+## Epic 33: Seasonal Door Theme Variants
+
+**Epic Goal:** Extend the Door Theme System (Epic 17) with time-based seasonal theme variants that auto-switch based on the current date, adding visual variety and delight while maintaining accessibility standards. Each seasonal theme is a standalone `DoorTheme` using only safe Unicode character ranges.
+
+**Prerequisites:** Epic 17 ✅ (Door Theme System)
+**FRs covered:** FR132-FR137
+**NFRs covered:** NFR28-NFR30
+**Status:** Not Started
+
+### Story 33.1: Seasonal Theme Metadata Model and Date-Range Resolver
+
+As a developer,
+I want a pure-function seasonal resolver and metadata extensions on DoorTheme,
+So that the system can determine which seasonal theme to apply based on the current date.
+
+**Acceptance Criteria:**
+
+**Given** the `DoorTheme` struct in `internal/tui/themes/theme.go`
+**When** the seasonal metadata fields are added
+**Then** the struct includes `Season string`, `SeasonStart MonthDay`, and `SeasonEnd MonthDay` fields
+**And** a `MonthDay` struct is defined with `Month int` and `Day int` fields
+**And** zero-value `Season` ("") indicates a non-seasonal theme (backward compatible)
+
+**Given** a `ResolveSeason(now time.Time, ranges []SeasonRange) string` pure function in `internal/tui/themes/seasonal.go`
+**When** called with a date falling within a season's date range
+**Then** it returns the season name (e.g., "winter", "spring", "summer", "autumn")
+**And** when no season matches, it returns an empty string
+
+**Given** `DefaultSeasonRanges` using meteorological seasons
+**When** the default ranges are defined
+**Then** spring starts March 1, summer starts June 1, autumn starts September 1, winter starts December 1
+**And** winter correctly wraps across year boundary (December 1 - February 28/29)
+
+**Given** the `Registry` in `internal/tui/themes/registry.go`
+**When** `GetBySeason(season string)` is called
+**Then** it returns the first theme with a matching `Season` field, or `(nil, false)` if none match
+
+**Given** table-driven tests in `internal/tui/themes/seasonal_test.go`
+**When** `ResolveSeason` is tested
+**Then** tests cover: spring start (March 1), spring end (May 31), summer start (June 1), autumn start (September 1), winter start (December 1), winter wrap (January 15), leap year (February 29), season boundary transitions
+**And** `ResolveSeason` completes in under 1 microsecond per Go benchmark (NFR28)
+
+**Quality Gate:** AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+**Technical Notes:**
+- `ResolveSeason` has no I/O dependencies — pure date arithmetic
+- Existing themes (classic, modern, scifi, shoji) remain unchanged — `Season` field is zero-value
+
+---
+
+### Story 33.2: Four Seasonal Theme Implementations
+
+As a user,
+I want visually distinct seasonal door themes for winter, spring, summer, and autumn,
+So that the door presentation reflects the current season with appropriate visual patterns.
+
+**Acceptance Criteria:**
+
+**Given** the theme creation pattern established in `internal/tui/themes/modern.go`
+**When** four seasonal themes are implemented
+**Then** each theme is in its own file: `winter.go`, `spring.go`, `summer.go`, `autumn.go`
+**And** each exports a constructor: `NewWinterTheme()`, `NewSpringTheme()`, `NewSummerTheme()`, `NewAutumnTheme()`
+**And** each returns a `*DoorTheme` with populated `Season`, `SeasonStart`, and `SeasonEnd` fields
+
+**Given** the Unicode character constraint (NFR17)
+**When** seasonal themes render door frames
+**Then** only characters from box-drawing (`U+2500–U+257F`), block elements (`U+2580–U+259F`), and geometric shapes (`U+25A0–U+25FF`) are used
+**And** no emoji or Unicode symbols outside these ranges appear in any theme
+
+**Given** the seasonal theme design patterns
+**When** each theme renders content
+**Then** winter uses crystalline angular frames and dense dot patterns
+**And** spring uses flowing curved lines and light open patterns
+**And** summer uses radiating lines and bold geometric shapes
+**And** autumn uses layered block elements and angular textures
+**And** each theme has a distinct visual identity distinguishable from all other themes
+
+**Given** WCAG AA accessibility requirements (FR136)
+**When** seasonal themes are rendered
+**Then** all text content maintains minimum 4.5:1 contrast ratio against both dark (#000000) and light (#FFFFFF) terminal backgrounds
+**And** contrast ratios are validated programmatically in `internal/tui/themes/accessibility_test.go` (NFR30)
+
+**Given** the golden file testing pattern (NFR19, NFR29)
+**When** golden file tests run for seasonal themes
+**Then** 24 golden files exist: 4 seasons × 3 widths (minimum, 80-column, 120-column) × 2 states (selected, unselected)
+**And** all golden files pass comparison
+
+**Given** the `NewDefaultRegistry()` function
+**When** the registry is created
+**Then** all four seasonal themes are registered alongside existing themes (classic, modern, scifi, shoji)
+
+**Quality Gate:** AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+**Technical Notes:**
+- Each seasonal render function follows the same pattern as `modernRender` — pure function, `strings.Builder`, `fmt.Fprintf`
+- Spring theme uses `╭╮╰╯` curves (Tier 2 risk per analyst review) — verify rendering across iTerm2, Terminal.app, Alacritty
+
+---
+
+### Story 33.3: Auto-Switch Integration in DoorsView and Config
+
+As a user,
+I want ThreeDoors to automatically switch to the appropriate seasonal theme based on today's date,
+So that I see seasonally appropriate door styling without manual configuration.
+
+**Acceptance Criteria:**
+
+**Given** `seasonal_themes: true` in `~/.threedoors/config.yaml` (default when not specified)
+**When** the DoorsView is constructed at app startup
+**Then** `ResolveSeason(time.Now().UTC(), DefaultSeasonRanges)` is called
+**And** if a matching seasonal theme exists in the registry, it is used instead of the user's configured base theme
+**And** the resolved theme is stored in DoorsView for the session duration (no per-render rechecks)
+
+**Given** `seasonal_themes: false` in `~/.threedoors/config.yaml`
+**When** the DoorsView is constructed
+**Then** no seasonal resolution occurs
+**And** the user's configured base theme is used directly
+
+**Given** `seasonal_themes` is not present in config (new or upgraded install)
+**When** the config is loaded
+**Then** seasonal themes default to enabled (`true`)
+
+**Given** the terminal width is below the seasonal theme's declared `MinWidth`
+**When** DoorsView renders doors
+**Then** the system falls back to the user's configured base theme (consistent with FR61)
+
+**Given** a planning session starts (FR133)
+**When** the planning mode initializes
+**Then** seasonal theme resolution is re-checked (handles overnight sessions crossing season boundaries)
+
+**Quality Gate:** AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+**Technical Notes:**
+- Config schema adds `seasonal_themes` boolean — backward compatible (missing = true)
+- DoorsView seasonal resolution is at construction time, not per-render
+- Integration test: mock time to verify correct seasonal theme selection
+
+---
+
+### Story 33.4: Seasonal Theme Picker and `:seasonal` Command
+
+As a user,
+I want to preview all seasonal themes and manually override the current season,
+So that I can see what each seasonal theme looks like and choose my preferred seasonal style.
+
+**Acceptance Criteria:**
+
+**Given** the existing `:theme` command pattern (FR58, Story 17.5)
+**When** a user enters `:seasonal` in the TUI command palette
+**Then** a seasonal theme picker view opens showing all four seasonal themes in a horizontal preview grid
+**And** each preview renders a sample door at standard width in the seasonal theme's style
+**And** the currently active seasonal theme (if any) is highlighted
+
+**Given** the seasonal theme picker is open
+**When** the user selects a seasonal theme
+**Then** the selected seasonal theme is applied immediately (no restart required)
+**And** the theme change persists for the current session
+
+**Given** the seasonal theme picker is open
+**When** the user presses Esc
+**Then** the picker closes without changing the active theme
+
+**Given** the theme_picker.go already exists for `:theme` command
+**When** the `:seasonal` picker is implemented
+**Then** it reuses the existing theme picker component with a filter for themes where `Season != ""`
+**And** the existing `:theme` command continues to show only non-seasonal themes
+
+**Quality Gate:** AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+**Technical Notes:**
+- Reuse `ThemePicker` component filtered by `Season != ""`
+- Manual season override is session-scoped (not persisted to config — auto-switch resumes on next launch)
+- Add `:seasonal` to command palette registration in MainModel
+
+---
+
+### Epic 33 Story Dependencies
+
+```
+33.1 Seasonal Theme Metadata Model and Date-Range Resolver
+  └── 33.2 Four Seasonal Theme Implementations (depends on 33.1)
+  └── 33.3 Auto-Switch Integration in DoorsView and Config (depends on 33.1)
+       └── 33.4 Seasonal Theme Picker and `:seasonal` Command (depends on 33.2, 33.3)
+```
 
 ---
 

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -190,6 +190,20 @@
 
 **FR62:** The system shall overlay door number labels separately from the theme frame, maintaining consistent door identification across all themes
 
+**Seasonal Door Theme Variants:**
+
+**FR132:** The system shall provide seasonal door theme variants — self-contained `DoorTheme` implementations with time-appropriate visual patterns (e.g., crystalline patterns for winter, flowing lines for spring, radiating shapes for summer, angular textures for autumn) — using only Unicode characters from the box-drawing (`U+2500–U+257F`), block elements (`U+2580–U+259F`), and geometric shapes (`U+25A0–U+25FF`) ranges per NFR17
+
+**FR133:** The system shall support automatic seasonal theme switching based on the current date, with configurable season date ranges stored in `~/.threedoors/config.yaml` — defaulting to meteorological seasons (spring: March 1, summer: June 1, autumn: September 1, winter: December 1) — checked on application startup and on each planning session start
+
+**FR134:** The system shall allow users to disable automatic seasonal switching via `seasonal_themes: false` in `~/.threedoors/config.yaml` (default: `true`), reverting to the user's manually selected base theme when disabled
+
+**FR135:** The system shall provide a `:seasonal` command in the TUI that displays all seasonal theme variants in a horizontal preview grid (consistent with the `:theme` command from FR58), allowing manual season override for testing or preference
+
+**FR136:** All seasonal theme variants shall maintain WCAG AA contrast ratios (minimum 4.5:1 for text content) in both light and dark terminal color schemes, validated by automated contrast-ratio checks in theme test suites
+
+**FR137:** Seasonal themes shall fall back to the user's configured base theme when the terminal width is below the seasonal variant's declared minimum width, consistent with FR61 fallback behavior
+
 ---
 
 ## Non-Functional Requirements
@@ -251,6 +265,12 @@
 **NFR18:** Door theme render functions shall complete within 1ms for standard terminal widths (40-200 columns), as theme rendering is pure string manipulation with no I/O
 
 **NFR19:** Each door theme shall include golden file tests verifying rendered output at multiple widths (minimum width, standard width, wide terminal) in both selected and unselected states
+
+**NFR28:** The seasonal theme date-range resolver shall be a pure function with no I/O dependencies, completing date-to-season resolution in under 1 microsecond as measured by Go benchmark tests
+
+**NFR29:** Each seasonal theme variant shall include golden file tests at three widths (minimum, 80-column standard, 120-column wide) in both selected and unselected states — totaling 24 golden files minimum (4 seasons x 3 widths x 2 states)
+
+**NFR30:** Seasonal theme contrast ratios shall be validated programmatically in test suites by extracting Lipgloss color values and computing WCAG luminance ratios, not by manual visual inspection alone
 
 ---
 

--- a/docs/stories/33.1.story.md
+++ b/docs/stories/33.1.story.md
@@ -1,0 +1,49 @@
+<!--
+title: "33.1: Seasonal Theme Metadata Model and Date-Range Resolver"
+epic: 33
+status: "Not Started"
+priority: "P2"
+depends_on: []
+-->
+
+# Story 33.1: Seasonal Theme Metadata Model and Date-Range Resolver
+
+**As a** developer,
+**I want** a pure-function seasonal resolver and metadata extensions on DoorTheme,
+**so that** the system can determine which seasonal theme to apply based on the current date.
+
+## Acceptance Criteria
+
+1. `DoorTheme` struct in `internal/tui/themes/theme.go` extended with `Season string`, `SeasonStart MonthDay`, and `SeasonEnd MonthDay` fields
+2. `MonthDay` struct defined with `Month int` and `Day int` fields
+3. Zero-value `Season` ("") indicates a non-seasonal theme — backward compatible with existing themes
+4. `ResolveSeason(now time.Time, ranges []SeasonRange) string` pure function in `internal/tui/themes/seasonal.go`
+5. `DefaultSeasonRanges` uses meteorological seasons: spring March 1, summer June 1, autumn September 1, winter December 1
+6. Winter wraps across year boundary (December 1 – February 28/29)
+7. `Registry.GetBySeason(season string) (*DoorTheme, bool)` method added to `internal/tui/themes/registry.go`
+8. Table-driven tests in `internal/tui/themes/seasonal_test.go` cover: spring start (March 1), spring end (May 31), summer start (June 1), autumn start (September 1), winter start (December 1), winter wrap (January 15), leap year (February 29), season boundary transitions
+9. `ResolveSeason` completes in under 1 microsecond per Go benchmark (NFR28)
+10. Existing themes (classic, modern, scifi, shoji) unchanged — `Season` field is zero-value
+
+## NOT In Scope
+
+- Seasonal theme render functions (Story 33.2)
+- DoorsView integration (Story 33.3)
+- Config changes (Story 33.3)
+- Theme picker changes (Story 33.4)
+
+## Definition of Done
+
+- [ ] All acceptance criteria met
+- [ ] `make test` passes with all new and existing tests
+- [ ] `make lint` passes with zero warnings
+- [ ] `make fmt` produces no changes
+- [ ] Story file updated with PR number
+
+## FRs Covered
+
+- FR133 (seasonal date ranges, auto-switching logic)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/33.2.story.md
+++ b/docs/stories/33.2.story.md
@@ -1,0 +1,61 @@
+<!--
+title: "33.2: Four Seasonal Theme Implementations"
+epic: 33
+status: "Not Started"
+priority: "P2"
+depends_on: ["33.1"]
+-->
+
+# Story 33.2: Four Seasonal Theme Implementations
+
+**As a** user,
+**I want** visually distinct seasonal door themes for winter, spring, summer, and autumn,
+**so that** the door presentation reflects the current season with appropriate visual patterns.
+
+## Acceptance Criteria
+
+1. Four seasonal theme files: `winter.go`, `spring.go`, `summer.go`, `autumn.go` in `internal/tui/themes/`
+2. Each exports a constructor: `NewWinterTheme()`, `NewSpringTheme()`, `NewSummerTheme()`, `NewAutumnTheme()` returning `*DoorTheme`
+3. Each `DoorTheme` has populated `Season`, `SeasonStart`, and `SeasonEnd` fields matching `DefaultSeasonRanges`
+4. Only Unicode characters from box-drawing (`U+2500–U+257F`), block elements (`U+2580–U+259F`), and geometric shapes (`U+25A0–U+25FF`) are used (NFR17) — no emoji
+5. Winter: crystalline angular frames and dense dot patterns
+6. Spring: flowing curved lines (`╭╮╰╯`) and light open patterns
+7. Summer: radiating lines and bold geometric shapes
+8. Autumn: layered block elements (`▒▓`) and angular textures
+9. Each theme has a distinct visual identity distinguishable from all other themes
+10. All text content maintains minimum 4.5:1 WCAG AA contrast ratio against both dark (#000000) and light (#FFFFFF) terminal backgrounds (FR136)
+11. Contrast ratios validated programmatically in `internal/tui/themes/accessibility_test.go` (NFR30)
+12. 24 golden files: 4 seasons × 3 widths (minimum, 80-column, 120-column) × 2 states (selected, unselected) (NFR29)
+13. All four seasonal themes registered in `NewDefaultRegistry()`
+
+## NOT In Scope
+
+- DoorsView integration and auto-switching (Story 33.3)
+- Config changes (Story 33.3)
+- Theme picker changes (Story 33.4)
+- Holiday-specific themes (future epic)
+
+## Definition of Done
+
+- [ ] All acceptance criteria met
+- [ ] `make test` passes with all new and existing tests
+- [ ] `make lint` passes with zero warnings
+- [ ] `make fmt` produces no changes
+- [ ] Golden file tests pass for all 24 combinations
+- [ ] Accessibility tests pass for all seasonal themes
+- [ ] Story file updated with PR number
+
+## FRs Covered
+
+- FR132 (seasonal theme variants with safe Unicode)
+- FR136 (WCAG AA contrast ratios)
+- FR137 (minimum width fallback)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+## Technical Notes
+
+- Spring theme uses `╭╮╰╯` curves (Tier 2 rendering risk per analyst review) — verify across iTerm2, Terminal.app, Alacritty
+- Follow the render function pattern from `modernRender` in `modern.go`: pure function, `strings.Builder`, `fmt.Fprintf`

--- a/docs/stories/33.3.story.md
+++ b/docs/stories/33.3.story.md
@@ -1,0 +1,51 @@
+<!--
+title: "33.3: Auto-Switch Integration in DoorsView and Config"
+epic: 33
+status: "Not Started"
+priority: "P2"
+depends_on: ["33.1"]
+-->
+
+# Story 33.3: Auto-Switch Integration in DoorsView and Config
+
+**As a** user,
+**I want** ThreeDoors to automatically switch to the appropriate seasonal theme based on today's date,
+**so that** I see seasonally appropriate door styling without manual configuration.
+
+## Acceptance Criteria
+
+1. When `seasonal_themes: true` in config (or not specified — default is `true`), `ResolveSeason(time.Now().UTC(), DefaultSeasonRanges)` is called during DoorsView construction
+2. If a matching seasonal theme exists in the registry, it overrides the user's configured base theme for the session
+3. The resolved theme is stored in DoorsView at construction time — no per-render rechecks
+4. When `seasonal_themes: false` in config, no seasonal resolution occurs and the user's base theme is used
+5. When `seasonal_themes` is absent from config (new/upgraded install), seasonal themes default to enabled
+6. When terminal width is below the seasonal theme's `MinWidth`, fallback to user's configured base theme (consistent with FR61)
+7. Planning session start re-checks seasonal resolution (handles overnight sessions crossing season boundaries)
+8. Config schema extends with `seasonal_themes` boolean — backward compatible
+9. Integration tests verify correct seasonal theme selection with mocked time
+10. Existing theme selection behavior (`theme: modern` etc.) unchanged when `seasonal_themes: false`
+
+## NOT In Scope
+
+- Seasonal theme render functions (Story 33.2)
+- Theme metadata model (Story 33.1)
+- Seasonal theme picker (Story 33.4)
+- Hemisphere-aware season detection (future consideration)
+
+## Definition of Done
+
+- [ ] All acceptance criteria met
+- [ ] `make test` passes with all new and existing tests
+- [ ] `make lint` passes with zero warnings
+- [ ] `make fmt` produces no changes
+- [ ] Story file updated with PR number
+
+## FRs Covered
+
+- FR133 (automatic seasonal switching based on current date)
+- FR134 (opt-out via `seasonal_themes: false`)
+- FR137 (fallback when below minimum width)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/33.4.story.md
+++ b/docs/stories/33.4.story.md
@@ -1,0 +1,49 @@
+<!--
+title: "33.4: Seasonal Theme Picker and :seasonal Command"
+epic: 33
+status: "Not Started"
+priority: "P2"
+depends_on: ["33.2", "33.3"]
+-->
+
+# Story 33.4: Seasonal Theme Picker and `:seasonal` Command
+
+**As a** user,
+**I want** to preview all seasonal themes and manually override the current season,
+**so that** I can see what each seasonal theme looks like and choose my preferred seasonal style.
+
+## Acceptance Criteria
+
+1. `:seasonal` command registered in TUI command palette
+2. `:seasonal` opens a seasonal theme picker view showing all four seasonal themes in a horizontal preview grid
+3. Each preview renders a sample door at standard width in the seasonal theme's style
+4. Currently active seasonal theme (if any) is highlighted
+5. Selecting a seasonal theme applies it immediately — no restart required
+6. Theme change from `:seasonal` picker persists for the current session only (not written to config — auto-switch resumes on next launch)
+7. Pressing Esc closes the picker without changing the active theme
+8. Reuses existing `ThemePicker` component filtered for themes where `Season != ""`
+9. Existing `:theme` command continues to show only non-seasonal themes
+10. Unit tests verify picker filtering, selection, and Esc behavior
+
+## NOT In Scope
+
+- Persisting seasonal override to config.yaml (session-scoped only)
+- Holiday-specific themes
+- User-defined seasonal date ranges
+- Animated season transitions
+
+## Definition of Done
+
+- [ ] All acceptance criteria met
+- [ ] `make test` passes with all new and existing tests
+- [ ] `make lint` passes with zero warnings
+- [ ] `make fmt` produces no changes
+- [ ] Story file updated with PR number
+
+## FRs Covered
+
+- FR135 (`:seasonal` command with preview grid and manual override)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

- Add **Epic 33: Seasonal Door Theme Variants** — time-based seasonal themes that auto-switch based on the current date, extending Epic 17's proven theme infrastructure
- Full BMAD pipeline: course correction → party mode → PRD updates → architecture → epics & stories
- 4 stories covering metadata model, 4 seasonal implementations, DoorsView auto-switch, and `:seasonal` TUI command

## Planning Artifacts

| Artifact | Path |
|----------|------|
| Sprint Change Proposal | `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08.md` |
| Architecture Decisions | `_bmad-output/planning-artifacts/architecture-seasonal-themes.md` |
| PRD Requirements | `docs/prd/requirements.md` (FR132-FR137, NFR28-NFR30) |
| Epic & Stories | `docs/prd/epics-and-stories.md` (Epic 33) |
| Story Files | `docs/stories/33.{1-4}.story.md` |
| ROADMAP | `ROADMAP.md` (Epic 33 added, P2) |

## Key Design Decisions

1. **Replacement model** — each seasonal theme is a standalone `DoorTheme`, not an overlay
2. **SeasonalResolver as pure function** — `ResolveSeason(time.Time, []SeasonRange) string`
3. **Strict Unicode constraint** — box-drawing, block elements, geometric shapes only (no emoji)
4. **Auto-switch at construction time** — not per-render, season checked on startup
5. **WCAG AA accessibility** — programmatic contrast ratio validation in test suites
6. **P2 priority** — does not displace any P1 work

## Stories

| Story | Title | Depends On |
|-------|-------|------------|
| 33.1 | Seasonal Theme Metadata Model and Date-Range Resolver | Epic 17 (done) |
| 33.2 | Four Seasonal Theme Implementations | 33.1 |
| 33.3 | Auto-Switch Integration in DoorsView and Config | 33.1 |
| 33.4 | Seasonal Theme Picker and `:seasonal` Command | 33.2, 33.3 |

## Test plan

- [ ] Verify all modified files are docs/planning only — no code changes
- [ ] Verify FR132-FR137 added to requirements.md
- [ ] Verify NFR28-NFR30 added to requirements.md
- [ ] Verify Epic 33 added to epics-and-stories.md with 4 stories
- [ ] Verify 4 story files created in docs/stories/
- [ ] Verify ROADMAP.md updated with Epic 33
- [ ] Verify architecture decisions document is complete