### PR TITLE
docs: research — persistent BMAD agent architecture for autonomous governance

### DIFF
--- a/_bmad-output/planning-artifacts/persistent-agent-architecture-round1-role-evaluation.md
+++ b/_bmad-output/planning-artifacts/persistent-agent-architecture-round1-role-evaluation.md
@@ -1,0 +1,66 @@
+# Party Mode Artifact: Persistent Agent Role Evaluation (Round 1)
+
+**Date:** 2026-03-08
+**Topic:** Which BMAD roles should become persistent multiclaude agents?
+**Participants:** John (PM), Winston (Architect), Bob (SM), Quinn (QA), Murat (TEA), Mary (Analyst), Paige (Tech Writer), Sally (UX Designer)
+
+## Adopted Approach
+
+### Persistent Agents (Always-On with Polling)
+
+1. **PM Agent ("project-watchdog")** — Strongest case
+   - **Monitor:** Merged PRs, story completion status, PRD alignment, ROADMAP.md accuracy, story sequencing
+   - **Trigger:** PR merge events (poll `gh pr list --state merged`), message from other agents
+   - **Authority:** Direct updates to story files, ROADMAP.md. Flag PRD drift. Message architect for cascading changes. Cannot create stories or modify code.
+   - **Polling interval:** Every 10-15 minutes
+   - **Rationale:** Every merged PR potentially drifts planning docs. This is the highest-frequency governance gap.
+
+2. **Architect Agent ("arch-watchdog")** — Second strongest case
+   - **Monitor:** Code changes in `internal/` vs architecture docs, new patterns introduced, architectural debt
+   - **Trigger:** Code changes detected in recent merges, messages from PM about PRD changes
+   - **Authority:** Direct updates to architecture docs. Flag code divergence via issues. Cannot refactor code directly.
+   - **Polling interval:** Every 20-30 minutes
+   - **Rationale:** Code-to-doc divergence accumulates silently. 210+ PRs means significant drift potential.
+
+### Cron/Periodic (Not Persistent)
+
+3. **SM (Sprint Health)** — Every 4 hours
+   - Sprint status summary: blocked stories, stale PRs, idle workers
+   - Overlaps significantly with merge-queue and pr-shepherd functions
+   - Value is in summarization, not continuous monitoring
+
+4. **QA/TEA (Coverage Audit)** — Weekly
+   - Run `go test -cover ./...`, compare to baseline
+   - Flag regressions to PM
+   - CI already catches per-PR issues; this catches trend drift
+
+5. **Tech Writer (Doc Staleness)** — Weekly
+   - Check last-modified dates vs code changes
+   - Flag docs that may be stale
+   - Low frequency of doc changes makes persistence wasteful
+
+### Stay Ephemeral (On-Demand Only)
+
+6. **Analyst** — Research sweeps are monthly at most; fold into PM's responsibilities
+7. **UX Designer** — CLI/TUI changes are story-driven, always ephemeral
+8. **Dev** — Always ephemeral, spawned per-story via `/implement-story`
+
+## Rejected Options
+
+### All Roles Persistent
+- **Why rejected:** Resource overhead (API costs, tmux sessions, compute) for 8+ persistent agents is untenable. Most roles don't generate enough monitoring events to justify always-on status.
+
+### SM as Persistent
+- **Why rejected:** Merge-queue and pr-shepherd already handle the mechanical aspects of process health (PR status, CI failures, rebasing). The SM's value is in periodic summarization, not continuous monitoring. A cron job every 4 hours provides equivalent value at 1/10th the cost.
+
+### QA as Persistent
+- **Why rejected:** CI runs on every PR and catches quality issues at the PR level. Persistent QA would mostly be idle. Coverage trend monitoring is a weekly concern, not a minute-by-minute one.
+
+### Analyst as Persistent
+- **Why rejected:** Research findings accumulate slowly (days/weeks between new research docs). A monthly sweep is sufficient. The PM can absorb this function as part of its monitoring loop.
+
+### Tech Writer as Persistent
+- **Why rejected:** Documentation drift happens over weeks, not hours. A weekly cron audit achieves the same result as persistence.
+
+### UX Designer as Persistent
+- **Why rejected:** Zero monitoring surface for a CLI/TUI project. UX decisions are made during story planning, not discovered through continuous monitoring.

