### PR TITLE
docs: BMAD planning — door selection tactile feedback improvements (issue #219)

### DIFF
--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 0-15, 3.5, 17-22 are COMPLETE. Epics 16, 23, 24, and 25 are NOT STARTED. 164 merged PRs total. Last audit: 2026-03-07.
+**Implementation Status:** Epics 0-15, 3.5, 17-22 are COMPLETE. Epics 16, 23, 24, 25, and 36 are NOT STARTED. 164 merged PRs total. Last audit: 2026-03-08.
 
 ## Requirements Inventory
 
@@ -2472,6 +2472,92 @@ So that doors appear to have dimension and stand out from the background.
        └── 35.6 Golden File Test Regeneration (depends on 35.2-35.5)
        └── 35.7 Shadow/Depth Effect (depends on 35.2-35.5)
 ```
+
+---
+
+## Epic 36: Door Selection Interaction Feedback
+
+**Epic Goal:** Make door selection feel responsive and satisfying by enhancing visual feedback contrast, adding deselect toggle, and ensuring universal quit. Addresses GitHub Issue #219.
+
+**Prerequisites:** None (complements Epic 35 but does not depend on it)
+**FRs covered:** FR148-FR151
+**Status:** Not Started
+
+### Story 36.1: Enhanced Door Selection Visual Feedback
+
+As a user,
+I want the selected door to be visually unmistakable through strong contrast with unselected doors,
+So that every keypress produces a satisfying, confident "I picked this one" response.
+
+**Acceptance Criteria:**
+
+**Given** the doors view with three doors displayed and no door selected
+**When** the user presses a selection key (a/left, w/up, d/right)
+**Then** the selected door renders with bold text, bright foreground, and enhanced border
+**And** unselected doors render with faint/dimmed text and subdued border color
+
+**Given** no door is selected (selectedDoorIndex == -1)
+**When** all three doors render
+**Then** all doors use their normal (non-dimmed, non-emphasized) styling
+
+**Given** theme-based rendering is active
+**When** a door is selected
+**Then** the contrast difference is apparent even in monochrome mode
+
+**Quality Gate:** AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+---
+
+### Story 36.2: Deselect Toggle — Press Same Key to Unselect
+
+As a user,
+I want to press the same selection key again to deselect a door,
+So that I can explore options freely without feeling prematurely committed.
+
+**Acceptance Criteria:**
+
+**Given** door N is currently selected
+**When** the user presses the same key that selected door N
+**Then** selectedDoorIndex is set to -1 (no selection)
+**And** all doors return to their neutral visual state
+
+**Given** door N is currently selected
+**When** the user presses a different selection key
+**Then** selection switches to the new door (normal behavior)
+
+**Quality Gate:** AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+---
+
+### Story 36.3: Universal Quit — 'q' Works From All Screens
+
+As a user,
+I want 'q' to quit the application from any non-text-input view,
+So that I never feel trapped in a screen.
+
+**Acceptance Criteria:**
+
+**Given** the user is on any non-text-input view
+**When** the user presses 'q'
+**Then** the application exits cleanly
+
+**Given** the user is in a text input mode (search, feedback, quick add)
+**When** the user presses 'q'
+**Then** 'q' is treated as text input, not as quit
+
+**Quality Gate:** AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)
+
+---
+
+### Epic 36 Story Dependencies
+
+```
+36.1 Enhanced Door Selection Visual Feedback (independent)
+36.2 Deselect Toggle (independent)
+36.3 Universal Quit (independent)
+```
+
+All three stories are independent and can be implemented in parallel.
 
 ---
 

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -226,6 +226,16 @@
 
 **FR147:** All door appearance signifiers (proportion, panel divider, handle, threshold) shall work in monochrome mode using structural elements rather than color — ensuring accessibility for users with color vision deficiencies or monochrome terminals
 
+**Door Selection Interaction Feedback (Issue #219):**
+
+**FR148:** When a door is selected, the system shall render the selected door with strong visual emphasis (bold text, bright foreground, enhanced border) and render unselected doors with diminished styling (faint/dimmed text, subdued borders), creating an unmistakable focus funnel effect
+
+**FR149:** The visual contrast between selected and unselected door states shall be distinguishable in monochrome mode using structural emphasis (bold, faint) rather than relying solely on color differentiation
+
+**FR150:** Pressing the same door selection key that selected the currently active door shall toggle the selection off, returning to the neutral state (no door selected) — enabling reversible exploration without re-rolling
+
+**FR151:** The 'q' key shall function as a universal quit command from all non-text-input views, providing a consistent escape route regardless of current screen
+
 ---
 
 ## Non-Functional Requirements

--- a/docs/prd/user-interface-design-goals.md
+++ b/docs/prd/user-interface-design-goals.md
@@ -17,6 +17,11 @@ The main interface presents three tasks simultaneously as entry points. These ta
 
 Over time, the system learns: "On Tuesday mornings, user picks Door 1 (focused work). On Friday afternoons, user picks Door 3 (quick wins). User never picks administrative tasks before 10am."
 
+**Door Selection Feedback (Interaction Feel):**
+- **Strong visual response** - Every keypress must produce a visible, satisfying response. The selected door should draw the eye through contrast, scale, or emphasis — not just a minor color shift. Unselected doors should visually recede (dim/fade) to create a focus funnel effect.
+- **Reversibility** - Pressing the same selection key again toggles the door off, returning to neutral state. Users who know they can undo a selection explore more freely.
+- **Consistent escape routes** - 'q' (quit) works from every non-text-input view. Users should never feel trapped in a screen.
+
 **Door Refresh & Feedback (MVP Core):**
 - **Refresh/New Doors** - Simple keystroke ('s' or 'down arrow') to generate a new set of three doors if current options don't appeal. No judgment, no friction—just new options.
 - **Task Management Feedback** - Options to indicate task status or modify tasks:

--- a/docs/stories/36.1.story.md
+++ b/docs/stories/36.1.story.md
@@ -1,0 +1,75 @@
+# Story 36.1: Enhanced Door Selection Visual Feedback
+
+## Status: Not Started
+
+## Epic
+
+Epic 36: Door Selection Interaction Feedback
+
+## References
+
+- GitHub Issue: #219 (Door selection lacks tactile feedback)
+- Related: Epic 35 (Door Visual Appearance — complementary scope)
+- PR #214 (Door theme visual redesign — complementary scope)
+
+## Story
+
+As a user,
+I want the selected door to be visually unmistakable through strong contrast with unselected doors,
+So that every keypress produces a satisfying, confident "I picked this one" response.
+
+## Background
+
+Currently, door selection changes only the border color to white (`selectedDoorStyle`). This provides weak feedback that doesn't create a clear cause-and-effect relationship between the keypress and the UI response. The user should instantly know which door is active without scanning and comparing.
+
+The party mode consensus identified three Lipgloss-based techniques (no animation system needed):
+1. **Scale contrast** — selected door gains visual weight, unselected doors recede
+2. **Dimming** — unselected doors fade (faint/dim), creating a focus funnel
+3. **Style emphasis** — selected door uses bold text, bright foreground, enhanced border
+
+## Acceptance Criteria
+
+**Given** the doors view with three doors displayed and no door selected
+**When** the user presses a selection key (a/left, w/up, d/right)
+**Then** the selected door renders with:
+  - Bold text content
+  - Bright/vivid foreground color
+  - Enhanced border (e.g., double-line or bright border color)
+  - Maintained or slightly increased width allocation
+**And** the two unselected doors render with:
+  - Faint/dimmed text content (Lipgloss `.Faint(true)`)
+  - Subdued border color
+  - Maintained width allocation (no layout shift that breaks alignment)
+
+**Given** the doors view with no door selected (selectedDoorIndex == -1)
+**When** all three doors are rendered
+**Then** all doors render with their normal (non-dimmed, non-emphasized) styling
+**And** the visual state matches the current default appearance
+
+**Given** theme-based rendering is active
+**When** a door is selected
+**Then** the theme's `Render()` function produces visually distinct selected vs unselected output
+**And** the contrast difference is apparent even in monochrome mode (structural emphasis, not just color)
+
+**Given** the fallback (non-theme) rendering path
+**When** a door is selected
+**Then** the `selectedDoorStyle` provides the same strong contrast as themed rendering
+**And** `doorStyle` for unselected doors applies faint/dim treatment
+
+**Given** golden file tests for theme rendering
+**When** tests compare selected vs unselected door output
+**Then** golden files capture the new enhanced contrast
+**And** the visual difference between states is structurally verifiable (not just color codes)
+
+## Technical Notes
+
+- Primary changes in `internal/tui/doors_view.go` (View method, lines 234-379)
+- Fallback styles defined in `internal/tui/styles.go` (selectedDoorStyle, doorStyle)
+- Theme rendering via `activeTheme.Render(content, width, isSelected)` at line 335
+- Each theme's Render function in `internal/tui/themes/` needs enhanced selected/unselected contrast
+- Do NOT build an animation system — pure Lipgloss styling changes only
+- Do NOT add content reveal/progressive disclosure — that's separate scope
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/36.2.story.md
+++ b/docs/stories/36.2.story.md
@@ -1,0 +1,61 @@
+# Story 36.2: Deselect Toggle — Press Same Key to Unselect
+
+## Status: Not Started
+
+## Epic
+
+Epic 36: Door Selection Interaction Feedback
+
+## References
+
+- GitHub Issue: #219 (Door selection lacks tactile feedback)
+- ThreeDoors philosophy: "Reversibility builds confidence"
+
+## Story
+
+As a user,
+I want to press the same selection key again to deselect a door,
+So that I can explore options freely without feeling prematurely committed.
+
+## Background
+
+Currently, once a door is selected, there is no way to return to the neutral state (no door selected) without re-rolling all doors with 's'. This creates premature commitment anxiety — users hesitate to select because they can't easily undo it. The `selectedDoorIndex` field already supports `-1` (no selection), so the deselect toggle is architecturally trivial.
+
+## Acceptance Criteria
+
+**Given** door 0 is currently selected (selectedDoorIndex == 0)
+**When** the user presses 'a' or 'left' (the same key that selected door 0)
+**Then** selectedDoorIndex is set to -1 (no selection)
+**And** all three doors return to their neutral visual state (no emphasis, no dimming)
+
+**Given** door 1 is currently selected (selectedDoorIndex == 1)
+**When** the user presses 'w' or 'up' (the same key that selected door 1)
+**Then** selectedDoorIndex is set to -1 (no selection)
+
+**Given** door 2 is currently selected (selectedDoorIndex == 2)
+**When** the user presses 'd' or 'right' (the same key that selected door 2)
+**Then** selectedDoorIndex is set to -1 (no selection)
+
+**Given** door 0 is currently selected
+**When** the user presses 'w' or 'd' (a different selection key)
+**Then** the selection switches to the corresponding door (normal behavior, not a toggle)
+
+**Given** no door is currently selected (selectedDoorIndex == -1)
+**When** the user presses any selection key
+**Then** the corresponding door is selected (normal behavior)
+
+**Given** table-driven unit tests in `main_model_test.go` or equivalent
+**When** tests exercise the toggle behavior
+**Then** tests cover: select→deselect (same key), select→switch (different key), deselect→select, all three door positions
+
+## Technical Notes
+
+- Change is in `internal/tui/main_model.go`, `updateDoors` function (lines 917-922)
+- Current code: `m.doorsView.selectedDoorIndex = 0` (unconditional assignment)
+- New code pattern: `if m.doorsView.selectedDoorIndex == 0 { m.doorsView.selectedDoorIndex = -1 } else { m.doorsView.selectedDoorIndex = 0 }`
+- Repeat for all three door keys
+- Help text in `doors_view.go` line 374 should be updated to mention deselect behavior
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/36.3.story.md
+++ b/docs/stories/36.3.story.md
@@ -1,0 +1,59 @@
+# Story 36.3: Universal Quit — 'q' Works From All Screens
+
+## Status: Not Started
+
+## Epic
+
+Epic 36: Door Selection Interaction Feedback
+
+## References
+
+- GitHub Issue: #219 (Door selection lacks tactile feedback)
+- ThreeDoors philosophy: "Consistent escape routes reduce anxiety"
+
+## Story
+
+As a user,
+I want 'q' to quit the application from any view,
+So that I never feel trapped in a screen with no obvious way out.
+
+## Background
+
+Currently 'q' works from the doors view but may not work from all other views (detail, search, feedback, mood, etc.). Some views use 'esc' or other keys to go back, but 'q' as a universal quit is expected behavior in TUI applications (following conventions from tools like lazygit, htop, less).
+
+## Acceptance Criteria
+
+**Given** the user is on any view in the application
+**When** the user presses 'q'
+**Then** the application exits cleanly (same as quit from doors view)
+**Unless** the user is actively typing in a text input field (search, feedback, quick add, etc.)
+
+**Given** the user is in a text input mode (search query, feedback form, quick add)
+**When** the user presses 'q'
+**Then** 'q' is treated as text input (typed into the field), not as quit
+**And** the user can quit from these views using 'esc' to exit the input, then 'q' to quit
+
+**Given** the user is on the detail view for a selected task
+**When** the user presses 'q'
+**Then** the application exits cleanly
+
+**Given** the user is on the mood selection view
+**When** the user presses 'q'
+**Then** the application exits cleanly
+
+**Given** table-driven tests covering quit behavior
+**When** 'q' is sent as a key message to each view's update handler
+**Then** each non-input view returns a quit command
+**And** each text-input view does NOT return a quit command
+
+## Technical Notes
+
+- Audit all `update*` functions in `internal/tui/main_model.go` for 'q' handling
+- Key views to check: `updateDetail`, `updateSearch`, `updateFeedback`, `updateMood`, `updateAvoidancePrompt`, `updateConflictResolution`, `updateProposalReview`, `updateCommandPalette`
+- Views with text input (search, feedback, quick add) must NOT intercept 'q' as quit
+- `ctrl+c` already works universally via Bubbletea — this story ensures 'q' has the same reach where appropriate
+- The `RequestQuitMsg` pattern is already established in `updateDoors` (line 916)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

BMAD triage pipeline for GitHub Issue #219 (Door Selection Lacks Tactile Feedback). Planning artifacts only — no code changes.

- **PM Examination**: Validated issue as P1 — directly impacts core interaction loop. Distinct from Epic 35 (visual appearance at rest) but complementary.
- **Party Mode**: Full agent panel (UX Designer, Architect, PM, Design Thinking Coach, Brainstorming Coach, Test Architect). Consensus: pure Lipgloss styling changes, no animation system.
- **PRD Update**: Added FR148-FR151 (selection feedback contrast, monochrome support, deselect toggle, universal quit). Updated UX design goals.
- **Epic 36 Created**: Door Selection Interaction Feedback — 3 independent stories, all parallelizable.

## New Epic 36: Door Selection Interaction Feedback

| Story | Title | Status | Depends On |
|-------|-------|--------|------------|
| 36.1 | Enhanced Door Selection Visual Feedback | Not Started | None |
| 36.2 | Deselect Toggle — Press Same Key to Unselect | Not Started | None |
| 36.3 | Universal Quit — 'q' Works From All Screens | Not Started | None |

## Party Mode Key Decisions

1. **No animation system** — Lipgloss bold/faint/dim styling provides 80% of the improvement with zero complexity
2. **Focus funnel** — selected door emphasized, unselected doors dimmed (not just selected brightened)
3. **Deselect toggle** — same key press toggles off, architecturally trivial (selectedDoorIndex already supports -1)
4. **Universal quit** — audit all views, add 'q' handler to non-text-input views
5. **Complementary to Epic 35** — Epic 35 = doors look like doors at rest; Epic 36 = doors feel responsive when interacted with

## Files Changed

- `docs/stories/36.1.story.md` — Enhanced visual feedback story
- `docs/stories/36.2.story.md` — Deselect toggle story
- `docs/stories/36.3.story.md` — Universal quit story
- `docs/prd/requirements.md` — Added FR148-FR151
- `docs/prd/user-interface-design-goals.md` — Added interaction feedback section
- `docs/prd/epics-and-stories.md` — Added Epic 36 with 3 stories

## Opportunities (Not Implemented)

- Animation system (frame-tick based) for pulse/transition effects — save for Epic 35.7
- Progressive disclosure (content reveal on selection) — separate feature scope
- Spatial layout shifts (selected door wider) — could enhance 36.1 but adds layout complexity

## References

- Issue #219 (does not close — implementation needed via `/implement-story`)
- Related: Epic 35 (Door Visual Appearance), PR #214 (door theme redesign)