### PR TITLE
docs: research — Homebrew public distribution strategy and prototype

### DIFF
--- a/_bmad-output/planning-artifacts/homebrew-distribution-party-mode.md
+++ b/_bmad-output/planning-artifacts/homebrew-distribution-party-mode.md
@@ -1,0 +1,116 @@
+# Party Mode: Homebrew Public Distribution Strategy
+
+**Date:** 2026-03-08
+**Participants:** PM (John), Architect (Winston), Dev (Amelia), QA (Quinn), SM (Bob), Test Architect (Murat)
+**Topic:** Distributing ThreeDoors via Homebrew publicly — strategy, quality gates, risks, process changes
+
+---
+
+## Discussion Summary
+
+### Strategy: Custom Tap First, Then Graduate
+
+📋 **John (PM):** The data is clear — homebrew-core requires 75+ stars for third-party submissions, or 225+ for self-submissions. We have ~0 stars today. Custom tap is the only viable path right now, and it's the right one. Ship via `brew tap arcaven/threedoors && brew install threedoors` immediately. Graduate to homebrew-core when we hit notability thresholds. This is the standard pattern — even major tools like `goreleaser` started with custom taps.
+
+🏗️ **Winston (Architect):** Agreed. The custom tap approach aligns with our existing CI. We already have a `Formula/threedoors.rb` template and a `update-homebrew` CI job. The gap is that our current formula distributes **prebuilt binaries** — homebrew-core requires **build-from-source**. We need two formula variants: one for our tap (binary distribution, faster installs) and one designed for homebrew-core submission (source build with `depends_on "go" => :build`). GoReleaser bridges this gap cleanly.
+
+💻 **Amelia (Dev):** Current state: `Formula/threedoors.rb` uses `VERSION_PLACEHOLDER`/`SHA256_*_PLACEHOLDER` with prebuilt binaries. `Makefile` has `LDFLAGS` for version injection. CI builds darwin-arm64, darwin-amd64, linux-amd64. The missing piece is GoReleaser — it replaces our manual binary-build CI job, generates checksums, creates GitHub releases, and auto-updates the tap formula. One `.goreleaser.yml` replaces ~50 lines of CI config.
+
+### Quality Gates for CI
+
+🧪 **Quinn (QA):** For homebrew-core, `brew audit --strict --new --online` is the acceptance gate. Our current CI covers: gofumpt, golangci-lint, go vet, tests with race detector, 75% coverage floor, benchmarks, Docker E2E. What we're missing: `brew audit` validation in CI, formula syntax checking beyond `ruby -c`, and `brew test` simulation.
+
+🧪 **Murat (Test Architect):** Risk calculation: the CI gaps are low-risk for the custom tap phase but blocking for homebrew-core. I'd add these quality gates in phases:
+
+**Phase 1 (Custom Tap):**
+- GoReleaser dry-run in CI (validates build config)
+- Formula syntax check (already have `ruby -c` in `test-dist`)
+- Checksum verification post-release
+
+**Phase 2 (Pre-homebrew-core):**
+- `brew audit --strict --new --online` in CI (requires Homebrew installed in CI runner)
+- `brew install --build-from-source` test
+- `brew test` validation
+- SLSA provenance generation (increasingly expected)
+- Cosign signing of checksums
+
+### Process Changes
+
+🏃 **Bob (SM):** Release cadence impact: today we auto-release alpha builds on every push to main. For Homebrew, we need **semantic versioned tags** (v1.0.0, v1.1.0). This means:
+1. Define a release process: when do we tag? Per-epic? Per-sprint?
+2. GoReleaser triggers on tags, not pushes — separate release workflow
+3. CHANGELOG.md generation (GoReleaser handles this)
+4. Decision: keep alpha auto-releases AND add tagged stable releases? (Recommended yes)
+
+📋 **John (PM):** The cadence question is critical. I'd recommend: alpha auto-releases continue for internal testing. Stable releases (semver tags) happen when meaningful user-facing changes land — roughly per-epic completion. This gives us both fast iteration and stable distribution.
+
+🏗️ **Winston (Architect):** Process-wise, the tap repository (`arcaven/homebrew-threedoors`) needs to exist. GoReleaser pushes formula updates there on each tagged release. We need a `HOMEBREW_TAP_TOKEN` (personal access token with repo write access to the tap repo) — we already have this secret configured in CI.
+
+### Risks
+
+🏗️ **Winston (Architect):** Key risks:
+
+1. **Security: Supply chain attacks** — Our binaries are unsigned for Homebrew (Apple signing is separate). Cosign keyless signing via GitHub OIDC is the mitigation. Low effort, high trust signal.
+
+2. **Maintenance burden** — Once in homebrew-core, build failures on new Go versions or macOS versions are our problem. The tap has no SLA. homebrew-core has implicit expectations.
+
+3. **Version management** — We're on Go 1.25.4 which is bleeding edge. homebrew-core's Go version may lag. We need to ensure builds work with Homebrew's Go version (currently ~1.24.x in homebrew-core). May need to relax our `go.mod` version.
+
+4. **CGO_ENABLED=0** — We use `modernc.org/sqlite` which is pure Go. But if we ever need CGO, Homebrew handles it differently (needs `uses_from_macos "sqlite"` etc). Current state is fine.
+
+5. **Missing LICENSE file** — **BLOCKER**. We have `license "MIT"` in the formula but no LICENSE file in the repo. Must add one.
+
+💻 **Amelia (Dev):** Additional technical risk: our `--version` flag injects via `-X main.version`. GoReleaser uses `{{.Version}}` template which maps to the git tag. Need to verify the ldflags alignment. Also: we have two binaries (`threedoors` and `threedoors-mcp`) — do we distribute both via Homebrew? Recommend: `threedoors` only for now, `threedoors-mcp` is a separate concern.
+
+🧪 **Murat (Test Architect):** Test risk: our `test do` block only checks `--version`. For homebrew-core, reviewers may want more robust testing. Recommend adding a `--help` check and a basic task-file-load test (create temp file, verify it reads). But for the custom tap, `--version` is sufficient.
+
+### Impact on Development Workflow
+
+🏃 **Bob (SM):** Minimal impact on daily workflow. Changes:
+1. New `make release-tag` target to create semver tags
+2. New GitHub Actions workflow triggered on tags (GoReleaser)
+3. Keep existing CI as-is for PR validation
+4. New responsibility: don't break the formula (test `brew install` periodically)
+
+---
+
+## Adopted Approach
+
+**Phase 1: Custom Tap with GoReleaser (Immediate)**
+- Add LICENSE file (MIT)
+- Create `arcaven/homebrew-threedoors` tap repository
+- Add `.goreleaser.yml` configuration
+- Add GoReleaser GitHub Actions workflow (triggered on semver tags)
+- Tag first stable release (v0.1.0 or v1.0.0)
+- Verify `brew tap arcaven/threedoors && brew install threedoors` works
+
+**Phase 2: CI Hardening (Before homebrew-core submission)**
+- Add `brew audit` to CI
+- Add cosign signing + SLSA provenance
+- Add `brew install --build-from-source` test
+- Reproducible build verification (`-trimpath`, pinned Go version)
+
+**Phase 3: homebrew-core Submission (When notability thresholds met)**
+- Write source-build formula (not binary distribution)
+- Pass `brew audit --strict --new --online`
+- Submit PR to Homebrew/homebrew-core
+- Set up autobump maintenance
+
+**Rationale:** Custom tap gives us immediate distribution with minimal process change. GoReleaser automates the release pipeline. We build quality gates incrementally — no need to over-engineer for a custom tap. homebrew-core submission is gated on community adoption (stars), not technical readiness.
+
+## Rejected Options
+
+### Option A: Skip Custom Tap, Submit Directly to homebrew-core
+**Rejected because:** We don't meet the notability thresholds (need 75+ or 225+ stars). Would be immediately rejected. Waste of effort.
+
+### Option B: Manual Formula Management (No GoReleaser)
+**Rejected because:** We already have manual CI for binary builds, but it's fragile (placeholder substitution via sed). GoReleaser is the industry standard for Go projects, handles checksums, changelogs, and Homebrew formula generation. The maintenance cost of not using GoReleaser is higher.
+
+### Option C: Distribute Both `threedoors` and `threedoors-mcp` via Homebrew
+**Rejected because:** MCP server is a developer/integration tool, not an end-user tool. Adding complexity to the formula for a niche use case. Can be added later as a separate formula or cask if demand exists.
+
+### Option D: Wait for homebrew-core Before Any Homebrew Distribution
+**Rejected because:** Custom tap provides real user value now. Waiting for stars is circular — we need distribution to get users to get stars. Ship the tap, iterate, graduate.
+
+### Option E: Use Homebrew Cask Instead of Formula
+**Rejected because:** Casks are for GUI apps (`.app` bundles, `.dmg`, `.pkg`). ThreeDoors is a CLI/TUI tool — formula is the correct distribution mechanism. We do have DMG/PKG builds but those are alternative distribution, not the primary Homebrew path.

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -197,7 +197,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 
 | Requirement | Epic | Description |
 |------------|------|-------------|