--- a/_bmad-output/planning-artifacts/persistent-agent-architecture-round2-collaboration.md
+++ b/_bmad-output/planning-artifacts/persistent-agent-architecture-round2-collaboration.md
@@ -1,0 +1,79 @@
+# Party Mode Artifact: Agent Collaboration & Propagation Chain (Round 2)
+
+**Date:** 2026-03-08
+**Topic:** How should persistent BMAD agents collaborate?
+**Participants:** John (PM), Winston (Architect), Bob (SM), Murat (TEA)
+
+## Adopted Approach
+
+### Communication Model: Message-Driven Chain
+
+Agents communicate via `multiclaude message send`, not shared file polling. Each agent has an independent monitoring loop AND message reactivity.
+
+### Propagation Chain: PR Merge → Doc Cascade
+
+```
+PR Merged (detected by PM in polling loop)
+  │
+  ├── PM updates story status → Done (PR #NNN)
+  ├── PM updates ROADMAP.md → Epic progress
+  ├── PM checks PRD alignment
+  │     └── If PRD drift detected:
+  │           PM messages Architect: "PRD section X changed, verify architecture alignment"
+  │           └── Architect reviews architecture docs
+  │                 └── If architecture update needed:
+  │                       Architect updates docs directly
+  │                       Architect messages PM: "Architecture updated, stories may need tech note refresh"
+  │                       └── PM flags affected stories for next worker
+  │
+  └── merge-queue handles the merge itself (existing)
+```
+
+### Architect Independent Loop
+
+```
+Architect polls recent merges (every 20-30 min)
+  │
+  ├── Checks code changes in internal/ against docs/architecture/
+  │     └── If pattern divergence:
+  │           Opens GitHub issue with details
+  │           Messages PM: "Architecture drift detected, see issue #NNN"
+  │
+  └── Checks for undocumented new packages/interfaces
+        └── If found: flags for documentation
+```
+
+### Anti-Patterns Avoided
+
+1. **Circular notifications:** Each message includes a correlation ID (PR number). Agents skip already-processed PRs.
+2. **Authority creep:** PM edits planning docs. Architect edits architecture docs. Neither creates stories or modifies code — those require worker spawning.
+3. **Chatty agents:** Messages are sent only on state changes, never as status pings.
+
+### Authority Boundaries
+
+| Agent | Can Directly Edit | Must Spawn Worker | Must Escalate to Supervisor |
+|-------|-------------------|-------------------|----------------------------|
+| PM | Story files, ROADMAP.md | New story creation | Scope decisions, priority changes |
+| Architect | Architecture docs | Code refactoring | Design decision overrides |
+| SM (cron) | Sprint status doc | Nothing | Blocked items, risk alerts |
+| QA (cron) | Coverage reports | Test improvements | Coverage policy changes |
+
+### Cron-Based Agent Integration
+
+- **SM cron (every 4 hours):** Queries PR status, worker status, story progress. Generates summary. Messages supervisor if risks detected.
+- **QA cron (weekly):** Runs coverage analysis. Compares to baseline. Messages PM if regression detected.
+- Both can be implemented via `multiclaude` `/loop` skill or external cron.
+
+## Rejected Options
+
+### Shared File Protocol (agents write to a shared state file)
+- **Why rejected:** Race conditions in shared worktrees. Message passing is the established multiclaude pattern. File-based coordination adds complexity without benefit.
+
+### Event-Driven Architecture (webhook-based)
+- **Why rejected:** multiclaude doesn't support webhook triggers. Polling + messages is the available primitive. Over-engineering for the scale of this project.
+
+### Dense Agent Mesh (every agent talks to every other agent)
+- **Why rejected:** Combinatorial explosion. With N agents, N*(N-1) communication channels. The hub-and-spoke model (PM as hub) is simpler and sufficient.
+
+### PM as Single Hub for All Communication
+- **Why rejected (partially):** PM is the primary hub, but Architect needs an independent monitoring loop for code-level concerns that PM can't assess. Two independent loops with message bridges is better than one monolithic loop.

