### PR TITLE
docs: Story 0.22 — fix homebrew strict audit failures

### DIFF
--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -694,6 +694,22 @@ So that users can install ThreeDoors with a single `brew install` command.
 - **AC6:** Cosign signing and SLSA provenance enabled for releases (Phase 2)
 - **AC7:** Source-build formula submitted and accepted to homebrew-core (Phase 3)
 
+### Story 0.22: Fix Homebrew Strict Audit Failures
+
+As the ThreeDoors maintainer,
+I want the Homebrew tap CI to pass `brew audit --strict` and `brew style` for all formulas,
+So that formula updates don't break CI and we maintain homebrew-core readiness.
+
+**Status:** Not Started
+
+**Acceptance Criteria:**
+- **AC1:** Formula template uses `if Hardware::CPU.arm?` / `else` instead of `on_arm`/`on_intel`
+- **AC2:** Formula `desc` does not start with the formula name
+- **AC3:** Formula `test do` block does not pass redundant `0` to `shell_output`
+- **AC4:** `brew audit --strict` passes for all formulas in tap CI
+- **AC5:** `brew style` passes for all formulas in tap CI
+- **AC6:** Formula update automation generates compliant formulas
+
 ---
 
 ## Epic 1: Three Doors Technical Demo ✅ COMPLETE

--- a/docs/stories/0.23.story.md
+++ b/docs/stories/0.23.story.md
@@ -1,0 +1,133 @@
+# Story 0.23: Fix Homebrew Strict Audit Failures
+
+## Story
+
+As the ThreeDoors maintainer,
+I want the Homebrew tap CI to pass `brew audit --strict` and `brew style` for all formulas,
+So that formula updates don't break CI and we maintain homebrew-core readiness.
+
+**Status:** Not Started
+
+---
+
+## Background & Root Cause Analysis
+
+The `arcaven/homebrew-tap` repo added CI with `brew audit --strict` and `brew style` checks. Multiple failures were discovered and manually fixed across commits `bed7451e`, `48953f2f`, and `d0e4153a`. This story documents the failures and ensures the automated formula update process (in the ThreeDoors release workflow) generates compliant formulas from the start.
+
+### Failure 1: Description starts with formula name
+
+**Rule:** `FormulaAudit/Desc` — `desc` must not start with the formula name (case-insensitive).
+
+```ruby
+# WRONG
+desc "Three Doors - radical task management showing only 3 tasks at a time"
+
+# FIXED
+desc "Radical task management showing only 3 tasks at a time"
+```
+
+**Root cause:** The formula template/generator included the project name in the description.
+
+### Failure 2: `on_arm`/`on_intel` cannot contain `url` or `sha256`
+
+**Rule:** `FormulaAudit/ComponentsOrder` — `on_arm` and `on_intel` blocks only allow a restricted set of DSL methods (`depends_on`, `patch`, `resource`, etc.). They cannot contain `url` or `sha256`.
+
+```ruby
+# WRONG — on_arm/on_intel cannot hold url/sha256
+on_arm do
+  url "..."
+  sha256 "..."
+end
+on_intel do
+  url "..."
+  sha256 "..."
+end
+
+# FIXED — use if/else with Hardware::CPU
+if Hardware::CPU.arm?
+  url "..."
+  sha256 "..."
+else
+  url "..."
+  sha256 "..."
+end
+```
+
+**Root cause:** The formula generator used `on_arm`/`on_intel` blocks for arch detection, which is the wrong DSL for containing `url`/`sha256` directives.
+
+### Failure 3: Redundant `0` exit status in `shell_output`
+
+**Rule:** `FormulaAudit/Test` — Passing `0` to `shell_output` is redundant (0 is the default expected exit code).
+
+```ruby
+# WRONG
+shell_output("#{bin}/threedoors --version 2>&1", 0)
+
+# FIXED
+shell_output("#{bin}/threedoors --version 2>&1")
+```
+
+**Root cause:** Formula template included explicit `0` exit status argument.
+
+### Failure 4: `brew audit` no longer accepts file paths
+
+**Rule:** CI must symlink the checkout as a local tap and audit by formula name, not file path.
+
+```yaml
+# WRONG
+brew audit --strict --formula Formula/*.rb
+
+# FIXED
+mkdir -p "$(brew --repository)/Library/Taps/arcaven"
+ln -sf "$GITHUB_WORKSPACE" "$(brew --repository)/Library/Taps/arcaven/homebrew-tap"
+brew audit --strict "arcaven/tap/$name"
+```
+
+**Root cause:** The initial CI workflow used file paths instead of tap-qualified formula names.
+
+---
+
+## Acceptance Criteria
+
+- **AC1:** The ThreeDoors release workflow formula template uses `if Hardware::CPU.arm?` / `else` instead of `on_arm`/`on_intel` blocks
+- **AC2:** The formula template `desc` does not start with the formula name (ThreeDoors/Switchboard)
+- **AC3:** The formula template `test do` block does not pass redundant `0` to `shell_output`
+- **AC4:** `brew audit --strict` passes for all formulas in `arcaven/homebrew-tap` CI
+- **AC5:** `brew style` passes for all formulas in `arcaven/homebrew-tap` CI
+- **AC6:** Formula update automation (if any exists in ThreeDoors CI) generates compliant formulas
+
+## Tasks
+
+- [ ] Identify the formula generation code in ThreeDoors CI (`.github/workflows/` or scripts)
+- [ ] Update formula template to use `if/else` arch detection pattern
+- [ ] Update formula template description to not start with formula name
+- [ ] Update formula template test block to omit redundant `shell_output` arg
+- [ ] Verify `arcaven/homebrew-tap` CI is green (already fixed manually)
+- [ ] Add a formula lint check to the ThreeDoors release workflow (optional hardening)
+
+## Test Criteria
+
+- `brew audit --strict arcaven/tap/threedoors` passes
+- `brew style arcaven/tap/threedoors` passes
+- `brew install arcaven/tap/threedoors` succeeds
+- `brew test arcaven/tap/threedoors` succeeds
+- CI on `arcaven/homebrew-tap` main branch is green
+
+## References
+
+- Homebrew Formula Cookbook: https://docs.brew.sh/Formula-Cookbook
+- Homebrew strict audit rules: `brew audit --strict`
+- Fix commits: `bed7451e`, `48953f2f`, `d0e4153a` in `arcaven/homebrew-tap`
+- Related: Story 0.21 (Homebrew distribution strategy)
+- Research: `docs/research/homebrew-distribution-research.md`
+
+## Patterns to Avoid (Lessons Learned)
+
+These patterns will cause `brew audit --strict` or `brew style` failures:
+
+| Pattern | Rule | Fix |
+|---------|------|-----|
+| `desc` starts with formula name | `FormulaAudit/Desc` | Remove formula name from start of desc |
+| `on_arm { url ... }` | `FormulaAudit/ComponentsOrder` | Use `if Hardware::CPU.arm?` |
+| `shell_output(cmd, 0)` | `FormulaAudit/Test` | Omit the `0` — it's the default |
+| `brew audit Formula/x.rb` | CLI change | Symlink as tap, audit by `tap/name` |


