### PR TITLE
docs: Story 0.24 — Renovate + Dependabot dependency management

### DIFF
--- a/_bmad-output/planning-artifacts/dependency-management-party-mode.md
+++ b/_bmad-output/planning-artifacts/dependency-management-party-mode.md
@@ -1,0 +1,126 @@
+# Party Mode: Renovate + Dependabot Dependency Management
+
+**Date:** 2026-03-08
+**Participants:** PM, Architect, Dev, QA, SM
+**Topic:** Automated dependency management for ThreeDoors
+
+---
+
+## Discussion Summary
+
+### Q1: What should Renovate handle vs Dependabot?
+
+**Adopted Approach:** Renovate handles Go module dependencies (go.mod/go.sum) with security scanning. Dependabot handles GitHub Actions version pinning (.github/workflows/*.yml).
+
+**Rationale:** Renovate has superior grouping, scheduling, and auto-merge policies for application dependencies. Dependabot has native GitHub Actions ecosystem support and is zero-config for action version updates. This avoids overlap — each tool owns a distinct ecosystem.
+
+**Rejected Options:**
+- *Renovate for everything:* Renovate can manage GitHub Actions, but Dependabot does it natively with less config and better GitHub integration (security advisories appear directly in the Security tab). Rejected because the marginal benefit doesn't justify the extra Renovate config complexity.
+- *Dependabot for everything:* Dependabot's grouping and auto-merge capabilities are weaker. It creates one PR per dependency update (no grouping in go ecosystem), which would flood the merge queue. Rejected for merge-queue noise.
+- *Neither (manual updates):* Not viable for a project with 20+ Go dependencies. Security patches would be delayed.
+
+### Q2: Auto-merge policy
+
+**Adopted Approach:**
+- **Patch updates:** Auto-merge if CI green (for both Go deps and GitHub Actions)
+- **Minor updates:** Auto-merge if CI green, but only for non-breaking Go dependencies (charmbracelet, standard library wrappers)
+- **Major updates:** Never auto-merge. Create PR, label `breaking-change`, require human review.
+- **Security updates:** Auto-merge patches and minors if CI green, regardless of other policies. Major security updates get priority label but still require human review.
+
+**Rationale:** ThreeDoors has strong test coverage (75%+ enforced) and a comprehensive CI pipeline (unit tests, race detector, benchmarks, Docker E2E). This gives high confidence that auto-merged patch/minor updates won't introduce regressions.
+
+**Rejected Options:**
+- *Auto-merge everything including majors:* Too risky. Major version bumps in charmbracelet/bubbletea could change TUI behavior in ways tests don't catch (visual regressions). Rejected.
+- *Never auto-merge:* Creates review burden. Patch updates (e.g., v1.0.1 → v1.0.2) are almost always safe and shouldn't require human attention. Rejected for being too conservative.
+- *Auto-merge only security:* Leaves routine patches piling up. Rejected.
+
+### Q3: Interaction with merge-queue agent
+
+**Adopted Approach:**
+- Renovate/Dependabot PRs get auto-labeled `dependencies` by their respective bots
+- Security PRs additionally labeled `security` by Renovate's vulnerability detection
+- Merge-queue agent treats `dependencies` PRs as in-scope (infrastructure/Epic 0 work)
+- No special merge priority — dependency PRs go through normal CI and merge-queue flow
+- Renovate schedule: weekdays only, batch window 6-8 AM UTC to avoid merge-queue contention during active development
+
+**Rationale:** Dependency updates are routine infrastructure. They should flow through the same quality gates as all other PRs. Scheduling during off-hours prevents merge-queue congestion.
+
+**Rejected Options:**
+- *Priority lane for security PRs:* Adds complexity to merge-queue. Security patches auto-merge anyway, so they'll flow through quickly. Rejected unless we encounter actual delays.
+- *Separate CI workflow for dependency PRs:* Unnecessary duplication. The existing CI pipeline is sufficient. Rejected.
+- *Skip merge-queue for auto-merged PRs:* Violates branch protection. Rejected.
+
+### Q4: Grouping strategy
+
+**Adopted Approach:**
+- Group all non-security patch updates into a single weekly PR (`chore(deps): patch updates`)
+- Group charmbracelet ecosystem updates together (bubbles, bubbletea, lipgloss, etc.)
+- Security updates get individual PRs for clear audit trail
+- GitHub Actions updates grouped monthly
+
+**Rationale:** Grouping reduces PR noise. The charmbracelet ecosystem is tightly coupled and should be updated together. Security updates need individual PRs for compliance visibility.
+
+**Rejected Options:**
+- *No grouping (one PR per dep):* Too noisy. With 20+ deps, this would create 5-10 PRs per week. Rejected.
+- *Group everything including security:* Obscures security patches in routine updates. Rejected for auditability.
+- *Daily batches:* Too frequent. Weekly is sufficient for a project of this size. Rejected.
+
+### Q5: Breaking changes from major version bumps
+
+**Adopted Approach:**
+- Major version PRs are never auto-merged
+- PR description includes changelog link and breaking change summary (Renovate does this automatically)
+- Label `breaking-change` applied automatically
+- Developer reviews changelog, updates code if needed, then merges manually
+- If multiple major updates accumulate, they can be tackled as a dedicated story
+
+**Rationale:** Major bumps require human judgment. Renovate's release notes extraction gives reviewers the information they need.
+
+**Rejected Options:**
+- *Automated migration scripts:* Over-engineered for a project with this dependency count. Rejected.
+- *Ignore major updates:* Falling behind on majors creates security risk and tech debt. Rejected.
+
+### Q6: Envoy agent notification for security PRs
+
+**Adopted Approach:** Not implemented in Phase 1. Renovate's `security` label on PRs is sufficient visibility. If security PRs start accumulating without review, add a GitHub Actions workflow to ping the relevant team.
+
+**Rationale:** The envoy agent concept is not yet implemented in the multiclaude setup. Adding notification infrastructure before the agent exists is premature.
+
+**Rejected Options:**
+- *Build custom notification system:* YAGNI. Labels and PR descriptions provide enough visibility. Rejected.
+- *Slack/email notifications:* No Slack/email integration exists. Rejected as out of scope.
+
+### Q7: Renovate security features to enable
+
+**Adopted Approach:**
+- **Vulnerability alerts:** Enabled (Renovate's built-in vulnerability detection via OSV database)
+- **Security updates priority:** Enabled (security PRs created immediately, not batched)
+- **Release notes extraction:** Enabled (changelogs included in PR descriptions)
+- **SLSA verification:** Deferred to Phase 2 or later (requires additional infrastructure)
+
+**Rationale:** OSV-based vulnerability detection is zero-config and high-value. SLSA verification adds complexity and is better suited for a future hardening story.
+
+**Rejected Options:**
+- *Enable everything at once including SLSA:* Over-scoped for initial setup. Rejected.
+- *Skip vulnerability alerts (rely on GitHub's native alerts):* Renovate's alerts are more actionable because they come with an update PR. Rejected.
+
+### Q8: Impact on Homebrew formula maintenance
+
+**Adopted Approach:** No direct impact. Homebrew formula updates are triggered by the release workflow, not by dependency changes. Dependency updates flow through normal CI → merge → release pipeline. The formula template in the repo is not affected by go.mod changes.
+
+**Rationale:** The Homebrew formula references binary artifacts, not Go module dependencies. The only connection is that dependency updates might trigger a new release (if merged to main), which would then update the formula via the existing `update-homebrew` CI job.
+
+**Rejected Options:**
+- *Special handling for Homebrew-affecting deps:* No dependency directly affects the formula. Rejected as unnecessary.
+
+---
+
+## Consensus Decisions
+
+1. **Renovate = Go deps, Dependabot = GitHub Actions** — clean separation, no overlap
+2. **Auto-merge patches + non-breaking minors** — leveraging strong CI coverage
+3. **Weekly grouped PRs** with security as individual PRs
+4. **Standard merge-queue flow** — no special lanes or priority
+5. **Weekday morning schedule** — avoid developer contention
+6. **OSV vulnerability scanning** enabled from day one
+7. **SLSA verification** deferred to future story

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -197,7 +197,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 
 | Requirement | Epic | Description |
 |------------|------|-------------|
-| (cross-cutting) | Epic 0 | Infrastructure & Process Backfill (19/21 complete) |
+| (cross-cutting) | Epic 0 | Infrastructure & Process Backfill (19/22 complete) |
 | TD1-TD9 | Epic 1 ✅ | Three Doors Technical Demo (COMPLETE) |
 | FR2, FR4, FR5, FR12, FR15 | Epic 2 ✅ | Apple Notes Integration (COMPLETE) |
 | FR3, FR6-FR10, FR16, FR18, FR19 | Epic 3 ✅ | Enhanced Interaction (COMPLETE) |
@@ -232,7 +232,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 ### Epic 0: Infrastructure & Process (Backfill)
 Retroactive stories covering CI, documentation, tooling, quality standards, and research work from 29 unstory'd PRs. Now also includes forward-looking infrastructure improvements.
 **FRs covered:** None (cross-cutting infrastructure)
-**Status:** 19 of 21 stories complete. Stories 0.20 (CI Churn Reduction, PR #231) and 0.21 (Homebrew Public Distribution) not started.
+**Status:** 19 of 22 stories complete. Stories 0.20 (CI Churn Reduction), 0.21 (Homebrew Public Distribution), and 0.24 (Renovate + Dependabot) not started.
 
 ### Epic 1: Three Doors Technical Demo ✅ COMPLETE
 Build and validate the Three Doors interface with minimal viable functionality to prove the UX concept.
@@ -403,7 +403,7 @@ Time-based seasonal theme variants that auto-switch based on the current date, e
 
 **Epic Goal:** Retroactively track infrastructure, documentation, tooling, and process work that was performed outside of story-level planning. These backfill stories capture work from 29 merged PRs that had no backing story. Now also includes forward-looking infrastructure improvements.
 
-**Status:** 19 of 21 stories complete. Stories 0.20 (CI Churn Reduction, PR #231) and 0.21 (Homebrew Public Distribution) not started.
+**Status:** 19 of 22 stories complete. Stories 0.20 (CI Churn Reduction), 0.21 (Homebrew Public Distribution), and 0.24 (Renovate + Dependabot) not started.
 
 **Origin:** PR-Story Gap Analysis (2026-03-03), see `docs/analysis/pr-story-gap-analysis.md`
 
@@ -709,6 +709,23 @@ So that formula updates don't break CI and we maintain homebrew-core readiness.
 - **AC4:** `brew audit --strict` passes for all formulas in tap CI
 - **AC5:** `brew style` passes for all formulas in tap CI
 - **AC6:** Formula update automation generates compliant formulas
+
+### Story 0.24: Renovate + Dependabot Automated Dependency Management
+
+As the ThreeDoors maintainer,
+I want automated dependency management via Renovate (Go deps) and Dependabot (GitHub Actions),
+So that dependencies stay up to date with security as the top priority and minimal manual effort.
+
+**Status:** Not Started
+
+**Acceptance Criteria:**
+- **AC1:** `renovate.json` configured for Go module dependency management with OSV vulnerability scanning
+- **AC2:** Renovate groups patch updates weekly, charmbracelet ecosystem together, security updates individually
+- **AC3:** Auto-merge enabled for patches and non-breaking minors; majors require human review
+- **AC4:** `.github/dependabot.yml` configured for GitHub Actions version pinning (monthly grouped)
+- **AC5:** Go modules ecosystem excluded from Dependabot (Renovate handles this)
+- **AC6:** Merge-queue agent accepts `dependencies` labeled PRs as in-scope infrastructure
+- **AC7:** Renovate schedule avoids active development hours (weekdays 6-8 AM UTC)
 
 ---
 

--- a/docs/stories/0.24.story.md
+++ b/docs/stories/0.24.story.md
@@ -1,0 +1,192 @@
+# Story 0.24: Renovate + Dependabot Automated Dependency Management
+
+## Story
+
+As the ThreeDoors maintainer,
+I want automated dependency management via Renovate (Go deps) and Dependabot (GitHub Actions),
+So that dependencies stay up to date with security as the top priority and minimal manual effort.
+
+**Status:** Not Started
+
+---
+
+## Background
+
+ThreeDoors has 20+ Go module dependencies (go.mod) and 8+ GitHub Actions references in CI workflows. Currently all dependency updates are manual. This creates risk of missed security patches and accumulating tech debt from outdated dependencies.
+
+**Party Mode Artifact:** `_bmad-output/planning-artifacts/dependency-management-party-mode.md`
+
+**Key Decision:** Renovate handles Go module dependencies (superior grouping, auto-merge, vulnerability scanning). Dependabot handles GitHub Actions version pinning (native ecosystem support, zero-config).
+
+---
+
+## Phase 1: Renovate Setup (Go Dependencies)
+
+### Acceptance Criteria
+
+- **AC1:** `renovate.json` exists at repo root with valid configuration
+- **AC2:** Renovate is enabled for `arcaven/ThreeDoors` repository (GitHub App installed or self-hosted configured)
+- **AC3:** Go module dependencies (`go.mod`/`go.sum`) are managed by Renovate
+- **AC4:** Patch updates are grouped into a single weekly PR (`chore(deps): patch updates`)
+- **AC5:** Charmbracelet ecosystem packages (bubbletea, lipgloss, bubbles, etc.) are grouped together
+- **AC6:** Security updates create individual PRs immediately (not batched)
+- **AC7:** Auto-merge enabled for patch updates when CI is green
+- **AC8:** Auto-merge enabled for minor updates of non-breaking dependencies when CI is green
+- **AC9:** Major version updates are never auto-merged; labeled `breaking-change`
+- **AC10:** Renovate schedule is weekdays only, 6-8 AM UTC batch window
+- **AC11:** OSV vulnerability scanning is enabled
+- **AC12:** PR descriptions include release notes / changelog extraction
+
+### Tasks
+
+- [ ] Install Renovate GitHub App on `arcaven/ThreeDoors` (or configure self-hosted)
+- [ ] Create `renovate.json` with:
+  - `extends: ["config:recommended"]` base
+  - Go module manager enabled
+  - GitHub Actions manager **disabled** (Dependabot handles this)
+  - Grouping rules: patch updates weekly, charmbracelet ecosystem together
+  - Security update rules: immediate, individual PRs
+  - Auto-merge rules: patch + non-breaking minor
+  - Schedule: weekdays 6-8 AM UTC
+  - Labels: `dependencies` on all PRs, `security` on vulnerability PRs
+  - OSV vulnerability alerts enabled
+  - Release notes extraction enabled
+- [ ] Verify first Renovate PR is created correctly (manual check)
+- [ ] Verify auto-merge works for a patch update (manual check)
+
+---
+
+## Phase 2: Dependabot Setup (GitHub Actions)
+
+### Acceptance Criteria
+
+- **AC13:** `.github/dependabot.yml` exists with valid configuration
+- **AC14:** GitHub Actions ecosystem is managed by Dependabot
+- **AC15:** Go modules ecosystem is **not** managed by Dependabot (Renovate handles this)
+- **AC16:** GitHub Actions updates are grouped into monthly PRs
+- **AC17:** Auto-merge enabled for GitHub Actions patch and minor updates when CI is green
+- **AC18:** Dependabot PRs are labeled `dependencies`
+
+### Tasks
+
+- [ ] Create `.github/dependabot.yml` with:
+  - `github-actions` ecosystem enabled, monthly schedule
+  - `gomod` ecosystem **omitted** (Renovate handles Go deps)
+  - Grouping: all actions updates in one PR
+  - Labels: `dependencies`
+- [ ] Verify Dependabot creates grouped Actions update PR (manual check)
+
+---
+
+## Phase 3: Merge-Queue Integration
+
+### Acceptance Criteria
+
+- **AC19:** Merge-queue agent recognizes `dependencies` labeled PRs as in-scope (Epic 0 infrastructure)
+- **AC20:** Auto-merged dependency PRs flow through normal CI and branch protection
+- **AC21:** No merge-queue contention from dependency PRs during active development hours
+- **AC22:** ROADMAP.md acknowledges dependency management as ongoing Epic 0 infrastructure
+
+### Tasks
+
+- [ ] Verify merge-queue agent accepts `dependencies` labeled PRs (check agent prompt/config)
+- [ ] Verify branch protection rules apply to Renovate/Dependabot PRs
+- [ ] Test that auto-merged PRs pass all CI gates (quality-gate, benchmarks, Docker E2E)
+- [ ] Document the dependency management flow in project docs if needed
+
+---
+
+## Configuration Reference
+
+### `renovate.json` (Phase 1)
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":automergeMinor",
+    "group:recommended"
+  ],
+  "schedule": ["before 8am on weekday"],
+  "timezone": "UTC",
+  "enabledManagers": ["gomod"],
+  "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security"]
+  },
+  "packageRules": [
+    {
+      "description": "Group all patch updates weekly",
+      "matchUpdateTypes": ["patch"],
+      "groupName": "patch updates",
+      "schedule": ["before 8am on monday"],
+      "automerge": true
+    },
+    {
+      "description": "Group charmbracelet ecosystem",
+      "matchPackagePatterns": ["^github\\.com/charmbracelet/"],
+      "groupName": "charmbracelet ecosystem"
+    },
+    {
+      "description": "Auto-merge minor updates",
+      "matchUpdateTypes": ["minor"],
+      "automerge": true
+    },
+    {
+      "description": "Never auto-merge major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "labels": ["dependencies", "breaking-change"]
+    },
+    {
+      "description": "Security updates: immediate, individual PRs",
+      "matchCategories": ["security"],
+      "groupName": null,
+      "schedule": ["at any time"],
+      "automerge": true,
+      "labels": ["dependencies", "security"]
+    }
+  ]
+}
+```
+
+### `.github/dependabot.yml` (Phase 2)
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+```
+
+---
+
+## Test Criteria
+
+- Renovate creates a valid onboarding PR or initial dependency update PR
+- Renovate groups patch updates into a single PR
+- Renovate creates individual PRs for security vulnerabilities
+- Auto-merge triggers for patch updates after CI passes
+- Dependabot creates grouped GitHub Actions update PR
+- All CI jobs (quality-gate, benchmarks, Docker E2E) pass on dependency update PRs
+- Merge-queue agent processes dependency PRs without errors
+
+## References
+
+- [Renovate Documentation](https://docs.renovatebot.com/)
+- [Renovate Go Module Manager](https://docs.renovatebot.com/modules/manager/gomod/)
+- [Dependabot Configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
+- [OSV Database](https://osv.dev/)
+- Party Mode: `_bmad-output/planning-artifacts/dependency-management-party-mode.md`
+- Related: Story 0.20 (CI Churn Reduction), Story 0.22 (Homebrew Audit), Story 0.23 (Homebrew Strict Audit)


### PR DESCRIPTION
## Summary

- Added Story 0.24 under Epic 0 (Infrastructure) for automated dependency management
- Created party mode planning artifact with adopted and rejected options for 8 discussion questions
- Updated epics-and-stories.md with new story and corrected counts (19/22)

### Key Decisions (from party mode)

- **Renovate** handles Go module dependencies (go.mod/go.sum) — grouping, auto-merge, OSV vulnerability scanning
- **Dependabot** handles GitHub Actions version pinning — native ecosystem support, monthly grouped PRs
- **Auto-merge policy:** patches + non-breaking minors auto-merge when CI green; majors require human review
- **Grouping:** weekly patch batch, charmbracelet ecosystem grouped, security updates individual
- **Schedule:** weekdays 6-8 AM UTC to avoid merge-queue contention

### Artifacts

| File | Description |
|------|-------------|
| `docs/stories/0.24.story.md` | Story with 3 phases, 22 ACs, config reference |
| `_bmad-output/planning-artifacts/dependency-management-party-mode.md` | Party mode with adopted + rejected options |
| `docs/prd/epics-and-stories.md` | Updated with Story 0.24 and corrected counts |

### Story Phases

1. **Phase 1:** Renovate setup (renovate.json, OSV scanning, grouping, auto-merge)
2. **Phase 2:** Dependabot setup (.github/dependabot.yml for GitHub Actions)
3. **Phase 3:** Merge-queue integration (labeling, flow verification)

## Opportunities (not implemented)

- SLSA verification could be added as a future hardening story
- Envoy agent notification for security PRs (deferred until agent exists)
- Custom notification workflow if security PRs accumulate without review

## Test plan

- [ ] Verify story file has clear ACs for all 3 phases
- [ ] Verify party mode artifact includes adopted AND rejected options
- [ ] Verify epics-and-stories.md counts are correct
- [ ] Verify no overlap between Renovate and Dependabot ecosystems