--- a/_bmad-output/planning-artifacts/persistent-agent-architecture-round3-mvp.md
+++ b/_bmad-output/planning-artifacts/persistent-agent-architecture-round3-mvp.md
@@ -1,0 +1,72 @@
+# Party Mode Artifact: MVP Persistent Agent Selection (Round 3)
+
+**Date:** 2026-03-08
+**Topic:** MVP — Top 2-3 persistent agents for maximum autonomous governance
+**Participants:** John (PM), Winston (Architect), Bob (SM), Murat (TEA), Mary (Analyst), Barry (Quick Flow)
+
+## Adopted Approach: Two New Persistent Agents
+
+### MVP: PM + Architect (Total: 5 Persistent Agents)
+
+Current persistent agents (3):
+1. merge-queue — merges PRs
+2. pr-shepherd — rebases branches
+3. envoy — issue triage
+
+**Add (2):**
+
+4. **project-watchdog (PM role)** — Planning-side governance
+   - Watches merged PRs, updates story status and ROADMAP.md
+   - Detects PRD drift
+   - Validates story sequencing
+   - Monthly research doc sweep (absorbs analyst function)
+   - Polling: every 10-15 minutes
+
+5. **arch-watchdog (Architect role)** — Implementation-side governance
+   - Watches code changes vs architecture docs
+   - Detects undocumented patterns
+   - Flags architectural debt
+   - Polling: every 20-30 minutes
+
+### Supporting Cron Jobs (Not Persistent)
+
+- **Sprint health (SM):** Every 4 hours via `/loop`
+- **Coverage audit (QA/TEA):** Weekly via cron or scheduled worker
+
+### Why Two, Not Three
+
+- 5 total persistent agents is manageable for compute/API cost
+- 6+ starts creating coordination overhead that outweighs governance value
+- The two selected agents cover the two most critical governance gaps: planning-side drift and implementation-side drift
+- Start with 2, observe for 2 weeks, add a third only if a clear gap emerges
+
+### Projected Impact
+
+| Problem | Solved By | Coverage |
+|---------|-----------|----------|
+| PRD drift unnoticed | project-watchdog | ~90% |
+| Architecture divergence | arch-watchdog | ~80% |
+| Stories out of sequence | project-watchdog | ~70% |
+| Research findings unactioned | project-watchdog (monthly sweep) | ~50% |
+| Test coverage regression | QA cron (weekly) | ~60% |
+| Doc staleness | Tech writer cron (weekly) | ~50% |
+| Sprint health blindness | SM cron (4-hourly) | ~70% |
+
+## Rejected Options
+
+### Three Persistent Agents (PM + Architect + SM)
+- **Why rejected:** SM's monitoring overlaps with merge-queue and pr-shepherd. The marginal value of persistent SM doesn't justify the resource cost. A 4-hourly cron achieves 70%+ of the value at minimal cost.
+
+### Three Persistent Agents (PM + Architect + QA)
+- **Why rejected:** QA monitoring is episodic (per-PR via CI, weekly via audit). No continuous monitoring surface justifies persistence. Weekly cron is sufficient and much cheaper.
+
+### One Persistent Agent (PM only)
+- **Why rejected:** Missing the code-to-docs feedback loop. The PM can't assess whether code changes comply with architecture docs — that requires architect domain knowledge. Without the architect agent, architectural drift continues unchecked.
+
+### Zero New Persistent Agents (All Cron-Based)
+- **Why rejected:** Cron jobs lack the contextual awareness and message-reactivity of persistent agents. A cron PM would miss the cascade: "PR merged → story updated → ROADMAP updated → PRD checked → architect notified" because each step depends on the previous. Persistent agents maintain state across these cascading checks.
+
+### Deferred for Future Evaluation
+- **Tech Writer persistent agent:** Revisit after 1 month if doc staleness remains a problem
+- **SM persistent agent:** Revisit if sprint health summaries from cron prove insufficient
+- **Analyst persistent agent:** Revisit if research doc backlog grows beyond PM's monthly sweep capacity

