### PR TITLE
feat: BMAD planning — SOUL.md and Custom Multiclaude Skills epic and stories

### DIFF
--- a/_bmad-output/planning-artifacts/architecture-soul-skills.md
+++ b/_bmad-output/planning-artifacts/architecture-soul-skills.md
@@ -1,0 +1,241 @@
+---
+stepsCompleted: ["step-01-init", "step-02-context", "step-03-decisions", "step-04-components", "step-05-review"]
+inputDocuments:
+  - docs/prd/requirements.md (NFR-DX1 through NFR-DX5)
+  - docs/research/ai-tooling-findings.md (7 findings, research spike)
+  - docs/prd/epic-list.md (Epic 34 added)
+  - CLAUDE.md (existing coding standards)
+  - _bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-soul-skills.md
+workflowType: 'architecture'
+project_name: 'ThreeDoors'
+user_name: 'arcaven'
+date: '2026-03-08'
+---
+
+# Architecture Decision Document: Epic 34 — SOUL.md + Custom Development Skills
+
+## 1. Overview
+
+Epic 34 adds two developer-facing capabilities to ThreeDoors:
+
+1. **SOUL.md** — A project philosophy document that captures the "why" behind ThreeDoors, complementing CLAUDE.md which captures the "how"
+2. **Custom Claude Code Slash Commands** — Four project-specific commands (`/pre-pr`, `/validate-adapter`, `/check-patterns`, `/new-story`) that automate common development workflows
+
+**Key constraint:** This is a documentation/configuration-only epic. No Go code changes, no new packages, no architectural changes to the application runtime.
+
+## 2. Project Context
+
+### Current State
+
+| Artifact | Status | Role |
+|----------|--------|------|
+| CLAUDE.md | Exists | Coding standards, pre-PR checklist, Go idioms, design patterns |
+| SOUL.md | Does not exist | (Proposed) Project philosophy and AI agent behavioral guidelines |
+| .claude/commands/ | 50+ BMAD commands | BMAD framework skills (planning, analysis, QA, etc.) |
+| ThreeDoors-specific commands | 0 | (Proposed) /pre-pr, /validate-adapter, /check-patterns, /new-story |
+
+### Problem
+
+- AI agents make decisions without consistent philosophical alignment
+- 11 story files contain ~500 lines of duplicated content (checklists, standards, patterns)
+- 12+ PRs had preventable CI failures that a `/pre-pr` command would have caught
+- No project-specific development automation despite extensive BMAD infrastructure
+
+## 3. Architectural Decisions
+
+### AD-34.1: SOUL.md Placement and Relationship to CLAUDE.md
+
+**Decision:** Place SOUL.md at project root alongside CLAUDE.md. Establish a clear separation:
+- **CLAUDE.md** = "How" — coding standards, technical rules, pre-PR checklists
+- **SOUL.md** = "Why" — project philosophy, design principles, behavioral guidelines
+
+**Rationale:** Claude Code automatically loads CLAUDE.md. SOUL.md is referenced from CLAUDE.md so agents see both. The separation keeps each document focused and scannable. CLAUDE.md stays action-oriented (rules to follow); SOUL.md stays values-oriented (principles for ambiguous decisions).
+
+**Integration:** CLAUDE.md will include a reference: `See SOUL.md for project philosophy and design principles.`
+
+### AD-34.2: Slash Command Location and Naming
+
+**Decision:** Place all custom commands in `.claude/commands/` as standard Claude Code slash commands with descriptive names:
+- `.claude/commands/pre-pr.md`
+- `.claude/commands/validate-adapter.md`
+- `.claude/commands/check-patterns.md`
+- `.claude/commands/new-story.md`
+
+**Rationale:** This is the standard Claude Code convention. Commands placed here are automatically available as `/pre-pr`, `/validate-adapter`, etc. They work in any Claude Code session (standalone or multiclaude). No special infrastructure needed.
+
+**Note:** These coexist with 50+ existing BMAD commands in the same directory. The naming convention (no `bmad-` prefix) distinguishes ThreeDoors-specific commands from BMAD framework commands.
+
+### AD-34.3: Remote Reference Convention
+
+**Decision:** All commands reference `origin/main` (not `upstream/main`).
+
+**Rationale:** ThreeDoors switched from fork workflow to direct push (2026-03-07). The `/pre-pr` command must use `origin/main` for branch freshness checks, scope review, and rebase validation.
+
+### AD-34.4: Forward-Only Template Changes
+
+**Decision:** New story template (via `/new-story`) applies to future stories only. Completed story files are not retroactively modified to remove duplicated content.
+
+**Rationale:** Party mode consensus. Completed stories are historical records. Retroactive DRY modifications create git blame noise and risk accidental content removal. The benefit of DRYing old stories (marginal — they're already done) does not justify the risk.
+
+### AD-34.5: MCP Prompt Template Integration Point
+
+**Decision:** Document SOUL.md as an input source for Epic 24.8 (MCP Prompt Templates & Advanced Interaction Patterns). SOUL.md's philosophy — particularly the coaching tone ("a friend saying pick one and go") — should inform MCP prompt template design.
+
+**Rationale:** MCP prompts need personality alignment. SOUL.md provides the authoritative source for ThreeDoors' voice and interaction philosophy. Story 24.8 can reference SOUL.md directly rather than embedding philosophy ad hoc.
+
+**No action required in Epic 34.** This is a documented integration point for future work.
+
+## 4. Component Design
+
+### 4.1: SOUL.md Content Structure
+
+```
+SOUL.md
+├── What Is ThreeDoors? (one-paragraph identity)
+├── Core Philosophy
+│   ├── Progress Over Perfection
+│   ├── Work With Human Nature
+│   ├── Three Doors, Not Three Hundred
+│   ├── Local-First, Privacy-Always
+│   ├── Meet Users Where They Are
+│   └── Solo Dev Reality
+├── Design Principles for AI Agents (5 decision heuristics)
+├── What ThreeDoors Is NOT (anti-patterns)
+└── The Feeling We're Going For (emotional target)
+```
+
+**Source:** Content derived from docs/research/ai-tooling-findings.md Finding 2 (proposed SOUL.md). Reviewed and approved in party mode.
+
+### 4.2: /pre-pr Command Design
+
+**8-step sequential validation:**
+
+| Step | Check | Tool | Pass Condition |
+|------|-------|------|---------------|
+| 1 | Branch freshness | `git fetch origin main` + log | ≤5 commits behind |
+| 2 | Formatting | `gofumpt -l .` | No output |
+| 3 | Linting | `golangci-lint run ./...` | 0 issues |
+| 4 | Tests | `go test ./... -count=1` | All pass |
+| 5 | Race detection | `go test -race ./...` | No races |
+| 6 | Dead code | `go vet ./...` | Clean |
+| 7 | Scope review | `git diff --stat origin/main...HEAD` | Show file list, warn on out-of-scope |
+| 8 | Commit cleanliness | `git log --oneline origin/main..HEAD` | No fixup/wip/squash messages |
+
+**Output:** Summary table with pass/fail per step. Final verdict: "Ready to push" or "Fix issues above."
+
+**Design note:** Step 5 (`go test -race`) added per QA agent recommendation in party mode. This catches race conditions that standard `go test` misses.
+
+### 4.3: /validate-adapter Command Design
+
+**Validation sequence:**
+
+1. Read `internal/tasks/provider.go` for current `TaskProvider` interface
+2. Find all implementing types via method signature grep
+3. For each implementation, verify:
+   - All interface methods implemented
+   - Error wrapping uses `%w` pattern
+   - Type registered in factory switch statement
+   - Corresponding `_test.go` file exists
+   - File-based providers use atomic write pattern
+
+**Output:** Compliance table per adapter.
+
+### 4.4: /check-patterns Command Design
+
+**6 pattern violation categories:**
+
+| Category | Detection Method |
+|----------|-----------------|
+| Direct status mutation | Grep for `.Status =` outside `task_status.go` |
+| Non-atomic file writes | Grep for `os.WriteFile`/`ioutil.WriteFile` not targeting `.tmp` |
+| fmt.Println in TUI | Grep for `fmt.Print` in `internal/tui/` |
+| Panics in user code | Grep for `panic(` in `internal/` |
+| Factory bypass | Grep for direct provider construction outside factory/tests |
+| Missing error wrapping | Grep for bare `return.*err$` without `%w` |
+
+**Output:** Findings grouped by category with file:line references.
+
+### 4.5: /new-story Command Design
+
+**Story template structure:**
+
+```markdown
+<!--
+title: "X.Y: Story Title"
+status: "Draft"
+-->
+
+# Story X.Y: Title
+
+**As a** user,
+**I want** ...,
+**so that** ...
+
+## Acceptance Criteria
+(numbered ACs with Given/When/Then)
+
+## NOT In Scope
+
+## Definition of Done
+- All standard checks pass (see CLAUDE.md Pre-PR Checklist)
+- [Story-specific DoD items only]
+
+## Architecture & Design
+(data models, view modes, files table)
+
+## Key Files to Create/Modify
+| File | Action |
+
+## Testing
+(Story-specific test requirements)
+
+## Tasks / Subtasks
+- [ ] Task 1...
+
+## Dev Agent Record
+## QA Results
+```
+
+**Key change from current template:** No embedded Pre-PR Submission Checklist, no repeated coding standards, no pattern reminders. All reference CLAUDE.md.
+
+## 5. File Inventory
+
+| File | Action | Description |
+|------|--------|-------------|
+| `SOUL.md` | Create | Project philosophy document |
+| `.claude/commands/pre-pr.md` | Create | Pre-PR validation command |
+| `.claude/commands/validate-adapter.md` | Create | Adapter compliance command |
+| `.claude/commands/check-patterns.md` | Create | Pattern violation scanner |
+| `.claude/commands/new-story.md` | Create | Story template generator |
+| `CLAUDE.md` | Edit | Add reference to SOUL.md |
+
+**Total files:** 5 new, 1 edited. All markdown. Zero Go code changes.
+
+## 6. Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Skill bash commands have bugs | Medium | Low | Fix in subsequent PR; no production impact |
+| SOUL.md contradicts CLAUDE.md | Low | Low | Review both documents for consistency |
+| Agents ignore SOUL.md | Low | Low | Reference from CLAUDE.md ensures loading |
+| /pre-pr produces false failures | Medium | Low | Run manually, fix command definitions |
+
+**Overall risk: Low.** No code changes means zero regression risk. Worst case: a slash command has a typo in a bash snippet.
+
+## 7. NFR Traceability
+
+| NFR | Architectural Decision | Component |
+|-----|----------------------|-----------|
+| NFR-DX1 | AD-34.1 (SOUL.md placement) | SOUL.md |
+| NFR-DX2 | AD-34.2 (command location) | /pre-pr |
+| NFR-DX3 | AD-34.2 (command location) | /validate-adapter |
+| NFR-DX4 | AD-34.2 (command location) | /check-patterns |
+| NFR-DX5 | AD-34.2 (command location) | /new-story |
+
+## 8. Integration Points (Future Epics)
+
+| Epic | Integration | Status |
+|------|------------|--------|
+| Epic 24.8 (MCP Prompt Templates) | SOUL.md philosophy informs coaching tone in prompts | Documented, not yet started |
+| Epic 25-26, 30 (New Integrations) | /validate-adapter checks new adapter implementations | Available immediately |
+| All future stories | /new-story generates DRY templates; /pre-pr catches CI issues | Available immediately |

--- a/_bmad-output/planning-artifacts/epic-34-soul-skills.md
+++ b/_bmad-output/planning-artifacts/epic-34-soul-skills.md
@@ -1,0 +1,235 @@
+---
+stepsCompleted: ["step-01-validate-prerequisites", "step-02-design-epics", "step-03-create-stories", "step-04-final-validation"]
+inputDocuments:
+  - docs/prd/requirements.md (NFR-DX1 through NFR-DX5)
+  - docs/prd/epic-list.md (Epic 34 entry)
+  - _bmad-output/planning-artifacts/architecture-soul-skills.md
+  - _bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-soul-skills.md
+  - docs/research/ai-tooling-findings.md
+  - CLAUDE.md
+---
+
+# ThreeDoors - Epic 34 Breakdown: SOUL.md + Custom Development Skills
+
+## Overview
+
+This document provides the epic and story breakdown for Epic 34, which adds project philosophy documentation (SOUL.md) and four custom Claude Code slash commands to improve AI agent alignment and developer workflow. Based on research findings (docs/research/ai-tooling-findings.md) and party mode consensus (2026-03-08).
+
+**Key constraint:** Documentation/configuration only. Zero Go code changes.
+
+## Requirements Inventory
+
+### Non-Functional Requirements (Developer Experience)
+
+- **NFR-DX1:** The project shall maintain a SOUL.md document at the project root defining the project's philosophy, design principles, and behavioral guidelines for AI agents — ensuring consistent decision-making aligned with ThreeDoors values (progress over perfection, work with human nature, three doors not three hundred, local-first privacy-always, meet users where they are)
+- **NFR-DX2:** The project shall provide a `/pre-pr` Claude Code slash command that automates an 8-step pre-PR validation checklist (branch freshness, formatting via `gofumpt`, linting via `golangci-lint`, tests via `go test`, race detection via `go test -race`, dead code via `go vet`, scope review via `git diff`, commit cleanliness check)
+- **NFR-DX3:** The project shall provide a `/validate-adapter` Claude Code slash command that checks TaskProvider implementations for interface compliance, error wrapping patterns, factory registration, test coverage, and atomic write usage
+- **NFR-DX4:** The project shall provide a `/check-patterns` Claude Code slash command that scans the codebase for design pattern violations
+- **NFR-DX5:** The project shall provide a `/new-story` Claude Code slash command that generates story files from a standard template, referencing CLAUDE.md for coding standards
+
+### Additional Requirements (from Architecture)
+
+- SOUL.md placed at project root, referenced from CLAUDE.md (AD-34.1)
+- All commands in `.claude/commands/` following Claude Code convention (AD-34.2)
+- Use `origin/main` not `upstream/main` in all commands (AD-34.3)
+- Forward-only template changes — do not modify completed stories (AD-34.4)
+- Document MCP integration point for Epic 24.8 (AD-34.5)
+
+### NFR Coverage Map
+
+| NFR | Story | Coverage |
+|-----|-------|----------|
+| NFR-DX1 | 34.1 | SOUL.md creation and CLAUDE.md reference |
+| NFR-DX2 | 34.2 | /pre-pr command with 8 validation steps |
+| NFR-DX3 | 34.2 | /validate-adapter command |
+| NFR-DX4 | 34.2 | /check-patterns command |
+| NFR-DX5 | 34.2 | /new-story command with DRY template |
+
+## Epic List
+
+| Epic | Title | Stories | Priority | Prerequisites |
+|------|-------|---------|----------|---------------|
+| 34 | SOUL.md + Custom Development Skills | 3 | P1 | None |
+
+---
+
+## Epic 34: SOUL.md + Custom Development Skills
+
+**Goal:** Create SOUL.md project philosophy document and 4 custom Claude Code slash commands (/pre-pr, /validate-adapter, /check-patterns, /new-story) to improve AI agent alignment and developer workflow automation.
+
+**Rationale:** Research identified ~500 lines of duplicated content across 11 stories, 12+ PRs with preventable CI failures, and zero ThreeDoors-specific development commands despite 50+ BMAD commands. This epic addresses all three gaps with documentation/configuration files only — no code changes.
+
+**Prerequisites:** None (CLAUDE.md already exists with coding standards)
+
+**Estimated Effort:** 1-2 days
+
+---
+
+### Story 34.1: Create SOUL.md Project Philosophy Document
+
+**As a** developer or AI agent working on ThreeDoors,
+**I want** a SOUL.md document that captures the project's philosophy and design principles,
+**So that** I can make aligned decisions on ambiguous design choices without per-story guidance.
+
+**Acceptance Criteria:**
+
+**AC 34.1.1:**
+**Given** the project root directory,
+**When** I look for SOUL.md,
+**Then** it exists with the following sections: "What Is ThreeDoors?", "Core Philosophy" (with 6 sub-principles), "Design Principles for AI Agents" (with 5 decision heuristics), "What ThreeDoors Is NOT", and "The Feeling We're Going For"
+
+**AC 34.1.2:**
+**Given** SOUL.md exists,
+**When** I read the Core Philosophy section,
+**Then** it contains principles for: Progress Over Perfection, Work With Human Nature, Three Doors Not Three Hundred, Local-First Privacy-Always, Meet Users Where They Are, and Solo Dev Reality
+
+**AC 34.1.3:**
+**Given** SOUL.md exists,
+**When** I read the Design Principles for AI Agents section,
+**Then** it contains 5 decision heuristics: friction reduction, simplicity, data respect, pattern following, and user-visibility check
+
+**AC 34.1.4:**
+**Given** SOUL.md exists at project root,
+**When** I read CLAUDE.md,
+**Then** CLAUDE.md contains a reference to SOUL.md (e.g., "See SOUL.md for project philosophy and design principles")
+
+**AC 34.1.5:**
+**Given** SOUL.md content,
+**When** compared against the PRD executive summary and product brief,
+**Then** the philosophy is consistent with — not contradicting — existing product documentation
+
+**Tasks:**
+- [ ] Create SOUL.md at project root with all sections from architecture doc (AD-34.1)
+- [ ] Content sourced from docs/research/ai-tooling-findings.md Finding 2
+- [ ] Add SOUL.md reference to CLAUDE.md
+- [ ] Verify consistency with PRD goals and product brief
+
+**Key Files:**
+| File | Action |
+|------|--------|
+| `SOUL.md` | Create |
+| `CLAUDE.md` | Edit (add reference) |
+
+**NFRs covered:** NFR-DX1
+
+---
+
+### Story 34.2: Create Custom Claude Code Slash Commands
+
+**As a** developer or AI agent working on ThreeDoors,
+**I want** project-specific Claude Code slash commands for common workflows,
+**So that** I can automate pre-PR validation, adapter compliance checks, pattern enforcement, and story creation.
+
+**Acceptance Criteria:**
+
+**AC 34.2.1 — /pre-pr command:**
+**Given** the `.claude/commands/pre-pr.md` file exists,
+**When** an agent invokes `/pre-pr`,
+**Then** it runs 8 sequential checks: (1) branch freshness via `git fetch origin main`, (2) formatting via `gofumpt -l .`, (3) linting via `golangci-lint run ./...`, (4) tests via `go test ./... -count=1`, (5) race detection via `go test -race ./...`, (6) dead code via `go vet ./...`, (7) scope review via `git diff --stat origin/main...HEAD`, (8) commit cleanliness via `git log --oneline origin/main..HEAD`
+**And** reports a summary table with pass/fail per step
+**And** provides a final verdict: "Ready to push" or "Fix issues above"
+
+**AC 34.2.2 — /validate-adapter command:**
+**Given** the `.claude/commands/validate-adapter.md` file exists,
+**When** an agent invokes `/validate-adapter`,
+**Then** it reads the TaskProvider interface from `internal/tasks/provider.go`, finds all implementing types, and verifies for each: all interface methods implemented, error wrapping uses `%w`, type registered in factory, `_test.go` file exists, and file-based providers use atomic writes
+**And** reports a compliance table per adapter
+
+**AC 34.2.3 — /check-patterns command:**
+**Given** the `.claude/commands/check-patterns.md` file exists,
+**When** an agent invokes `/check-patterns`,
+**Then** it scans for 6 violation categories: direct status mutation (`.Status =` outside task_status.go), non-atomic file writes, `fmt.Println` in TUI code, panics in user code, provider instantiation outside factory/tests, and bare error returns without `%w`
+**And** reports findings grouped by category with file:line references
+
+**AC 34.2.4 — /new-story command:**
+**Given** the `.claude/commands/new-story.md` file exists,
+**When** an agent invokes `/new-story`,
+**Then** it prompts for story ID and title, uses the latest story format as reference, creates `docs/stories/{id}.story.md` with standard structure (frontmatter, user story, ACs, NOT In Scope, DoD referencing CLAUDE.md, Architecture, Key Files, Testing, Tasks, Dev Agent Record, QA Results)
+**And** the generated template does NOT include an embedded Pre-PR Submission Checklist
+**And** the generated template does NOT include duplicated coding standards or pattern reminders
+
+**AC 34.2.5 — Remote references:**
+**Given** any slash command that references a git remote,
+**When** comparing remote URLs in the command definitions,
+**Then** all commands use `origin/main` (not `upstream/main`)
+
+**Tasks:**
+- [ ] Create `.claude/commands/pre-pr.md` with 8-step validation (including -race per party mode)
+- [ ] Create `.claude/commands/validate-adapter.md` with adapter compliance checks
+- [ ] Create `.claude/commands/check-patterns.md` with 6 pattern violation categories
+- [ ] Create `.claude/commands/new-story.md` with DRY story template
+- [ ] Verify all commands use `origin/main` (AD-34.3)
+
+**Key Files:**
+| File | Action |
+|------|--------|
+| `.claude/commands/pre-pr.md` | Create |
+| `.claude/commands/validate-adapter.md` | Create |
+| `.claude/commands/check-patterns.md` | Create |
+| `.claude/commands/new-story.md` | Create |
+
+**NFRs covered:** NFR-DX2, NFR-DX3, NFR-DX4, NFR-DX5
+
+---
+
+### Story 34.3: Story Template Update and Integration Notes
+
+**As a** developer or AI agent creating new stories,
+**I want** the story template to reference CLAUDE.md instead of embedding standards,
+**So that** future stories are leaner and maintainable from a single source of truth.
+
+**Acceptance Criteria:**
+
+**AC 34.3.1:**
+**Given** the `/new-story` command from Story 34.2,
+**When** comparing its output template to completed story files,
+**Then** the template's Definition of Done section contains only "All standard checks pass (see CLAUDE.md Pre-PR Checklist)" plus story-specific items — no embedded Pre-PR Submission Checklist block
+
+**AC 34.3.2:**
+**Given** the `/new-story` command template,
+**When** reviewing for duplicated content,
+**Then** the template does NOT contain repeated Dev Notes about: atomic write pattern, error wrapping with %w, MVU pattern, "follow existing patterns in X", or historical PR references — all of which are already in CLAUDE.md
+
+**AC 34.3.3:**
+**Given** Epic 24.8 (MCP Prompt Templates) is pending,
+**When** reviewing Epic 34 deliverables,
+**Then** the architecture document (_bmad-output/planning-artifacts/architecture-soul-skills.md) contains an integration note documenting that SOUL.md philosophy should inform MCP prompt template design (AD-34.5)
+
+**AC 34.3.4:**
+**Given** the forward-only policy (AD-34.4),
+**When** reviewing the PR diff,
+**Then** no completed story files (docs/stories/*.story.md with status "Done" or "Complete") have been modified
+
+**Tasks:**
+- [ ] Verify /new-story template from 34.2 meets DRY criteria (AC 34.3.1, 34.3.2)
+- [ ] Verify architecture doc contains MCP integration note (AC 34.3.3)
+- [ ] Verify no completed story files modified (AC 34.3.4)
+- [ ] Document the forward-only policy in architecture doc
+
+**Key Files:**
+| File | Action |
+|------|--------|
+| `.claude/commands/new-story.md` | Verify (created in 34.2) |
+| `_bmad-output/planning-artifacts/architecture-soul-skills.md` | Verify (created in architecture step) |
+
+**NFRs covered:** NFR-DX5 (validation)
+
+---
+
+## Story Dependencies
+
+```
+34.1 (SOUL.md) ──────────────── No dependencies
+34.2 (Custom Skills) ────────── No dependencies (can run in parallel with 34.1)
+34.3 (Template Verification) ── Depends on 34.2 (verifies /new-story output)
+```
+
+**Parallelism:** Stories 34.1 and 34.2 can be implemented in parallel. Story 34.3 is a verification gate that runs after 34.2.
+
+## Implementation Notes
+
+1. **No code changes** — All deliverables are markdown files
+2. **No test infrastructure** — Slash commands are tested by running them manually
+3. **Forward-only** — Do not modify completed story files
+4. **Remote convention** — Use `origin/main` throughout (direct push, not fork)
+5. **MCP integration** — SOUL.md is a documented future input for Epic 24.8 prompt templates

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-soul-skills.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-soul-skills.md
@@ -1,0 +1,272 @@
+# Sprint Change Proposal: SOUL.md + Custom Multiclaude Skills
+
+**Date:** 2026-03-08
+**Triggered by:** Research spike (docs/research/ai-tooling-findings.md)
+**Scope Classification:** Moderate — New epic, PRD updates, no code changes
+**Proposed Epic:** Epic 34: SOUL.md + Custom Multiclaude Skills
+
+---
+
+## Section 1: Issue Summary
+
+### Problem Statement
+
+ThreeDoors has extensive AI-assisted development infrastructure (BMAD framework, 50+ slash commands, MCP server, self-driving dev pipeline) but lacks two critical pieces:
+
+1. **No SOUL.md** — The project's philosophy ("progress over perfection", "three doors not three hundred", "work with human nature") is scattered across story files and the PRD. AI agents make isolated decisions without consistent personality/behavioral guidelines. Each agent independently interprets the product vision.
+
+2. **No project-specific development skills** — Despite having 50+ BMAD commands, there are zero ThreeDoors-specific slash commands. Common workflows (pre-PR validation, adapter compliance checks, story creation, design pattern enforcement) are repeated manually in every story file, averaging ~40-50 duplicated lines per story.
+
+### Evidence
+
+- **11 story files** each contain near-identical Pre-PR Submission Checklist blocks (~10 lines each)
+- **~500 lines** of duplicated content across existing stories (coding standards, atomic write pattern, error wrapping, MVU reminders)
+- **50+ BMAD commands** in `.claude/commands/` but **0 ThreeDoors-specific commands**
+- Historical CI failures (PRs #9, #10, #16, #23, #24) from missed formatting/linting steps that a `/pre-pr` skill would have caught
+- CLAUDE.md already exists with coding standards but has no personality/philosophy layer
+
+### Discovery Context
+
+Research agent (zealous-rabbit) conducted a comprehensive analysis on 2026-03-02, producing 7 findings with priority recommendations. The CLAUDE.md recommendation (Finding 1) has already been implemented. Findings 2-4 (SOUL.md, custom skills, DRY reduction) remain unaddressed.
+
+---
+
+## Section 2: Impact Analysis
+
+### Epic Impact
+
+**No existing epics are affected.** This is a purely additive proposal that creates a new Epic 34.
+
+| Aspect | Impact |
+|--------|--------|
+| Current epics (23, 24, 25, 26, 30-33) | No changes needed |
+| Epic dependencies | No dependencies on or from other epics |
+| Epic ordering | No resequencing needed |
+| Priority | P1 — Improves all future development velocity |
+
+### Story Impact
+
+- **Existing stories:** No modifications needed to any existing story files
+- **Future stories:** All future stories benefit by removing ~40-50 lines of boilerplate (Pre-PR Checklist, coding standards reminders, pattern documentation)
+- **Story file template:** Will be updated via `/new-story` skill to reference CLAUDE.md instead of embedding standards
+
+### Artifact Conflicts
+
+| Artifact | Conflict? | Changes Needed |
+|----------|-----------|----------------|
+| PRD | Minor addition | Add FR138-FR142 (SOUL.md, skills requirements) |
+| Architecture | Minor addition | Add section on SOUL.md integration and skills |
+| UI/UX | None | No user-facing changes |
+| CLAUDE.md | None | Already exists, SOUL.md complements it |
+| CI/CD | None | No pipeline changes |
+| ROADMAP.md | Addition | Add Epic 34 to active epics |
+
+### Technical Impact
+
+- **Code changes:** None — SOUL.md and skills are documentation/configuration files
+- **Infrastructure:** None
+- **Deployment:** None
+- **Testing:** Skills can be manually tested; no automated test infrastructure needed
+
+---
+
+## Section 3: Recommended Approach
+
+### Selected Path: Direct Adjustment (Option 1)
+
+**Rationale:** This is a purely additive, low-risk change that creates configuration and documentation files. No code changes, no architectural shifts, no rollbacks needed.
+
+| Factor | Assessment |
+|--------|-----------|
+| Effort | Low — primarily writing/configuration |
+| Risk | Low — no code changes, no breaking changes |
+| Timeline impact | None — can run in parallel with other work |
+| Long-term value | High — improves every future story's quality and reduces boilerplate |
+
+### Alternatives Considered
+
+- **Rollback (Option 2):** Not applicable — no existing work to revert
+- **MVP Review (Option 3):** Not applicable — this is post-MVP enhancement that doesn't affect any MVP scope
+
+---
+
+## Section 4: Detailed Change Proposals
+
+### 4.1: Create SOUL.md
+
+**File:** `SOUL.md` (project root)
+
+**Content:** Project philosophy document capturing:
+- What ThreeDoors is (personal achievement partner)
+- Core philosophy: Progress Over Perfection, Work With Human Nature, Three Doors Not Three Hundred, Local-First Privacy-Always, Meet Users Where They Are, Solo Dev Reality
+- Design principles for AI agents (friction reduction, simplicity, data respect, pattern following)
+- What ThreeDoors is NOT (not project management, not habit tracker, not second brain)
+- The feeling we're going for ("a friend saying pick one and go")
+
+**Rationale:** Based on Finding 2 from research. Captures the "why" behind decisions so agents make aligned choices when stories don't specify every detail. Referenced from CLAUDE.md.
+
+### 4.2: Create /pre-pr Skill
+
+**File:** `.claude/commands/pre-pr.md`
+
+**Content:** Automated 7-step pre-PR validation:
+1. Branch freshness check (git fetch + rebase status)
+2. Formatting check (gofumpt -l .)
+3. Linting (golangci-lint run ./...)
+4. Tests (go test ./... -count=1)
+5. Dead code check (go vet ./...)
+6. Scope review (git diff --stat)
+7. Commit cleanliness (check for fixup/wip commits)
+
+**Rationale:** P0 priority from research. Automates the most-violated checklist. Would have prevented CI failures in PRs #9, #10, #16, #23, #24.
+
+### 4.3: Create /validate-adapter Skill
+
+**File:** `.claude/commands/validate-adapter.md`
+
+**Content:** TaskProvider compliance checker:
+- Read TaskProvider interface
+- Find all implementations
+- Verify method coverage, error wrapping, factory registration, test files, atomic writes
+- Report compliance table
+
+**Rationale:** P2 priority. Prevents adapter compliance issues as new integrations are added (Todoist, GitHub Issues, Linear).
+
+### 4.4: Create /check-patterns Skill
+
+**File:** `.claude/commands/check-patterns.md`
+
+**Content:** Design pattern violation scanner:
+- Direct status mutation without IsValidTransition()
+- Direct file writes bypassing atomic pattern
+- fmt.Println in TUI code
+- Panics in user code
+- Provider instantiation outside factory
+- Missing error wrapping
+
+**Rationale:** P2 priority. Catches anti-patterns before PR creation.
+
+### 4.5: Create /new-story Skill
+
+**File:** `.claude/commands/new-story.md`
+
+**Content:** Story template generator:
+- Prompts for story ID and title
+- Uses latest story format as reference
+- Creates docs/stories/{id}.story.md with standard structure
+- References CLAUDE.md instead of embedding checklist
+- Only includes story-specific dev notes
+
+**Rationale:** P3 priority. Ensures consistent story format, removes boilerplate from creation.
+
+### 4.6: PRD Updates
+
+**Section:** Requirements — add new functional requirements
+
+```
+FR138: The system shall maintain a SOUL.md document at the project root defining
+the project's philosophy, design principles, and behavioral guidelines for AI
+agents — ensuring consistent decision-making aligned with ThreeDoors values
+(progress over perfection, work with human nature, local-first)
+
+FR139: The project shall provide a /pre-pr skill that automates the 7-step
+pre-PR validation checklist (branch freshness, formatting, linting, tests, dead
+code, scope review, commit cleanliness) — reducing CI failures and enforcing
+NFR-CQ1 through NFR-CQ5
+
+FR140: The project shall provide a /validate-adapter skill that checks
+TaskProvider implementations for interface compliance, error wrapping patterns,
+factory registration, test coverage, and atomic write usage
+
+FR141: The project shall provide a /check-patterns skill that scans the codebase
+for design pattern violations (direct status mutation, direct file writes,
+fmt.Println in TUI, panics, factory bypass, missing error wrapping)
+
+FR142: The project shall provide a /new-story skill that generates story files
+from a standard template, referencing CLAUDE.md for coding standards and
+pre-PR checklists instead of embedding them
+```
+
+---
+
+## Section 5: Implementation Handoff
+
+### Scope Classification: Minor
+
+This is a documentation and configuration change. No code modifications. Can be implemented directly by a development worker agent.
+
+### Handoff Plan
+
+| Role | Responsibility |
+|------|---------------|
+| PM agent | Update PRD with FR138-FR142 |
+| Architect agent | Create architecture section for SOUL.md + skills integration |
+| SM agent | Create Epic 34 breakdown with stories |
+| Dev worker | Implement SOUL.md, create skill files, update ROADMAP.md |
+
+### Success Criteria
+
+1. SOUL.md exists at project root and is referenced from CLAUDE.md
+2. Four custom skills (/pre-pr, /validate-adapter, /check-patterns, /new-story) exist in `.claude/commands/`
+3. /pre-pr skill successfully runs all 7 validation steps
+4. PRD updated with FR138-FR142
+5. ROADMAP.md updated with Epic 34
+6. Future stories reference CLAUDE.md Pre-PR Checklist instead of embedding it
+
+### Epic 34 Story Breakdown (Proposed)
+
+| Story | Title | Priority | Effort |
+|-------|-------|----------|--------|
+| 34.1 | Create SOUL.md Project Philosophy Document | P1 | Small |
+| 34.2 | Create /pre-pr Pre-PR Validation Skill | P0 | Small |
+| 34.3 | Create /validate-adapter and /check-patterns Skills | P2 | Small |
+| 34.4 | Create /new-story Story Template Skill | P3 | Small |
+| 34.5 | DRY Existing Story Files (Remove Duplicated Content) | P1 | Medium |
+
+---
+
+## Change Navigation Checklist Results
+
+### Section 1: Understand the Trigger and Context
+- [x] 1.1: Triggering source identified (research spike, not a story)
+- [x] 1.2: Core problem defined (missing SOUL.md, missing project-specific skills, ~500 lines duplication)
+- [x] 1.3: Evidence gathered (11 stories, 50+ BMAD commands, 0 project commands, historical CI failures)
+
+### Section 2: Epic Impact Assessment
+- [x] 2.1: No current epics affected (additive proposal)
+- [x] 2.2: New epic proposed (Epic 34)
+- [x] 2.3: No future epics impacted
+- [x] 2.4: No epics invalidated
+- [x] 2.5: No resequencing needed
+
+### Section 3: Artifact Conflict Analysis
+- [x] 3.1: PRD needs minor additions (FR138-FR142)
+- [x] 3.2: Architecture needs minor addition (SOUL.md + skills section)
+- [N/A] 3.3: No UI/UX impact
+- [x] 3.4: ROADMAP.md update needed
+
+### Section 4: Path Forward Evaluation
+- [x] 4.1: Direct Adjustment — Viable (Low effort, Low risk)
+- [N/A] 4.2: Rollback — Not applicable
+- [N/A] 4.3: MVP Review — Not applicable
+- [x] 4.4: Selected approach: Direct Adjustment
+
+### Section 5: Sprint Change Proposal
+- [x] 5.1: Issue summary created
+- [x] 5.2: Epic and artifact impact documented
+- [x] 5.3: Recommended path with rationale
+- [x] 5.4: PRD MVP impact (none) and action plan
+- [x] 5.5: Agent handoff plan established
+
+### Section 6: Final Review
+- [x] 6.1: All sections addressed
+- [x] 6.2: Proposal is consistent and actionable
+- [x] 6.3: Approved (YOLO mode — automated pipeline)
+- [x] 6.4: Sprint status update pending (Epic 34 to be added)
+- [x] 6.5: Handoff responsibilities defined
+
+---
+
+**Correct Course workflow complete, arcaven!**
+
+Next steps: PM agent updates PRD → Architect creates architecture → SM creates stories → Dev implements.

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -341,9 +341,24 @@
 - **FRs covered:** FR116, FR117, FR118, FR119
 - **Research:** See `docs/research/task-source-expansion-research.md` (Linear section)
 
-**Epic 31+: Additional UX Improvements** (Quick Capture CLI, Snooze/Defer, Focus Timer, Batch Triage — see `docs/research/ux-workflow-improvements-research.md`)
-**Epic 32+: Cross-Computer Sync** (Implement alternative to monolithic SQLite on cloud storage)
-**Epic 33+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 34: SOUL.md + Custom Development Skills** (P1)
+- **Goal:** Create SOUL.md project philosophy document and 4 custom Claude Code slash commands (/pre-pr, /validate-adapter, /check-patterns, /new-story) to improve AI agent alignment and developer workflow
+- **Prerequisites:** None (CLAUDE.md already exists)
+- **Status:** Not Started
+- **Deliverables:**
+  - SOUL.md at project root — project philosophy, design principles, behavioral guidelines for AI agents
+  - `/pre-pr` slash command — 8-step pre-PR validation automation
+  - `/validate-adapter` slash command — TaskProvider compliance checking
+  - `/check-patterns` slash command — design pattern violation scanning
+  - `/new-story` slash command — story template generator referencing CLAUDE.md
+- **Stories:** 34.1-34.3 (3 stories)
+- **Estimated Effort:** 1-2 days
+- **NFRs covered:** NFR-DX1, NFR-DX2, NFR-DX3, NFR-DX4, NFR-DX5
+- **Research:** See `docs/research/ai-tooling-findings.md`
+
+**Epic 35+: Additional UX Improvements** (Quick Capture CLI, Focus Timer, Batch Triage — see `docs/research/ux-workflow-improvements-research.md`)
+**Epic 36+: Cross-Computer Sync** (Implement alternative to monolithic SQLite on cloud storage)
+**Epic 37+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -379,6 +394,7 @@
 | Epic 22: Self-Driving Dev Pipeline | 8 | Not Started |
 | Epic 27: Daily Planning Mode | 5 | Not Started |
 | Epic 30: Linear Integration | 4 | Not Started |
-| **Total** | **128** | **97 complete, 3 partial, 28 remaining** |
+| Epic 34: SOUL.md + Custom Dev Skills | 3 | Not Started |
+| **Total** | **131** | **97 complete, 3 partial, 31 remaining** |
 
 ---

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -516,6 +516,26 @@ These non-functional requirements establish code quality gates that all contribu
 
 ---
 
+## Developer Experience & AI Agent Tooling (Accepted)
+
+*The following requirements establish project-level AI agent alignment and developer workflow automation, based on findings from docs/research/ai-tooling-findings.md and party mode consensus (2026-03-08).*
+
+**SOUL.md — Project Philosophy Document:**
+
+**NFR-DX1:** The project shall maintain a SOUL.md document at the project root defining the project's philosophy, design principles, and behavioral guidelines for AI agents — ensuring consistent decision-making aligned with ThreeDoors values (progress over perfection, work with human nature, three doors not three hundred, local-first privacy-always, meet users where they are)
+
+**Custom Claude Code Slash Commands:**
+
+**NFR-DX2:** The project shall provide a `/pre-pr` Claude Code slash command that automates an 8-step pre-PR validation checklist (branch freshness, formatting via `gofumpt`, linting via `golangci-lint`, tests via `go test`, race detection via `go test -race`, dead code via `go vet`, scope review via `git diff`, commit cleanliness check) — reducing CI failures and enforcing NFR-CQ1 through NFR-CQ5
+
+**NFR-DX3:** The project shall provide a `/validate-adapter` Claude Code slash command that checks TaskProvider implementations for interface compliance, error wrapping patterns, factory registration, test coverage, and atomic write usage
+
+**NFR-DX4:** The project shall provide a `/check-patterns` Claude Code slash command that scans the codebase for design pattern violations (direct status mutation without `IsValidTransition()`, direct file writes bypassing atomic pattern, `fmt.Println` in TUI code, panics in user code, provider instantiation outside factory, missing error wrapping with `%w`)
+
+**NFR-DX5:** The project shall provide a `/new-story` Claude Code slash command that generates story files from a standard template, referencing CLAUDE.md for coding standards and pre-PR checklists instead of embedding them — applying to new stories only (existing completed stories are not modified)
+
+---
+
 ## Task Source Integration NFRs
 
 > Requirements specific to API-based and IPC-based task source adapters.


### PR DESCRIPTION
## Summary

- Ran full BMAD planning pipeline (course correction → party mode → PRD update → architecture → epics & stories) for adding SOUL.md + Custom Development Skills to ThreeDoors
- Created Epic 34 with 3 stories based on party mode consensus (consolidated from original 5-story proposal)
- Added NFR-DX1 through NFR-DX5 developer experience requirements to PRD

## Planning Artifacts Created

| Artifact | File |
|----------|------|
| Sprint Change Proposal | `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-soul-skills.md` |
| Architecture Decisions | `_bmad-output/planning-artifacts/architecture-soul-skills.md` |
| Epic 34 Breakdown | `_bmad-output/planning-artifacts/epic-34-soul-skills.md` |

## PRD Updates

- `docs/prd/requirements.md` — Added NFR-DX1 through NFR-DX5 (Developer Experience & AI Agent Tooling section)
- `docs/prd/epic-list.md` — Added Epic 34 entry, renumbered future placeholder epics (31+ → 35+)

## Party Mode Consensus (Key Decisions)

1. **Consolidated to 3 stories** (from 5): 34.1 SOUL.md, 34.2 All 4 custom skills, 34.3 Template verification
2. **Forward-only** — Don't modify completed story files retroactively
3. **Use `origin/main`** not `upstream/main` (direct push, not fork)
4. **Add `-race` flag** to `/pre-pr` skill (8 steps, not 7)
5. **NFR-DX prefix** for developer experience requirements (not FR prefix)
6. **MCP integration point** — SOUL.md philosophy to inform Epic 24.8 prompt templates

## Epic 34 Stories

| Story | Title | Priority |
|-------|-------|----------|
| 34.1 | Create SOUL.md Project Philosophy Document | P1 |
| 34.2 | Create Custom Claude Code Slash Commands (/pre-pr, /validate-adapter, /check-patterns, /new-story) | P0 |
| 34.3 | Story Template Update and Integration Notes | P1 |

## Opportunities (not implemented)

- SOUL.md could serve as context input for MCP prompt templates (Epic 24.8)
- `/pre-pr` could eventually be extended to auto-fix formatting issues
- Retroactive DRY of completed stories (~500 lines) deferred per party mode consensus

## Test plan

- [x] All planning artifacts are valid markdown
- [x] PRD requirements follow NFR-DX naming convention
- [x] Epic list story count updated correctly (131 total)
- [x] No credentials or secrets in committed files
- [ ] Verify ROADMAP.md update (to be done when Epic 34 is approved for scheduling)