### PR TITLE
docs: BMAD planning — nil pointer panic bug fix planning (issue #218)

### DIFF
--- a/_bmad-output/planning-artifacts/issue-218-party-mode-consensus.md
+++ b/_bmad-output/planning-artifacts/issue-218-party-mode-consensus.md
@@ -1,0 +1,58 @@
+# Party Mode Consensus: Issue #218 — Nil Pointer Panic on Missing Provider
+
+**Date:** 2026-03-08
+**Participants:** John (PM), Winston (Architect), Amelia (Dev), Quinn (QA), Bob (SM), Murat (Test Architect)
+**GitHub Issue:** #218
+
+## Verdict
+
+**Valid P0 bug.** Crash on default first-run path. Not previously reported or rejected.
+
+## Root Cause
+
+`loadTaskPool()` in `internal/cli/doors.go:195` calls `NewProviderFromConfig(cfg)` which returns nil when both provider resolution and textfile fallback fail. Line 198 dereferences nil → SIGSEGV. Same gap exists in MCP server at `cmd/threedoors-mcp/main.go:61`.
+
+Note: `internal/cli/bootstrap.go:37-39` already has the correct nil check pattern.
+
+## Agreed Fix Approach
+
+### Immediate (Story 23.11)
+
+1. Add nil check in `loadTaskPool()` after `NewProviderFromConfig()` — return descriptive error
+2. Add nil check in MCP server initialization — return descriptive error
+3. Add test coverage for nil provider scenarios in both paths
+4. Error message: clear, actionable (e.g., "no task provider available; check provider configuration")
+
+### Follow-up (Optional, Separate Story)
+
+Refactor `NewProviderFromConfig()` to return `(TaskProvider, error)` instead of just `TaskProvider`. Eliminates nil-return anti-pattern at the source. All callers forced to handle error. Medium scope.
+
+## Scope Boundary
+
+**In Scope:** Nil checks, error messages, tests for doors.go and MCP server
+**Out of Scope:** Signature refactor, auto-provider creation, first-run UX improvements
+
+## Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Nil check, not signature refactor | Bug fix should be minimal; refactor is separate story |
+| Descriptive error, not auto-fix | Auto-creating providers is feature scope, not bug fix |
+| Fix MCP too | Same gap, same risk — fix both in one story |
+| Table-driven tests | Consistent with project testing standards |
+
+## Risk Assessment
+
+| Provider Path | Nil Risk | Defense After Fix |
+|---|---|---|
+| `loadTaskPool()` single-provider | HIGH → FIXED | Nil check + error |
+| `loadTaskPool()` multi-provider | LOW | Returns error (already safe) |
+| `bootstrap.go` CLI | LOW | Nil check exists |
+| MCP server | HIGH → FIXED | Nil check + error |
+
+## Requirements Alignment
+
+- **TD-NFR7:** "Gracefully handle missing or corrupted task files" — nil panic violates this
+- **TD-NFR8 (new):** "Never panic due to nil provider initialization" — added to PRD
+- **NFR7:** "Fall back to local text file storage" — fallback exists but fails silently
+- **CLAUDE.md:** "No panics in user-facing code" — explicit rule being violated

--- a/docs/architecture/error-handling-strategy.md
+++ b/docs/architecture/error-handling-strategy.md
@@ -91,6 +91,29 @@ if err := os.Rename(tempPath, targetPath); err != nil {
 }
 ```
 
+### Provider Initialization Errors
+
+**Strategy:** Check for nil provider before use, return actionable error
+
+Factory functions like `NewProviderFromConfig()` can return `nil` when both
+provider resolution and fallback fail. All callers must nil-check before
+dereferencing. Follow the pattern established in `bootstrap.go`:
+
+```go
+provider := core.NewProviderFromConfig(cfg)
+if provider == nil {
+    return fmt.Errorf("no task provider available; check provider configuration")
+}
+```
+
+**Known call sites requiring nil defense:**
+- `internal/cli/doors.go` — `loadTaskPool()` (fixed in Story 23.11)
+- `cmd/threedoors-mcp/main.go` — MCP server init (fixed in Story 23.11)
+- `internal/cli/bootstrap.go` — already defended
+
+**Future consideration:** Refactor `NewProviderFromConfig()` to return
+`(TaskProvider, error)` to eliminate the nil-return pattern at the source.
+
 ## Error Message Guidelines
 
 **User-Facing Errors (in TUI):**

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -3265,6 +3265,27 @@ So that I can use the CLI efficiently with tab completion.
 
 **Phase 3 — Polish (Story 23.10):** Shell completions and interactive doors mode. Quality-of-life improvements for power users.
 
+### Story 23.11: Fix Nil Pointer Panic on Missing Provider
+
+**Status:** Not Started
+
+**GitHub Issue:** #218
+
+As a ThreeDoors user,
+I want the CLI to return a clear error when no provider is available,
+So that I don't experience a panic on first run.
+
+**Bug fix:** `loadTaskPool()` in `doors.go` and MCP server init call `NewProviderFromConfig()` which can return nil. Neither checks for nil before dereferencing. Fix: add nil check and return descriptive error in both locations.
+
+- **AC1:** `loadTaskPool()` returns error (not panic) when provider is nil
+- **AC2:** Error message is actionable — indicates no provider available
+- **AC3:** MCP server handles nil provider without panic
+- **AC4:** All existing tests pass
+- **AC5:** New tests cover nil provider scenario in `loadTaskPool()`
+- **AC6:** New tests cover nil provider scenario in MCP server
+
+**Quality Gate (AC-Q1–Q8):** gofumpt | golangci-lint | tests pass | rebased | scope-checked | errors handled
+
 ---
 
 ## Epic 25: Todoist Integration

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -246,6 +246,8 @@
 
 **TD-NFR7:** The system shall gracefully handle missing or corrupted task files by creating defaults
 
+**TD-NFR8:** The system shall never panic due to nil provider initialization — all code paths that obtain a `TaskProvider` from factory functions must check for nil and return a descriptive error before use (ref: Issue #218, Story 23.11)
+
 ---
 
 **Full MVP Phase (Post-Validation - Deferred):**

--- a/docs/stories/23.11.story.md
+++ b/docs/stories/23.11.story.md
@@ -1,0 +1,78 @@
+# Story 23.11: Fix Nil Pointer Panic on Missing Provider
+
+**Status:** Not Started
+**Epic:** 23 — CLI Interface
+**Depends on:** None (bug fix)
+**GitHub Issue:** #218
+
+## User Story
+
+As a ThreeDoors user,
+I want the CLI to return a clear error message when no task provider is available,
+So that I don't experience a crash (panic) on first run or when providers fail to initialize.
+
+## Bug Summary
+
+`loadTaskPool()` in `internal/cli/doors.go:195` calls `NewProviderFromConfig(cfg)` which can return `nil` when both provider resolution and the textfile fallback fail. Line 198 then calls `provider.LoadTasks()` on the nil pointer, causing a SIGSEGV panic. The MCP server (`cmd/threedoors-mcp/main.go`) has the same gap.
+
+**Root Cause:** `NewProviderFromConfig()` returns `TaskProvider` (interface) with no error return. When fallback fails, it logs to stderr and returns `nil`. The `loadTaskPool()` function does not check for nil before dereferencing. Note: `internal/cli/bootstrap.go:37-39` correctly checks for nil — the fix was applied there but not in `loadTaskPool()` or the MCP server.
+
+**Severity:** P0 — crash on default first-run path when no explicit provider is configured.
+
+## Acceptance Criteria
+
+**Given** a fresh install with no explicit provider configured in `config.yaml`
+**When** `loadTaskPool()` is called and `NewProviderFromConfig()` returns `nil`
+**Then:**
+
+- AC1: `loadTaskPool()` returns a descriptive error (not a panic) when the provider is nil
+- AC2: The error message is actionable: indicates no provider is available and suggests checking configuration
+- AC3: The MCP server (`cmd/threedoors-mcp/main.go`) handles nil provider without panic
+- AC4: All existing tests continue to pass
+- AC5: New test cases cover the nil provider scenario in `loadTaskPool()`
+- AC6: New test cases cover the nil provider scenario in MCP server initialization
+
+## Technical Notes
+
+### Fix Locations
+
+1. **`internal/cli/doors.go` — `loadTaskPool()` function (~line 195):**
+   Add nil check after `NewProviderFromConfig(cfg)` call, return error before attempting `provider.LoadTasks()`.
+
+2. **`cmd/threedoors-mcp/main.go` (~line 61):**
+   Add nil check after `NewProviderFromConfig(cfg)` call, return error before wrapping in WALProvider.
+
+### Pattern Reference
+
+Follow the existing pattern in `internal/cli/bootstrap.go:37-39`:
+```go
+baseProvider := core.NewProviderFromConfig(cfg)
+if baseProvider == nil {
+    return nil, fmt.Errorf("failed to initialize provider")
+}
+```
+
+### Out of Scope
+
+- Refactoring `NewProviderFromConfig()` to return `(TaskProvider, error)` — this is a larger change that should be a separate story
+- Auto-creating a textfile provider on first run — feature enhancement, not bug fix
+- First-run UX improvements — handled by Epic 10 (Onboarding)
+
+## Party Mode Consensus (2026-03-08)
+
+The full BMAD team reviewed this issue and agreed:
+- Valid P0 bug, not previously reported
+- Fix approach: nil check + descriptive error in both CLI and MCP paths
+- Error message should be clear and actionable, not a stack trace
+- Scope limited to defensive nil checks — no signature refactors or feature additions
+- Follow-up story (optional): refactor `NewProviderFromConfig()` to return `(TaskProvider, error)`
+
+## Quality Gate
+
+- QG1: `make fmt` passes (gofumpt formatted)
+- QG2: `make lint` passes with zero warnings
+- QG3: `make test` passes
+- QG4: `go test -race ./...` passes
+- QG5: New tests cover nil provider case in `loadTaskPool()`
+- QG6: New tests cover nil provider case in MCP server
+- QG7: No panics in any code path when provider is nil


### PR DESCRIPTION
## Summary

BMAD planning pipeline artifacts for GitHub Issue #218 — nil pointer panic when textfile provider is not registered.

- **PM Examination:** Confirmed P0 bug — crash on default first-run path when no explicit provider configured
- **Party Mode Consensus:** Full team agreed on fix approach (nil check + descriptive error, not signature refactor)
- **Story 23.11 created:** Bug fix story with clear ACs, technical notes, and quality gate
- **PRD updated:** Added TD-NFR8 requiring nil-safe provider initialization
- **Architecture updated:** Added provider initialization error handling section to error-handling-strategy.md

## Artifacts

| File | Change |
|------|--------|
| `docs/stories/23.11.story.md` | New story for nil pointer panic fix |
| `docs/prd/requirements.md` | Added TD-NFR8 |
| `docs/prd/epics-and-stories.md` | Added Story 23.11 to Epic 23 |
| `docs/architecture/error-handling-strategy.md` | Added provider init error handling section |
| `_bmad-output/planning-artifacts/issue-218-party-mode-consensus.md` | Party mode consensus record |

## Root Cause

`loadTaskPool()` in `internal/cli/doors.go:195` calls `NewProviderFromConfig(cfg)` which returns nil when both provider resolution and textfile fallback fail. Line 198 dereferences nil → SIGSEGV. Same gap in MCP server.

## Next Step

Implementation via `/implement-story 23.11` — separate PR will reference Issue #218 with `Fixes #218`.

## Notes for Supervisor

- ROADMAP.md may need updating: Epic 23 currently shows 10/10 but now has Story 23.11 (Not Started). Per standing orders, workers do not touch ROADMAP.md.
- Follow-up opportunity: refactor `NewProviderFromConfig()` to return `(TaskProvider, error)` — separate story, not required for the bug fix.

Related: #218