--- a/agents/arch-watchdog.md
+++ b/agents/arch-watchdog.md
@@ -1,0 +1,111 @@
+# Architecture Watchdog (Architect Governance Agent)
+
+You are the project's implementation-side watchdog. You continuously monitor for divergence between the codebase and its architecture documentation. You ensure that architectural decisions are followed and new patterns are documented.
+
+## Your Mission
+
+Ensure that the code in `internal/` and `cmd/` stays aligned with `docs/architecture/`. When new patterns, interfaces, or packages are introduced, they should be documented. When existing architecture decisions are violated, they should be flagged.
+
+**Your rhythm:**
+1. Poll for recently merged code PRs (`gh pr list --state merged --limit 10`)
+2. For each merged PR with code changes, check architecture alignment
+3. Compare new code patterns against documented architecture
+4. Flag undocumented patterns or architecture violations
+5. Update architecture docs when changes are straightforward
+6. React to messages from project-watchdog about PRD changes
+
+## Polling Loop
+
+**Interval:** Every 20-30 minutes
+
+```bash
+# Check recently merged PRs with code changes
+gh pr list --state merged --limit 10 --json number,title,mergedAt,headRefName,files
+
+# List architecture docs
+ls docs/architecture/*.md
+
+# Check for new packages/interfaces
+find internal/ -name "*.go" -newer docs/architecture/ -type f
+```
+
+### On Merged Code PR Detected
+
+1. Review the PR diff for architectural significance:
+   - New packages or interfaces introduced?
+   - New external dependencies added?
+   - Design patterns that differ from documented patterns?
+   - Changes to provider pattern, factory functions, or public APIs?
+2. Compare against architecture docs:
+   - `docs/architecture/coding-standards.md`
+   - `docs/architecture/` (other architecture docs)
+   - Design decisions documented in story files
+3. If divergence detected:
+   - **Minor:** Update architecture docs directly
+   - **Major:** Open GitHub issue with details, message project-watchdog and supervisor
+4. Track processed PRs to avoid re-processing
+
+## Architecture Checks
+
+### Pattern Compliance
+- Provider pattern followed for new storage backends?
+- Factory functions used for exported types?
+- Atomic writes for file persistence?
+- Bubbletea patterns for TUI output?
+
+### Code Organization
+- Package naming conventions followed?
+- File naming conventions followed?
+- Import order correct?
+- One primary type per file?
+
+### Interface Changes
+- New interfaces documented?
+- Existing interfaces modified without doc update?
+- Interface size reasonable (big interfaces = weak abstractions)?
+
+## Authority
+
+**CAN do directly:**
+- Update `docs/architecture/` files
+- Open GitHub issues for architecture divergence
+- Message project-watchdog and supervisor
+
+**CANNOT do — must spawn worker or escalate:**
+- Refactor code
+- Override design decisions
+- Modify story files or ROADMAP.md
+
+**ESCALATE to supervisor:**
+- Major architectural decisions that need human input
+- Design decision overrides
+- Significant technical debt accumulation
+
+## Message Handling
+
+**From project-watchdog:**
+- "PRD section X changed after PR #NNN, verify architecture alignment" → Review relevant architecture docs
+- "Story X.Y flagged for tech note refresh" → Check if architecture section needs update
+
+**To project-watchdog:**
+- "Architecture docs updated after PR #NNN, stories may need tech note refresh"
+- "Architecture drift detected in internal/foo/, see issue #NNN"
+
+**To supervisor:**
+- "New undocumented pattern in internal/foo/ introduced by PR #NNN"
+- "Architecture decision X violated by PR #NNN — details: ..."
+- "Significant architectural debt accumulating in package X"
+
+## Idempotency
+
+All checks are idempotent. Maintain a processed-PR list in memory. If a PR has been analyzed, skip it on subsequent polls.
+
+## What You Do NOT Do
+
+- Write application code or fix bugs
+- Merge PRs (that's merge-queue)
+- Rebase branches (that's pr-shepherd)
+- Triage issues (that's envoy)
+- Update story files or ROADMAP.md (that's project-watchdog)
+- Make scope decisions (that's supervisor)
+- Override architectural decisions without escalation

--- a/agents/project-watchdog.md
+++ b/agents/project-watchdog.md
@@ -1,0 +1,100 @@
+# Project Watchdog (PM Governance Agent)
+
+You are the project's planning-side watchdog. You continuously monitor for drift between what was planned and what was implemented. You keep the project's planning docs accurate and current.
+
+## Your Mission
+
+Ensure that story status, ROADMAP.md, and PRD stay aligned with actual merged work. When PRs merge, the planning docs should reflect reality — not lag behind by days or weeks.
+
+**Your rhythm:**
+1. Poll for recently merged PRs (`gh pr list --state merged --limit 10`)
+2. For each merged PR, check if it completes a story
+3. Update story file status → `Done (PR #NNN)`
+4. Update ROADMAP.md epic progress
+5. Check PRD for drift — does the merged work reveal gaps?
+6. Validate story sequencing — are dependencies being respected?
+7. Monthly: sweep `docs/research/` for unactioned recommendations
+8. React to messages from arch-watchdog about architecture changes
+
+## Polling Loop
+
+**Interval:** Every 10-15 minutes
+
+```bash
+# Check recently merged PRs
+gh pr list --state merged --limit 10 --json number,title,mergedAt,headRefName
+
+# Compare against story files
+ls docs/stories/*.story.md
+
+# Check ROADMAP.md last update
+git log -1 --format="%ci" ROADMAP.md
+```
+
+### On Merged PR Detected
+
+1. Identify which story the PR relates to (from branch name or PR title)
+2. Read the story file — check if status needs updating
+3. If story complete:
+   - Update story file: `Status: Done (PR #NNN)`
+   - Update ROADMAP.md: increment epic progress
+   - Check PRD: does completion reveal drift?
+4. If PRD drift detected:
+   - Message arch-watchdog: `"PRD section X may need architecture review after PR #NNN"`
+5. Track processed PRs to avoid re-processing (use correlation ID = PR number)
+
+## Authority
+
+**CAN do directly:**
+- Update story file status fields
+- Update ROADMAP.md epic progress counts
+- Flag PRD sections that may be drifting
+- Message other agents (arch-watchdog, supervisor)
+
+**CANNOT do — must spawn worker or escalate:**
+- Create new stories
+- Modify code
+- Make scope decisions
+- Update ROADMAP.md scope/priorities (supervisor only)
+
+**ESCALATE to supervisor:**
+- Stories out of sequence (dependency violations)
+- PRD drift requiring significant rewrite
+- Scope questions
+- Priority changes
+
+## Monthly Research Sweep
+
+Once per month (or when idle for extended periods):
+1. List all files in `docs/research/`
+2. Check each for unactioned recommendations
+3. Cross-reference against ROADMAP.md and story files
+4. Report unactioned items to supervisor
+
+## Message Handling
+
+**From arch-watchdog:**
+- "Architecture updated, stories may need tech note refresh" → Flag affected stories
+- "Architecture drift detected, see issue #NNN" → Cross-reference against PRD
+
+**To arch-watchdog:**
+- "PRD section X changed after PR #NNN, verify architecture alignment"
+
+**To supervisor:**
+- "Story X.Y status updated to Done (PR #NNN)"
+- "PRD drift detected in section X — details: ..."
+- "Dependency violation: story X.Y started before X.Z completed"
+- "Monthly research sweep: N unactioned recommendations found"
+
+## Idempotency
+
+All updates are idempotent. If a PR has already been processed (story already marked Done, ROADMAP already updated), skip it. Maintain a processed-PR list in memory during the session.
+
+## What You Do NOT Do
+
+- Write code or fix bugs
+- Merge PRs (that's merge-queue)
+- Rebase branches (that's pr-shepherd)
+- Triage issues (that's envoy)
+- Create stories without supervisor approval
+- Modify ROADMAP.md scope or priorities

--- a/docs/research/persistent-agent-architecture-research.md
+++ b/docs/research/persistent-agent-architecture-research.md
@@ -1,0 +1,325 @@
+# Persistent BMAD Agent Architecture for Autonomous Project Governance
+
+## 1. Executive Summary
+
+This research evaluates which BMAD roles should become persistent multiclaude agents to make the ThreeDoors project more self-governing. Currently, 3 persistent agents handle operational concerns (merge-queue, pr-shepherd, envoy), but core governance functions — PRD alignment, architecture compliance, story sequencing, coverage monitoring — only happen when the supervisor manually dispatches them.
+
+**Recommendation:** Add **two** persistent agents:
+1. **project-watchdog** (PM role) — monitors planning-side drift
+2. **arch-watchdog** (Architect role) — monitors implementation-side drift
+
+Plus **two cron jobs** for lower-frequency monitoring:
+- Sprint health (SM role) — every 4 hours
+- Coverage audit (QA/TEA role) — weekly
+
+Everything else stays ephemeral.
+
+---
+
+## 2. Current Agent Landscape
+
+### Persistent Agents (Always-On)
+
+| Agent | Role | Key Functions |
+|-------|------|---------------|
+| merge-queue | Merge PRs | CI validation, roadmap scope check, squash merge, emergency mode |
+| pr-shepherd | Branch maintenance | Rebase branches, resolve conflicts, keep PRs up-to-date |
+| envoy | Community liaison | Issue triage, reporter communication, cross-check merges vs issues |
+
+### Ephemeral Agents (On-Demand)
+
+| Agent | Role | Invocation Pattern |
+|-------|------|--------------------|
+| worker | Story implementation | Spawned per-story via `/implement-story` or `multiclaude work` |
+| reviewer | Code review | Spawned per-PR via `multiclaude review` |
+| release-manager | Release recovery | Spawned when release issues detected |
+
+### BMAD Roles (Currently Interactive Only)
+
+| Agent | Name | Key Capabilities |
+|-------|------|-------------------|
+| PM | John | PRD creation, requirements, stakeholder alignment |
+| SM | Bob | Sprint planning, story preparation, agile ceremonies |
+| Architect | Winston | System design, API design, scalable patterns |
+| QA | Quinn | Test automation, coverage analysis |
+| TEA | Murat | Risk-based testing, quality gates, CI governance |
+| Dev | Amelia | Story execution, TDD |
+| Analyst | Mary | Market research, competitive analysis, requirements |
+| Tech Writer | Paige | Documentation, diagrams, standards |
+| UX Designer | Sally | User research, interaction design |
+
+---
+
+## 3. Governance Gaps Analysis
+
+| Gap | Impact | Frequency | Current Mitigation |
+|-----|--------|-----------|-------------------|
+| PRD drift after implementation | High — planning docs diverge from reality | Every merged PR | Manual supervisor audit |
+| Architecture doc divergence | High — new patterns undocumented | Every code PR | None |
+| Story status not updated | Medium — ROADMAP.md stale | Every story completion | Manual supervisor update |
+| Story sequencing violations | Medium — dependencies broken | When multiple stories active | Supervisor monitors |
+| Test coverage regression | Medium — quality degrades silently | Per-PR (caught by CI), trends (not caught) | CI per-PR only |
+| Documentation staleness | Low — docs drift over weeks | Weekly/monthly | None |
+| Research findings unactioned | Low — recommendations ignored | Monthly | None |
+| Sprint health blindness | Medium — blocked work unnoticed | Continuous | Supervisor monitors manually |
+
+---
+
+## 4. Role-by-Role Persistence Evaluation
+
+### PM Agent → **PERSISTENT** (project-watchdog)
+
+**Monitoring Surface:**
+- Recently merged PRs (`gh pr list --state merged --limit 10`)
+- Story files in `docs/stories/` — status alignment with merged PRs
+- ROADMAP.md — epic progress accuracy
+- PRD — drift detection against implemented features
+- Story sequencing — dependency violations
+
+**Trigger Model:**
+- Primary: Polling every 10-15 minutes for merged PRs
+- Secondary: Messages from arch-watchdog about architecture changes
+- Tertiary: Monthly sweep of `docs/research/` for unactioned recommendations
+
+**Authority:**
+- CAN: Update story file status, update ROADMAP.md progress, flag PRD drift
+- CANNOT: Create new stories, modify code, make scope decisions
+- ESCALATES: Scope changes, priority changes → supervisor
+
+**Cost Justification:** Fixes the #1 governance gap (PRD/story drift). Every merged PR should trigger doc updates. Without persistent PM, this only happens when supervisor remembers. With 8 active epics and regular merges, this gap costs hours of manual reconciliation.
+
+### Architect Agent → **PERSISTENT** (arch-watchdog)
+
+**Monitoring Surface:**
+- Code changes in `internal/` and `cmd/` against `docs/architecture/`
+- New interfaces, packages, or patterns introduced in recent merges
+- Architectural decision records — are they being followed?
+
+**Trigger Model:**
+- Primary: Polling every 20-30 minutes for merged code PRs
+- Secondary: Messages from project-watchdog about PRD changes affecting architecture
+- Tertiary: Periodic scan for undocumented patterns
+
+**Authority:**
+- CAN: Update architecture docs, open GitHub issues for divergence
+- CANNOT: Refactor code, override design decisions
+- ESCALATES: Design decision overrides, major architectural changes → supervisor
+
+**Cost Justification:** Fixes the #2 governance gap (code-to-doc divergence). With 210+ PRs merged, some patterns have inevitably drifted from docs. Without persistent monitoring, this only gets caught during story planning when someone reads stale architecture docs.
+
+### SM Agent → **CRON** (every 4 hours)
+
+**Why not persistent:** Merge-queue and pr-shepherd already handle the mechanical aspects of process health (PR merging, branch rebasing). The SM's value is in periodic summarization and risk surfacing, not continuous monitoring. A 4-hourly cron achieves ~70% of persistent value at ~10% of the cost.
+
+**Cron Tasks:**
+- Query open PRs for staleness (>24h without activity)
+- Check for blocked stories (dependencies unmet)
+- Summarize worker activity (active, idle, stuck)
+- Report to supervisor if risks detected
+
+### QA/TEA Agent → **CRON** (weekly)
+
+**Why not persistent:** CI runs tests on every PR. Per-PR quality is already gated. What's missing is trend analysis — is overall coverage declining? Are test files growing bloated? This is a weekly concern, not minute-by-minute.
+
+**Cron Tasks:**
+- Run `go test -cover ./...` and compare to baseline
+- Check test-to-code ratio trends
+- Flag packages with declining coverage
+- Report to PM if regression detected
+
+### Tech Writer → **EPHEMERAL**
+
+**Why not persistent or cron:** Doc changes are story-driven and infrequent. A weekly staleness check could be folded into the PM's monitoring loop or run as an occasional cron job. Doesn't justify even periodic automation at current project scale.
+
+### Analyst → **EPHEMERAL**
+
+**Why not persistent:** Research docs accumulate slowly. The PM's monthly sweep of `docs/research/` covers the unactioned-recommendations concern. Analyst remains available on-demand for deep research tasks.
+
+### UX Designer → **EPHEMERAL**
+
+**Why not persistent:** Zero continuous monitoring surface for a CLI/TUI project. UX decisions are made during story planning, not discovered through monitoring.
+
+### Dev → **EPHEMERAL**
+
+**Why not persistent:** Dev agents are inherently task-scoped. They implement a story, create a PR, and complete. No monitoring function.
+
+---
+
+## 5. Agent Interaction Architecture
+
+### Communication Model
+
+Agents communicate via `multiclaude message send` — the established multiclaude primitive. No shared state files, no webhooks, no custom protocols.
+
+### Interaction Diagram
+
+```
+                    ┌─────────────────┐
+                    │   supervisor    │
+                    │  (human/agent)  │
+                    └────────┬────────┘
+                             │ escalations
+                    ┌────────┴────────┐
+                    │                 │
+         ┌─────────▼──────┐  ┌──────▼─────────┐
+         │ project-watchdog│  │  arch-watchdog  │
+         │  (PM - persist) │  │ (Arch - persist)│
+         │                 │  │                 │
+         │ Monitors:       │  │ Monitors:       │
+         │ - Merged PRs    │◄─┤ - Code changes  │
+         │ - Story status  │──►- Arch docs      │
+         │ - ROADMAP.md    │  │ - New patterns   │
+         │ - PRD alignment │  │ - Design records │
+         └────────┬────────┘  └──────┬─────────┘
+                  │                   │
+         ┌────────┴───────────────────┴────────┐
+         │           Message Bus               │
+         │    (multiclaude message send)        │
+         └────────┬───────────────────┬────────┘
+                  │                   │
+    ┌─────────────▼──┐          ┌─────▼──────────┐
+    │  merge-queue    │          │  pr-shepherd   │
+    │  (persist)      │          │  (persist)     │
+    │  Merges PRs     │          │  Rebases PRs   │
+    └─────────────────┘          └────────────────┘
+                  │
+    ┌─────────────▼──┐
+    │    envoy        │
+    │  (persist)      │
+    │  Issue triage   │
+    └─────────────────┘
+
+    ┌─────────────────┐          ┌────────────────┐
+    │  SM cron (4h)   │          │ QA cron (weekly)│
+    │  Sprint health  │          │ Coverage audit  │
+    └─────────────────┘          └────────────────┘
+```
+
+### Message Flow: PR Merge Cascade
+
+```
+1. merge-queue merges PR #NNN
+   │
+2. project-watchdog detects merge (polling)
+   ├── Updates story X.Y status → "Done (PR #NNN)"
+   ├── Updates ROADMAP.md epic progress
+   ├── Checks PRD alignment
+   │   └── If drift: messages arch-watchdog
+   │         └── arch-watchdog reviews architecture docs
+   │             └── If update needed: updates docs, messages project-watchdog
+   │                 └── project-watchdog flags affected stories
+   │
+3. envoy cross-checks open issues
+   └── If PR fixes open issue: comments and closes
+```
+
+### Anti-Patterns and Safeguards
+
+1. **Circular notification prevention:** Each message includes the triggering PR number as correlation ID. Agents skip PRs they've already processed.
+
+2. **Authority boundaries enforced:**
+   - project-watchdog: edits docs/stories/, ROADMAP.md only
+   - arch-watchdog: edits docs/architecture/ only
+   - Neither modifies code — that requires worker spawning
+
+3. **Rate limiting:** Polling intervals prevent API spam:
+   - project-watchdog: 10-15 min
+   - arch-watchdog: 20-30 min
+   - Neither polls more frequently than once per 10 minutes
+
+4. **Idempotency:** All updates are idempotent. Re-processing a PR produces the same result.
+
+---
+
+## 6. Practical Considerations
+
+### Resource Budget (5 Persistent Agents)
+
+| Agent | Poll Interval | Estimated API Calls/Hour | Notes |
+|-------|---------------|--------------------------|-------|
+| merge-queue | 5-10 min | 6-12 | Existing |
+| pr-shepherd | 10-15 min | 4-6 | Existing |
+| envoy | 15-20 min | 3-4 | Existing |
+| project-watchdog | 10-15 min | 4-6 | New |
+| arch-watchdog | 20-30 min | 2-3 | New |
+| **Total** | | **19-31/hour** | |
+
+Adding the cron jobs:
+- SM (every 4h): ~6/day
+- QA (weekly): ~1/week
+
+### tmux Session Management
+
+5 persistent agents = 5 tmux windows. multiclaude manages these natively. Each agent has its own worktree, preventing file conflicts.
+
+### Scaling Limits
+
+- **Recommended max:** 6-7 persistent agents before coordination overhead dominates
+- **Current proposal:** 5 persistent agents — well within limits
+- **If adding more:** Evaluate whether consolidation (merging roles into fewer agents) is better than adding agents
+
+### Cron Implementation Options
+
+1. **`/loop` skill:** `multiclaude` has a `/loop` command for recurring tasks
+2. **System cron:** `crontab -e` for scheduled `multiclaude work` commands
+3. **Supervisor-dispatched:** Supervisor manually runs periodic audits
+   - Recommended: `/loop` for SM, system cron for QA (weekly is too long for `/loop`)
+
+---
+
+## 7. Implementation Roadmap
+
+### Phase 1: MVP (Week 1)
+
+1. Create `agents/project-watchdog.md` agent definition
+2. Create `agents/arch-watchdog.md` agent definition
+3. Spawn both via `multiclaude agents spawn`
+4. Set up SM cron: `/loop 4h /bmad-bmm-sprint-status`
+5. Monitor for 1 week, adjust polling intervals
+
+### Phase 2: Tuning (Week 2-3)
+
+1. Review agent logs for excessive polling or missed events
+2. Adjust polling intervals based on actual merge frequency
+3. Add QA weekly cron
+4. Evaluate whether a third persistent agent is needed
+
+### Phase 3: Evaluation (Week 4)
+
+1. Measure governance gap closure (story status accuracy, ROADMAP freshness, architecture doc currency)
+2. Decide whether to promote SM or QA to persistent
+3. Document lessons learned
+
+---
+
+## 8. Draft Agent Definitions
+
+See companion files:
+- `agents/project-watchdog.md` — PM-based planning governance agent
+- `agents/arch-watchdog.md` — Architect-based implementation governance agent
+
+---
+
+## 9. Party Mode Artifacts
+
+Three rounds of multi-agent deliberation are documented at:
+- `_bmad-output/planning-artifacts/persistent-agent-architecture-round1-role-evaluation.md`
+- `_bmad-output/planning-artifacts/persistent-agent-architecture-round2-collaboration.md`
+- `_bmad-output/planning-artifacts/persistent-agent-architecture-round3-mvp.md`
+
+---
+
+## 10. Key Decisions Summary
+
+| Decision | Adopted | Rejected Alternatives |
+|----------|---------|----------------------|
+| Number of new persistent agents | 2 (PM + Architect) | 0, 1, 3, or all roles |
+| Communication model | Message-driven (`multiclaude message send`) | Shared files, webhooks, dense mesh |
+| PM persistence | Yes (project-watchdog) | Cron-only, ephemeral |
+| Architect persistence | Yes (arch-watchdog) | Cron-only, ephemeral |
+| SM persistence | No → 4-hourly cron | Persistent agent |
+| QA persistence | No → weekly cron | Persistent agent |
+| Tech Writer persistence | No → ephemeral | Persistent, cron |
+| Analyst persistence | No → absorbed by PM | Persistent, cron |
+| Hub topology | PM as primary hub, Architect as independent loop | Dense mesh, single hub |
+| Circular notification prevention | Correlation ID per PR | Cooldown timers, blacklists |


### PR DESCRIPTION
## Summary

- Researches which BMAD roles (PM, SM, Architect, QA, TEA, Tech Writer, Analyst, UX Designer) should become persistent multiclaude agents for autonomous project governance
- Evaluates each role against monitoring surface, trigger frequency, authority boundaries, and resource cost
- Conducts three rounds of party mode deliberation with all BMAD agents
- Provides draft agent definitions for the recommended persistent agents

## Recommendation

**Add 2 new persistent agents (total: 5 persistent):**
1. **project-watchdog** (PM role) — monitors merged PRs, updates story status and ROADMAP.md, detects PRD drift, validates story sequencing. Polls every 10-15 min.
2. **arch-watchdog** (Architect role) — monitors code changes vs architecture docs, flags undocumented patterns, detects architectural debt. Polls every 20-30 min.

**Plus 2 cron jobs:**
- Sprint health (SM) — every 4 hours
- Coverage audit (QA/TEA) — weekly

**Everything else stays ephemeral** — Analyst, UX Designer, Dev, Tech Writer invoked on demand.

## Deliverables

| File | Description |
|------|-------------|
| `docs/research/persistent-agent-architecture-research.md` | Full research document with analysis, interaction diagram, implementation roadmap |
| `_bmad-output/planning-artifacts/persistent-agent-architecture-round1-role-evaluation.md` | Party mode Round 1: role-by-role persistence evaluation |
| `_bmad-output/planning-artifacts/persistent-agent-architecture-round2-collaboration.md` | Party mode Round 2: collaboration and propagation chain design |
| `_bmad-output/planning-artifacts/persistent-agent-architecture-round3-mvp.md` | Party mode Round 3: MVP selection with rejected alternatives |
| `agents/project-watchdog.md` | Draft agent definition for PM-based planning governance |
| `agents/arch-watchdog.md` | Draft agent definition for Architect-based implementation governance |

## Key Design Decisions

- **Message-driven communication** via `multiclaude message send` (not shared files or polling)
- **Correlation ID per PR** to prevent circular notification loops
- **Authority boundaries**: project-watchdog edits planning docs, arch-watchdog edits architecture docs, neither modifies code
- **Two persistent agents is the sweet spot** — 6+ creates coordination overhead that outweighs governance value

## Opportunities (Not Implemented)

- SM could be promoted to persistent if 4-hourly cron proves insufficient
- Tech Writer periodic doc staleness audit could be added as a cron job
- The project-watchdog could absorb a quarterly strategic review function
- Agent definitions could be enhanced with specific `gh api` commands for richer monitoring

## Test plan

- [ ] Review research document for completeness and accuracy
- [ ] Validate party mode artifacts capture adopted AND rejected options
- [ ] Review draft agent definitions against existing agent patterns (envoy, merge-queue)
- [ ] Verify agent authority boundaries don't overlap with existing agents