### PR DESCRIPTION
## Summary

- Investigated `arcaven/homebrew-tap` CI failures with `brew audit --strict` and `brew style`
- Documented 4 root causes found across failed CI runs and manual fix commits
- Created Story 0.22 with detailed root cause analysis and acceptance criteria
- Updated epics-and-stories.md with the new story

## Root Causes Found

| # | Failure | Rule | Fix Applied |
|---|---------|------|-------------|
| 1 | `desc` starts with formula name | `FormulaAudit/Desc` | Remove formula name from description |
| 2 | `on_arm`/`on_intel` blocks with `url`/`sha256` | `FormulaAudit/ComponentsOrder` | Use `if Hardware::CPU.arm?` / `else` |
| 3 | Redundant `0` exit status in `shell_output` | `FormulaAudit/Test` | Omit the default argument |
| 4 | `brew audit` called with file paths | CLI behavior change | Symlink as local tap, audit by `tap/name` |

All 4 issues were manually fixed in the tap repo (commits `bed7451e`, `48953f2f`, `d0e4153a`). CI is now green. Story 0.22 tracks updating the **formula generator** in ThreeDoors CI so future automated formula updates don't reintroduce these failures.

## Opportunity

The formula generation code in the ThreeDoors release workflow likely still uses the old patterns. When Story 0.22 is implemented, the generator should be updated to produce compliant formulas from the start.

## Test plan

- [ ] Story file at `docs/stories/0.22.story.md` has correct root cause analysis
- [ ] Epics file updated with Story 0.22
- [ ] Acceptance criteria are actionable and testable