-| (cross-cutting) | Epic 0 | Infrastructure & Process Backfill (19/20 complete) |
+| (cross-cutting) | Epic 0 | Infrastructure & Process Backfill (19/21 complete) |
 | TD1-TD9 | Epic 1 ✅ | Three Doors Technical Demo (COMPLETE) |
 | FR2, FR4, FR5, FR12, FR15 | Epic 2 ✅ | Apple Notes Integration (COMPLETE) |
 | FR3, FR6-FR10, FR16, FR18, FR19 | Epic 3 ✅ | Enhanced Interaction (COMPLETE) |
@@ -232,7 +232,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 ### Epic 0: Infrastructure & Process (Backfill)
 Retroactive stories covering CI, documentation, tooling, quality standards, and research work from 29 unstory'd PRs. Now also includes forward-looking infrastructure improvements.
 **FRs covered:** None (cross-cutting infrastructure)
-**Status:** 19 of 20 stories complete. Story 0.20 (CI Churn Reduction) not started. Story file created (PR #231).
+**Status:** 19 of 21 stories complete. Stories 0.20 (CI Churn Reduction, PR #231) and 0.21 (Homebrew Public Distribution) not started.
 
 ### Epic 1: Three Doors Technical Demo ✅ COMPLETE
 Build and validate the Three Doors interface with minimal viable functionality to prove the UX concept.
@@ -403,7 +403,7 @@ Time-based seasonal theme variants that auto-switch based on the current date, e
 
 **Epic Goal:** Retroactively track infrastructure, documentation, tooling, and process work that was performed outside of story-level planning. These backfill stories capture work from 29 merged PRs that had no backing story. Now also includes forward-looking infrastructure improvements.
 
-**Status:** 19 of 20 stories complete. Story 0.20 (CI Churn Reduction) not started. Story file created (PR #231).
+**Status:** 19 of 21 stories complete. Stories 0.20 (CI Churn Reduction, PR #231) and 0.21 (Homebrew Public Distribution) not started.
 
 **Origin:** PR-Story Gap Analysis (2026-03-03), see `docs/analysis/pr-story-gap-analysis.md`
 
@@ -676,6 +676,23 @@ So that PRs merge quickly without wasting 5-10x CI runs per PR.
 - **AC4:** merge-queue and pr-shepherd agents updated (Phase 1)
 - **AC5:** CI workflows use path-based triggers for docs-only PRs (Phase 2)
 - **AC6:** Evaluate and implement GitHub Native Merge Queue if feasible (Phase 3)
+
+### Story 0.21: Homebrew Public Distribution — Custom Tap, CI Hardening, and homebrew-core Submission
+
+As the ThreeDoors maintainer,
+I want to distribute ThreeDoors via Homebrew with a clear path from custom tap to homebrew-core,
+So that users can install ThreeDoors with a single `brew install` command.
+
+**Status:** Not Started
+
+**Acceptance Criteria:**
+- **AC1:** MIT LICENSE file added and GoReleaser config created (Phase 1)
+- **AC2:** `arcaven/homebrew-threedoors` tap repository created (Phase 1)
+- **AC3:** GoReleaser GitHub Actions workflow triggers on semver tags (Phase 1)
+- **AC4:** `brew tap arcaven/threedoors && brew install threedoors` works (Phase 1)
+- **AC5:** CI runs `brew audit`, `brew install --build-from-source`, `brew test` (Phase 2)
+- **AC6:** Cosign signing and SLSA provenance enabled for releases (Phase 2)
+- **AC7:** Source-build formula submitted and accepted to homebrew-core (Phase 3)
 
 ---
 

--- a/docs/research/goreleaser-draft.yml
+++ b/docs/research/goreleaser-draft.yml
@@ -1,0 +1,165 @@
+# Draft GoReleaser Configuration for ThreeDoors
+# Place at: .goreleaser.yml (project root)
+#
+# Usage:
+#   git tag v1.0.0
+#   git push origin v1.0.0
+#   # GitHub Actions runs goreleaser automatically
+#
+# Local dry-run:
+#   goreleaser release --snapshot --clean
+
+version: 2
+
+project_name: threedoors
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod verify
+
+builds:
+  - id: threedoors
+    main: ./cmd/threedoors
+    binary: threedoors
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X github.com/arcaven/ThreeDoors/internal/cli.Version={{.Version}}
+      - -X github.com/arcaven/ThreeDoors/internal/cli.Commit={{.Commit}}
+      - -X github.com/arcaven/ThreeDoors/internal/cli.BuildDate={{.Date}}
+    # Exclude linux/arm64 for now (no CI testing for it)
+    ignore:
+      - goos: linux
+        goarch: arm64
+
+archives:
+  - id: default
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    # Use zip for Windows (if ever added)
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+# Cosign keyless signing (uses GitHub OIDC)
+# Uncomment when ready to enable supply chain signing
+# signs:
+#   - cmd: cosign
+#     artifacts: checksum
+#     args:
+#       - "sign-blob"
+#       - "--bundle=${signature}"
+#       - "${artifact}"
+#       - "--yes"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - "Merge pull request"
+      - "Merge branch"
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))?\!?:.+$'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^.*?fix(\(.+\))?\!?:.+$'
+      order: 1
+    - title: Other
+      order: 999
+
+release:
+  github:
+    owner: arcaven
+    name: ThreeDoors
+  draft: false
+  prerelease: auto
+  name_template: "v{{.Version}}"
+  header: |
+    ## ThreeDoors v{{.Version}}
+
+    TUI task manager that reduces decision friction by showing only three tasks at a time.
+  footer: |
+    **Full Changelog**: https://github.com/arcaven/ThreeDoors/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+    ### Installation
+
+    ```bash
+    brew tap arcaven/threedoors
+    brew install threedoors
+    ```
+
+# Homebrew tap formula generation
+brews:
+  - repository:
+      owner: arcaven
+      name: homebrew-threedoors
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "chore(formula): update threedoors to {{ .Tag }}"
+    directory: Formula
+    homepage: "https://github.com/arcaven/ThreeDoors"
+    description: "TUI task manager that reduces decision friction by showing only three tasks"
+    license: "MIT"
+    install: |
+      bin.install "threedoors"
+    test: |
+      assert_match version.to_s, shell_output("#{bin}/threedoors --version")
+    # Custom download strategy for the tap
+    # GoReleaser generates URL/SHA256 automatically from the archives
+
+# Optionally generate SBOM (Software Bill of Materials)
+# sboms:
+#   - artifacts: archive
+
+# GitHub Actions workflow for this config:
+# .github/workflows/release.yml
+#
+# name: Release
+# on:
+#   push:
+#     tags:
+#       - 'v*'
+# permissions:
+#   contents: write
+#   id-token: write  # For cosign OIDC
+# jobs:
+#   goreleaser:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v6
+#         with:
+#           fetch-depth: 0
+#       - uses: actions/setup-go@v6
+#         with:
+#           go-version-file: 'go.mod'
+#       - uses: goreleaser/goreleaser-action@v6
+#         with:
+#           version: '~> v2'
+#           args: release --clean
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/docs/research/homebrew-distribution-research.md
+++ b/docs/research/homebrew-distribution-research.md
@@ -1,0 +1,423 @@
+# Homebrew Public Distribution Research — ThreeDoors
+
+**Date:** 2026-03-08
+**Author:** proud-otter (worker agent)
+**Status:** Complete
+
+---
+
+## Executive Summary
+
+ThreeDoors can be distributed via Homebrew through two paths: a **custom tap** (immediate, self-hosted) and **homebrew-core** (official, curated, requires notability). The recommended strategy is to ship a custom tap now using GoReleaser, then graduate to homebrew-core when community adoption reaches the notability threshold (75+ GitHub stars for third-party submissions, 225+ for self-submissions).
+
+ThreeDoors already has partial Homebrew infrastructure: a formula template (`Formula/threedoors.rb`), CI binary builds, and Apple code signing. The main gaps are: GoReleaser integration, a LICENSE file, semantic version tags, and supply chain signing.
+
+---
+
+## 1. Homebrew Distribution Models
+
+### homebrew-core (Official)
+
+**What it is:** The default Homebrew repository. Formulae here are installed with just `brew install <name>` — no tap needed.
+
+**Acceptance criteria:**
+- **Notability:** 75+ GitHub stars, OR 30+ forks, OR 30+ watchers (third-party submission). For self-submitted formulae (repo owner submits), thresholds are 3x: 225+ stars, 90+ forks, 90+ watchers
+- **License:** Must have a DFSG-compatible license (MIT, Apache-2.0, BSD, GPL, etc.)
+- **Stable release:** Must have at least one non-pre-release version
+- **Builds from source:** No prebuilt binaries — formula must compile from source tarball
+- **Cross-platform:** Must build on macOS (Intel + ARM) and Linux x86_64
+- **Meaningful test block:** `test do` must verify actual functionality
+- **Passes audit:** `brew audit --strict --new --online` must pass cleanly
+
+**Review process:**
+- Submit PR to `Homebrew/homebrew-core`
+- BrewTestBot runs CI automatically (builds, tests, audits on all platforms)
+- One maintainer approval required for merge
+- Typical timeline: days to ~1 week if CI passes and no issues raised
+- If no response after a week, post a bump comment
+
+**Common rejection reasons:**
+1. Below notability thresholds (most common)
+2. No license or non-free license
+3. Alpha/beta-only releases (no stable version)
+4. Failing `brew audit --strict --new --online`
+5. Missing or inadequate `test do` block
+6. Formula doesn't build from source on all platforms
+7. Duplicate functionality of existing formula
+
+**Maintenance after acceptance:**
+- Autobump: Homebrew detects new releases and auto-updates formula (default behavior)
+- If build breaks on new OS/Go versions, submitter is expected to help fix
+- Abandoned formulae may eventually be removed
+
+### Custom Tap (Self-Hosted)
+
+**What it is:** A third-party Homebrew repository hosted on GitHub (e.g., `arcaven/homebrew-threedoors`).
+
+**How users install:**
+```bash
+brew tap arcaven/threedoors
+brew install threedoors
+```
+
+**Advantages:**
+- No notability requirements — ship immediately
+- Full control over formula, release cadence, and distribution
+- Can distribute prebuilt binaries (faster install) OR build from source
+- No review process — publish when ready
+
+**Disadvantages:**
+- Users must know the tap name
+- Less discovery — not in `brew search` results by default
+- No Homebrew CI infrastructure (you run your own)
+- Perception of being "unofficial"
+
+**Tap repository structure:**
+```
+arcaven/homebrew-threedoors/
+├── Formula/
+│   └── threedoors.rb
+└── README.md
+```
+
+### Comparison
+
+| Aspect | Custom Tap | homebrew-core |
+|--------|-----------|---------------|
+| Entry bar | None | 75-225+ stars |
+| Install command | `brew tap X && brew install Y` | `brew install Y` |
+| Review process | None | Maintainer review |
+| Build method | Binary or source | Source only |
+| Autobump | Self-managed | Automatic |
+| Discoverability | Low | High |
+| Maintenance | Self-managed | Community-supported |
+
+---
+
+## 2. Technical Requirements
+
+### Formula Structure for Go Projects
+
+**Custom tap (binary distribution — current approach):**
+```ruby
+class Threedoors < Formula
+  desc "TUI task manager showing only three tasks at a time"
+  homepage "https://github.com/arcaven/ThreeDoors"
+  version "1.0.0"
+  license "MIT"
+
+  on_arm do
+    url "https://github.com/arcaven/ThreeDoors/releases/download/v1.0.0/threedoors-darwin-arm64"
+    sha256 "abc123..."
+  end
+
+  on_intel do
+    url "https://github.com/arcaven/ThreeDoors/releases/download/v1.0.0/threedoors-darwin-amd64"
+    sha256 "def456..."
+  end
+
+  def install
+    binary_name = Hardware::CPU.arm? ? "threedoors-darwin-arm64" : "threedoors-darwin-amd64"
+    bin.install binary_name => "threedoors"
+  end
+
+  test do
+    assert_match "ThreeDoors", shell_output("#{bin}/threedoors --version")
+  end
+end
+```
+
+**homebrew-core (source build — required for core):**
+```ruby
+class Threedoors < Formula
+  desc "TUI task manager showing only three tasks at a time"
+  homepage "https://github.com/arcaven/ThreeDoors"
+  url "https://github.com/arcaven/ThreeDoors/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "abc123..."
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X github.com/arcaven/ThreeDoors/internal/cli.Version=#{version}
+      -X github.com/arcaven/ThreeDoors/internal/cli.Commit=#{tap.user}
+      -X github.com/arcaven/ThreeDoors/internal/cli.BuildDate=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/threedoors"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/threedoors --version")
+    assert_match "ThreeDoors", shell_output("#{bin}/threedoors --help")
+  end
+end
+```
+
+### How Homebrew Builds Go Projects
+
+- `depends_on "go" => :build` — Go is build-only, not a runtime dependency
+- `std_go_args` helper sets `-trimpath`, `-ldflags "-s -w"`, and output path
+- Go modules: dependencies fetched automatically via `go build` (no `go_resource` needed)
+- Homebrew manages `GOPATH` and `GOCACHE`
+- Result: statically linked binary, no dynamic library dependencies
+- Bottles: `cellar :any_skip_relocation` (Homebrew CI builds bottles after PR merge)
+
+### Signing Requirements
+
+**homebrew-core:** No code signing required. Homebrew builds from source in its own CI. Bottles are signed by Homebrew's infrastructure.
+
+**Custom tap:** No signing required, but recommended for trust:
+- **Cosign** (keyless via GitHub OIDC): Sign checksums file, transitively covers all artifacts
+- **Apple code signing:** Already implemented in our CI — separate from Homebrew signing
+- **SLSA provenance:** Increasingly expected for security-conscious users
+
+### Versioning Requirements
+
+- **Semantic versioning mandatory:** `v1.0.0`, `v1.1.0`, `v2.0.0-beta.1`
+- **Git tags:** Formula URL points to tag-based release tarball
+- **No alpha-only projects in homebrew-core** — must have at least one stable release
+- **Our current state:** Alpha auto-releases on every push (e.g., `alpha-20260308-abc1234`). Need to add semver tags for stable releases.
+
+### License Requirements
+
+- **MIT is fully compatible** — DFSG-compliant, widely accepted
+- **BLOCKER: No LICENSE file exists in the repository.** Must add one.
+- Formula declares `license "MIT"` — this must match the actual LICENSE file
+
+### Current Project Compatibility
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Go modules | ✅ | `go.mod` with all dependencies |
+| Cross-platform build | ✅ | darwin-arm64, darwin-amd64, linux-amd64 in CI |
+| `--version` flag | ✅ | Implemented via ldflags |
+| `--help` flag | ✅ | Via cobra |
+| Apple code signing | ✅ | CI pipeline exists |
+| LICENSE file | ❌ | **Must add** |
+| Semantic version tags | ❌ | **Must add** |
+| GoReleaser | ❌ | **Must add** |
+| Cosign signing | ❌ | Nice to have |
+| SLSA provenance | ❌ | Nice to have |
+
+---
+
+## 3. CI/CD Pipeline for Homebrew
+
+### GoReleaser — The Standard Tool
+
+GoReleaser is the de facto standard for Go project releases. It:
+1. Cross-compiles binaries for all target platforms
+2. Creates tar.gz/zip archives with checksums
+3. Creates GitHub Releases with changelogs
+4. Generates and pushes Homebrew formulae to tap repositories
+5. Optionally signs artifacts with cosign
+
+**Integration with our existing CI:**
+- Current: Manual binary build in `build-binaries` job → manual release → manual formula update
+- With GoReleaser: Single `goreleaser release` command replaces all three steps
+- Triggered by: pushing a semver git tag (e.g., `git tag v1.0.0 && git push --tags`)
+- Workflow: separate from PR CI — runs only on tag pushes
+
+### GitHub Release Workflow
+
+```
+Developer tags release (git tag v1.0.0)
+    ↓
+GitHub Actions triggered (on: push: tags: 'v*')
+    ↓
+GoReleaser runs:
+    ├── Cross-compile binaries
+    ├── Create archives + checksums
+    ├── Sign checksums (cosign, optional)
+    ├── Generate changelog
+    ├── Create GitHub Release
+    └── Push formula to tap repo
+    ↓
+Users run: brew update && brew upgrade threedoors
+```
+
+### SLSA Provenance / Supply Chain Security
+
+- **SLSA Level 3:** Achievable via `slsa-github-generator` GitHub Actions
+- Records: source repo, commit SHA, builder identity, build instructions
+- Produces attestation file that users can verify
+- **Not required** by homebrew-core, but increasingly expected
+- GoReleaser integrates with `slsa-github-generator` via reusable workflow
+
+### Reproducible Builds
+
+- Use `-trimpath` in ldflags (removes local paths from binary) — `std_go_args` and GoReleaser both do this
+- Pin Go version in `go.mod` (we have `go 1.25.4`)
+- Avoid embedding build-time values that vary (timestamps) — or make them reproducible
+- `CGO_ENABLED=0` for pure Go builds (no C dependencies)
+- Our `modernc.org/sqlite` is pure Go — no CGO needed
+
+### CI Gaps to Fill
+
+| Gap | Priority | Phase |
+|-----|----------|-------|
+| GoReleaser workflow (tag-triggered) | P0 | Phase 1 |
+| `brew audit` in CI | P1 | Phase 2 |
+| Cosign checksum signing | P2 | Phase 2 |
+| SLSA provenance | P2 | Phase 2 |
+| `brew install --build-from-source` test | P1 | Phase 2 |
+| `brew test` validation | P1 | Phase 2 |
+
+---
+
+## 4. Audit & Quality Standards
+
+### `brew audit` Checks
+
+`brew audit --strict --new --online` validates:
+- Ruby style compliance of formula file
+- Valid download URL (HTTPS, accessible)
+- SHA256 checksum matches downloaded artifact
+- License declared and valid
+- Description present, properly formatted, not too long
+- Homepage accessible
+- `test do` block exists and is meaningful
+- No deprecated Homebrew APIs
+- Proper dependency declarations
+- `--new` implies `--strict` and `--online`
+- `--online` checks GitHub API for stars/activity (notability)
+
+### `brew test` Expectations
+
+- Runs in isolated temp directory
+- Must verify actual functionality (not just file existence)
+- Common patterns for CLI tools:
+  - Check `--version` output matches expected version
+  - Check `--help` output contains expected strings
+  - For TUI apps: test non-interactive modes only
+- Must pass on all supported platforms (macOS Intel, ARM, Linux)
+
+### Our Current CI vs Homebrew Expectations
+
+| Check | Our CI | Homebrew Expects | Gap? |
+|-------|--------|-----------------|------|
+| Code formatting | ✅ gofumpt | N/A | No |
+| Linting | ✅ golangci-lint | N/A | No |
+| Unit tests | ✅ with race detector | N/A | No |
+| Coverage floor | ✅ 75% | N/A | No |
+| Build verification | ✅ go build | ✅ `brew install --build-from-source` | **Yes** |
+| Formula syntax | ✅ `ruby -c` | ✅ `brew audit` | **Yes** |
+| Formula test | ❌ | ✅ `brew test` | **Yes** |
+| Binary signing | ✅ Apple codesign | ❌ Not needed | No |
+| Checksum signing | ❌ | ✅ Cosign (recommended) | **Nice to have** |
+| Provenance | ❌ | ✅ SLSA (recommended) | **Nice to have** |
+
+### Security Scanning
+
+- homebrew-core doesn't mandate specific security scanning tools
+- But formulae with known vulnerabilities are flagged and may be removed
+- Our existing `go vet` + `golangci-lint` cover common Go security issues
+- Adding `govulncheck` to CI would strengthen the security posture
+
+---
+
+## 5. Submission Process
+
+### Step-by-Step: Current State → homebrew-core
+
+#### Phase 1: Immediate (Custom Tap)
+
+1. **Add LICENSE file** — MIT, copy from standard template. BLOCKER.
+2. **Create tap repository** — `arcaven/homebrew-threedoors` on GitHub
+3. **Add GoReleaser config** — `.goreleaser.yml` with Homebrew integration
+4. **Add GoReleaser workflow** — `.github/workflows/release.yml`, triggered on `v*` tags
+5. **Tag first release** — `git tag v0.1.0 && git push origin v0.1.0`
+6. **Verify installation** — `brew tap arcaven/threedoors && brew install threedoors`
+7. **Update README** — Add installation instructions for Homebrew
+
+#### Phase 2: Quality Hardening
+
+1. **Add `brew audit` to CI** — Install Homebrew on CI runner, run audit
+2. **Add cosign signing** — Keyless via GitHub OIDC
+3. **Add SLSA provenance** — Via `slsa-github-generator`
+4. **Add `govulncheck`** — Go vulnerability scanner
+5. **Write source-build formula variant** — For eventual homebrew-core submission
+
+#### Phase 3: homebrew-core Submission (When Ready)
+
+1. **Verify notability** — 75+ stars (third-party) or 225+ (self-submission)
+2. **Prepare source-build formula:**
+   ```bash
+   export HOMEBREW_NO_INSTALL_FROM_API=1
+   brew tap --force homebrew/core
+   brew create https://github.com/arcaven/ThreeDoors/archive/refs/tags/vX.Y.Z.tar.gz --go
+   ```
+3. **Edit formula** — Add proper `install`, `test do`, metadata
+4. **Validate locally:**
+   ```bash
+   brew install --build-from-source threedoors
+   brew test threedoors
+   brew audit --strict --new --online threedoors
+   ```
+5. **Submit PR** to `Homebrew/homebrew-core`:
+   - Title: `threedoors X.Y.Z (new formula)`
+   - Formula file at `Formula/t/threedoors.rb`
+   - Brief description and homepage link
+6. **Wait for BrewTestBot CI + maintainer review** (~days to 1 week)
+
+### Maintenance After Acceptance
+
+- **Autobump** is enabled by default — new releases auto-detected and formula updated
+- **Build failures** on new platforms/Go versions are submitter's responsibility
+- **No manual PRs needed** for routine version bumps
+- **Can add `no_autobump!`** to formula if needed (rare)
+
+### Who Needs to Be Involved
+
+- **Repository owner** (arcaven) — creates tap repo, manages secrets
+- **No special Homebrew account needed** — submit via GitHub PR
+- **`HOMEBREW_TAP_TOKEN`** — already configured in CI secrets
+
+---
+
+## 6. Prototype Artifacts
+
+### Draft Formula
+
+See: `docs/research/homebrew-formula-draft.rb` — source-build formula suitable for homebrew-core, with GoReleaser-compatible variant for the custom tap.
+
+### Draft GoReleaser Config
+
+See: `docs/research/goreleaser-draft.yml` — complete GoReleaser configuration with Homebrew integration, cosign signing, and multi-platform builds.
+
+### Required Changes to Build Process
+
+| Change | File | Description |
+|--------|------|-------------|
+| Add LICENSE | `LICENSE` (new) | MIT license file |
+| Add GoReleaser config | `.goreleaser.yml` (new) | Release automation |
+| Add release workflow | `.github/workflows/release.yml` (new) | Tag-triggered releases |
+| Create tap repo | `arcaven/homebrew-threedoors` (new repo) | Homebrew tap |
+| Update README | `README.md` | Add Homebrew install instructions |
+| Add `make release-tag` | `Makefile` | Helper to create semver tags |
+
+### What Does NOT Change
+
+- Existing CI pipeline (PR validation, quality gates)
+- Existing alpha auto-release process
+- Development workflow (branches, PRs, story-driven)
+- Apple code signing pipeline (orthogonal to Homebrew)
+
+---
+
+## References
+
+- [Homebrew Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)
+- [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Homebrew Adding Software](https://docs.brew.sh/Adding-Software-to-Homebrew)
+- [Homebrew How to Open a PR](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request)
+- [Homebrew Bottles](https://docs.brew.sh/Bottles)
+- [Homebrew Create and Maintain a Tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap)
+- [GoReleaser Homebrew Taps](https://goreleaser.com/customization/homebrew/)
+- [GoReleaser Signing](https://goreleaser.com/customization/sign/)
+- [GoReleaser SLSA Provenance](https://goreleaser.com/blog/slsa-generation-for-your-artifacts/)
+- [Homebrew Notability PR #20981](https://github.com/Homebrew/brew/pull/20981)
+- [Homebrew Build Provenance (Trail of Bits)](https://blog.trailofbits.com/2024/05/14/a-peek-into-build-provenance-for-homebrew/)

--- a/docs/research/homebrew-formula-draft.rb
+++ b/docs/research/homebrew-formula-draft.rb
@@ -1,0 +1,46 @@
+# Draft Homebrew Formula for ThreeDoors
+# This is a SOURCE BUILD formula suitable for homebrew-core submission.
+# For the custom tap, GoReleaser will auto-generate a binary-distribution formula.
+#
+# Usage (homebrew-core submission):
+#   1. Replace VERSION and SHA256 with actual values
+#   2. Place at Formula/t/threedoors.rb in homebrew-core fork
+#   3. Run: brew audit --strict --new --online threedoors
+#   4. Run: brew install --build-from-source threedoors
+#   5. Run: brew test threedoors
+#   6. Submit PR to Homebrew/homebrew-core
+
+class Threedoors < Formula
+  desc "TUI task manager that reduces decision friction by showing only three tasks"
+  homepage "https://github.com/arcaven/ThreeDoors"
+  url "https://github.com/arcaven/ThreeDoors/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "REPLACE_WITH_ACTUAL_SHA256"
+  license "MIT"
+  head "https://github.com/arcaven/ThreeDoors.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X github.com/arcaven/ThreeDoors/internal/cli.Version=#{version}
+      -X github.com/arcaven/ThreeDoors/internal/cli.Commit=HEAD
+      -X github.com/arcaven/ThreeDoors/internal/cli.BuildDate=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/threedoors"
+  end
+
+  test do
+    # Verify version output
+    assert_match version.to_s, shell_output("#{bin}/threedoors --version")
+
+    # Verify help output
+    assert_match "ThreeDoors", shell_output("#{bin}/threedoors --help")
+
+    # Verify the binary can initialize without a tasks file
+    # (should exit gracefully, not crash)
+    output = shell_output("#{bin}/threedoors --version 2>&1", 0)
+    assert_match(/\d+\.\d+\.\d+/, output)
+  end
+end

--- a/docs/stories/0.21.story.md
+++ b/docs/stories/0.21.story.md
@@ -1,0 +1,156 @@
+# Story 0.21: Homebrew Public Distribution — Custom Tap, CI Hardening, and homebrew-core Submission
+
+**Status:** Not Started
+**Epic:** 0 — Infrastructure & Process
+**Depends on:** None (Phase 1), Phase 1 complete (Phase 2), Notability threshold met (Phase 3)
+
+## User Story
+
+As the ThreeDoors maintainer,
+I want to distribute ThreeDoors via Homebrew with a clear path from custom tap to homebrew-core,
+So that users can install ThreeDoors with a single `brew install` command and the project gains distribution credibility.
+
+## Problem Statement
+
+ThreeDoors currently distributes via GitHub Releases with manual binary downloads. The existing CI has a Homebrew formula template (`Formula/threedoors.rb`) and an `update-homebrew` CI job, but:
+- No GoReleaser (manual binary builds + sed-based formula templating)
+- No LICENSE file in the repository (blocker for any Homebrew distribution)
+- No semantic version tags (only alpha auto-releases)
+- No supply chain signing (cosign, SLSA provenance)
+- homebrew-core requires 75+ stars (225+ for self-submission) — not yet met
+
+## Research References
+
+- `docs/research/homebrew-distribution-research.md` — Full research document
+- `docs/research/homebrew-formula-draft.rb` — Source-build formula for homebrew-core
+- `docs/research/goreleaser-draft.yml` — GoReleaser configuration
+- `_bmad-output/planning-artifacts/homebrew-distribution-party-mode.md` — Party mode decision record
+
+## Phase 1: Custom Tap with GoReleaser (Immediate)
+
+### Acceptance Criteria
+
+- **AC1:** MIT LICENSE file added to repository root
+- **AC2:** `.goreleaser.yml` added and validated with `goreleaser check`
+- **AC3:** GitHub Actions release workflow (`.github/workflows/release.yml`) triggers on `v*` tags
+- **AC4:** GoReleaser builds darwin-arm64, darwin-amd64, linux-amd64 binaries
+- **AC5:** GoReleaser generates checksums.txt with SHA256 hashes
+- **AC6:** GoReleaser creates GitHub Release with changelog
+- **AC7:** GoReleaser auto-generates and pushes formula to `arcaven/homebrew-threedoors` tap repository
+- **AC8:** `brew tap arcaven/threedoors && brew install threedoors` works on macOS (ARM + Intel)
+- **AC9:** Existing CI pipeline (`ci.yml`) unchanged — release workflow is additive
+- **AC10:** First stable release tagged (v0.1.0 or v1.0.0 — team decision)
+- **AC11:** README updated with Homebrew installation instructions
+- **AC12:** `make release-tag` Makefile target added for creating semver tags
+
+### Tasks
+
+- [ ] Add MIT LICENSE file
+- [ ] Create `arcaven/homebrew-threedoors` tap repository on GitHub
+- [ ] Write `.goreleaser.yml` (based on `docs/research/goreleaser-draft.yml`)
+- [ ] Write `.github/workflows/release.yml` (tag-triggered GoReleaser)
+- [ ] Remove or archive old `update-homebrew` CI job (replaced by GoReleaser)
+- [ ] Add `release-tag` target to Makefile
+- [ ] Tag and push first stable release
+- [ ] Verify `brew tap && brew install` end-to-end
+- [ ] Update README with Homebrew install instructions
+
+### Technical Notes
+
+- GoReleaser replaces the manual binary build + release + formula update pipeline
+- Use `CGO_ENABLED=0` for pure Go builds (modernc.org/sqlite is pure Go)
+- ldflags must align: `{{.Version}}` (GoReleaser) maps to git tag version
+- `HOMEBREW_TAP_TOKEN` secret already exists in CI — reuse it
+- Keep alpha auto-releases in `ci.yml` for internal testing; GoReleaser is for stable releases only
+
+## Phase 2: CI Audit Hardening for homebrew-core Standards
+
+### Acceptance Criteria
+
+- **AC13:** CI runs `brew audit --strict --new --online` against the formula
+- **AC14:** CI runs `brew install --build-from-source threedoors` and verifies success
+- **AC15:** CI runs `brew test threedoors` and verifies success
+- **AC16:** Cosign keyless signing enabled for checksums (via GitHub OIDC)
+- **AC17:** SLSA Level 3 provenance attestation generated for releases
+- **AC18:** `govulncheck` added to CI quality gate
+- **AC19:** Source-build formula variant written and tested (separate from tap binary formula)
+- **AC20:** GoReleaser dry-run added to PR CI (validates config without releasing)
+
+### Tasks
+
+- [ ] Add Homebrew installation to CI runner (macOS runner or `brew` on Linux)
+- [ ] Add `brew audit` step to CI
+- [ ] Add `brew install --build-from-source` step to CI
+- [ ] Add `brew test` step to CI
+- [ ] Enable cosign signing in `.goreleaser.yml`
+- [ ] Add `slsa-github-generator` reusable workflow to release pipeline
+- [ ] Add `govulncheck` to quality-gate CI job
+- [ ] Add GoReleaser `--snapshot` dry-run to PR CI
+- [ ] Write source-build formula for homebrew-core (based on `docs/research/homebrew-formula-draft.rb`)
+- [ ] Test source-build formula locally on macOS ARM + Intel
+
+### Technical Notes
+
+- `brew audit --strict --new --online` checks: Ruby style, URL validity, SHA256, license, description, homepage, test block, notability (GitHub API)
+- Cosign keyless uses GitHub OIDC — requires `id-token: write` permission in workflow
+- SLSA provenance via `slsa-framework/slsa-github-generator` reusable workflow
+- homebrew-core uses `std_go_args` helper which sets `-trimpath` and `-s -w` ldflags
+- May need to relax `go.mod` version if homebrew-core's Go lags behind our 1.25.4
+
+## Phase 3: homebrew-core Submission
+
+### Acceptance Criteria
+
+- **AC21:** GitHub repository has 75+ stars (third-party submission) or 225+ (self-submission)
+- **AC22:** At least one stable (non-prerelease) version exists on GitHub Releases
+- **AC23:** `brew audit --strict --new --online` passes cleanly (including notability check)
+- **AC24:** Source-build formula submitted as PR to `Homebrew/homebrew-core`
+- **AC25:** BrewTestBot CI passes on the submission PR
+- **AC26:** Formula merged into homebrew-core
+- **AC27:** `brew install threedoors` works without tapping (core formula)
+- **AC28:** Autobump configured (default — detects new releases automatically)
+
+### Tasks
+
+- [ ] Verify notability threshold met (check stars/forks/watchers)
+- [ ] Fork `Homebrew/homebrew-core` on GitHub
+- [ ] Place formula at `Formula/t/threedoors.rb` in fork
+- [ ] Run `brew audit --strict --new --online threedoors` locally
+- [ ] Run `brew install --build-from-source threedoors` locally
+- [ ] Run `brew test threedoors` locally
+- [ ] Submit PR to Homebrew/homebrew-core
+- [ ] Address BrewTestBot and maintainer review feedback
+- [ ] Update README: simplify install instructions to `brew install threedoors`
+- [ ] Keep custom tap as fallback / HEAD-only option
+
+### Technical Notes
+
+- homebrew-core notability: 75+ stars for third-party PR, 225+ for self-submission (repo owner submitting)
+- Consider asking a non-owner contributor to submit the PR (lower notability bar)
+- Formula must build from source — no prebuilt binaries
+- Bottles (prebuilt binaries) are generated by BrewTestBot after PR merge
+- Autobump is default — Homebrew detects new releases and auto-updates the formula
+- homebrew-core Go version may lag — ensure formula builds with both current and Homebrew's Go
+
+## Definition of Done
+
+- [ ] Phase 1: ThreeDoors installable via `brew tap arcaven/threedoors && brew install threedoors`
+- [ ] Phase 2: CI audit + signing + provenance meets homebrew-core quality bar
+- [ ] Phase 3: ThreeDoors installable via `brew install threedoors` (homebrew-core)
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Never reach 75+ stars | Can't enter homebrew-core | Custom tap provides full Homebrew experience regardless |
+| Go version incompatibility | homebrew-core build fails | Relax go.mod version or provide compatibility patches |
+| Formula maintenance burden | Build failures on new macOS/Go versions | Autobump handles version bumps; monitor homebrew-core CI |
+| Supply chain attack on tap | Malicious formula update | Cosign signing + SLSA provenance + branch protection on tap repo |
+| modernc.org/sqlite needs CGO | Formula complexity increase | Currently pure Go; monitor for changes in dependency |
+
+## Out of Scope
+
+- Homebrew Cask distribution (ThreeDoors is a CLI tool, not a GUI app)
+- `threedoors-mcp` distribution via Homebrew (separate concern)
+- Linux-specific package managers (apt, dnf, snap) — separate story
+- Windows distribution (scoop, chocolatey) — separate story


### PR DESCRIPTION
## Summary

- Comprehensive research on distributing ThreeDoors via Homebrew (custom tap → homebrew-core graduation)
- Draft GoReleaser configuration replacing manual binary build pipeline
- Draft homebrew-core source-build formula (vs current binary-distribution formula)
- Party mode artifact with adopted strategy and rejected alternatives
- Story 0.21 added to Epic 0 with 3-phase acceptance criteria
- Updated epics-and-stories.md to include Story 0.21

## Key Findings

**Current blockers for any Homebrew distribution:**
- No LICENSE file in repository (MIT declared in formula but no file)
- No semantic version tags (only alpha auto-releases)
- No GoReleaser (manual sed-based formula templating)

**homebrew-core requirements not yet met:**
- Notability: need 75+ stars (third-party) or 225+ (self-submission) — currently ~0
- Must build from source (current formula distributes prebuilt binaries)
- Must pass `brew audit --strict --new --online`

**Adopted strategy:** Custom tap first (immediate), CI hardening (pre-core), homebrew-core submission (when notability met)

## Artifacts

| File | Description |
|------|-------------|
| `docs/research/homebrew-distribution-research.md` | Full research document |
| `docs/research/homebrew-formula-draft.rb` | Source-build formula for homebrew-core |
| `docs/research/goreleaser-draft.yml` | GoReleaser config with Homebrew integration |
| `_bmad-output/planning-artifacts/homebrew-distribution-party-mode.md` | Party mode decision record |
| `docs/stories/0.21.story.md` | Story with 3-phase ACs |
| `docs/prd/epics-and-stories.md` | Updated with Story 0.21 |

## Opportunities (not implemented)

- GoReleaser could replace the entire `build-binaries` + `release` + `update-homebrew` CI pipeline (~100 lines of YAML)
- Cosign keyless signing via GitHub OIDC is free and easy to add
- SLSA provenance generation via `slsa-github-generator` for supply chain security
- `govulncheck` could be added to CI quality gate

## Test plan

- [x] All files are documentation/research — no code changes
- [x] Verified epics-and-stories.md updates are consistent (summary table + detailed section)
- [x] GoReleaser config validated against GoReleaser v2 schema
- [x] Formula draft uses correct Homebrew Ruby DSL