### PR TITLE
docs: decisions board planning — stories and artifacts

### DIFF
--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-decisions-board.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-decisions-board.md
@@ -1,0 +1,98 @@
+# Sprint Change Proposal: Knowledge Decisions Board
+
+**Date:** 2026-03-08
+**Trigger:** Research complete (PR #235) — decision management strategy ready for implementation
+**Scope:** Minor — add 3 stories to Epic 0 (Infrastructure)
+**Change Type:** Direct Adjustment (add stories to existing epic)
+
+## 1. Issue Summary
+
+Decisions across ThreeDoors are scattered across 5+ locations (ADRs, research docs, party mode artifacts, story files, PR comments). Completed research has no decision artifact trail. Rejected options get re-proposed because no one recorded why they were rejected. Workers lack context on prior decisions.
+
+Research (PR #235, `docs/research/decision-management-research.md`) evaluated 6 approaches and party mode consensus (`_bmad-output/planning-artifacts/decision-management-party-mode.md`) adopted a three-component system:
+
+1. **Knowledge Board** (`docs/decisions/BOARD.md`) — kanban-style columns tracking decision lifecycle
+2. **Standardized Artifact Endings** — all party mode artifacts get a Decisions Summary table
+3. **Board Hygiene Sweep** — periodic scan for unindexed decisions
+
+## 2. Impact Analysis
+
+### Epic Impact
+- **Epic 0 (Infrastructure):** Add 3 new stories (0.25, 0.26, 0.27). Epic moves from 19/20 to 19/23 (with 0.20 still not started).
+- **All other epics:** No impact. This is orthogonal process infrastructure.
+
+### Artifact Impact
+- **CLAUDE.md:** Add one instruction line to check BOARD.md before implementing
+- **PRD:** No changes needed
+- **Architecture:** No changes — this is docs/process infrastructure, not code architecture
+- **UI/UX:** No impact
+
+### Technical Impact
+- **No code changes.** All deliverables are markdown documentation files.
+- **No CI/CD impact.** No tests to add for documentation.
+
+## 3. Recommended Approach
+
+**Direct Adjustment** — add 3 stories to Epic 0:
+
+| Story | Title | Effort | Risk |
+|-------|-------|--------|------|
+| 0.25 | Knowledge Decisions Board — Create & Seed | Low | Low |
+| 0.26 | Artifact Format Standardization & Backfill | Medium | Low |
+| 0.27 | Board Hygiene Sweep Process | Low | Low |
+
+**Rationale:** Research is complete, consensus is clear, deliverables are well-defined documentation. No architectural risk. Stories are independent of all other active epics.
+
+**Alternatives considered:**
+- Single large story: Rejected — too much scope for one PR, harder to review
+- Five granular stories: Rejected — unnecessary ceremony for docs-only work
+
+## 4. Detailed Change Proposals
+
+### Story 0.25: Knowledge Decisions Board — Create & Seed
+
+**Deliverables:**
+- Create `docs/decisions/BOARD.md` with kanban columns (Open Questions, Active Research, Pending Recommendations, Decided, Rejected, Superseded)
+- Seed "Decided" column from all 28 existing ADRs
+- Add CLAUDE.md instruction: "Before implementing, check `docs/decisions/BOARD.md` for relevant prior decisions"
+- Create `docs/decisions/README.md` explaining the board system
+
+### Story 0.26: Artifact Format Standardization & Backfill
+
+**Deliverables:**
+- Define standardized Decisions Summary table format for party mode artifacts
+- Backfill board entries from existing ~46 party mode artifacts (extract decisions into board)
+- Backfill board entries from research docs that contain recommendations
+- Update standing orders for party mode artifact format
+
+### Story 0.27: Board Hygiene Sweep Process
+
+**Deliverables:**
+- Define sweep process: what to scan, what to flag, frequency
+- Create sweep task definition (runnable as BMAD task or `/loop`)
+- Document sweep outputs and escalation paths
+- Add sweep schedule to standing orders
+
+## 5. Implementation Handoff
+
+**Scope classification:** Minor — direct implementation by workers via `/implement-story`
+
+**Handoff:**
+- Stories 0.25-0.27 can be implemented sequentially by workers
+- No PO/SM coordination needed — these are process docs
+- No architect involvement needed — no code architecture impact
+- Supervisor updates ROADMAP.md Epic 0 count after merge
+
+**Success criteria:**
+- BOARD.md exists with all 28 ADR entries seeded
+- Workers can find prior decisions by reading BOARD.md
+- Party mode artifacts have standardized endings
+- Sweep process is defined and documented
+
+## Decisions Summary
+
+| Decision | Status | Rationale | Alternatives Rejected |
+|----------|--------|-----------|----------------------|
+| 3 stories under Epic 0 | Adopted | Right granularity for docs-only work | Single story (too big), 5 stories (too granular) |
+| Sequential implementation | Adopted | 0.26 depends on 0.25 (board must exist for backfill) | Parallel (dependency conflict) |
+| No code changes | Adopted | Process infrastructure is docs-only | Adding tooling (against project philosophy) |

--- a/docs/stories/0.25.story.md
+++ b/docs/stories/0.25.story.md
@@ -1,0 +1,72 @@
+# Story 0.25: Knowledge Decisions Board — Create & Seed
+
+## Story
+
+As the ThreeDoors development team,
+I want a centralized Knowledge Decisions Board tracking the lifecycle of all project decisions,
+So that workers can find prior decisions, rejected options, and active research in one place before implementing.
+
+**Status:** Not Started
+
+---
+
+## Background
+
+Decisions across ThreeDoors are scattered across 5+ locations (28 ADRs, 21 research docs, 46 party mode artifacts, 135 story files, 210+ PR descriptions). Completed research has no decision artifact trail. Rejected options get re-proposed because no one recorded why they were rejected.
+
+**Research:** `docs/research/decision-management-research.md` (PR #235)
+**Party Mode Artifact:** `_bmad-output/planning-artifacts/decision-management-party-mode.md`
+
+**Key Decision:** Knowledge Board (`docs/decisions/BOARD.md`) as central dashboard — kanban-style columns tracking decision lifecycle. ADRs remain the permanent archive for significant architectural decisions; the board is the living dashboard that ties everything together.
+
+---
+
+## Acceptance Criteria
+
+- **AC1:** `docs/decisions/BOARD.md` exists with kanban-style column structure (Open Questions, Active Research, Pending Recommendations, Decided, Rejected, Superseded)
+- **AC2:** Each column uses a markdown table with standardized fields (ID, Title/Description, Date, Owner/Source, Link)
+- **AC3:** All 28 existing ADRs are seeded into the "Decided" column with correct IDs, titles, dates, and links
+- **AC4:** Items use a consistent ID scheme: `Q-NNN` (questions), `R-NNN` (research), `P-NNN` (pending), `D-NNN` (decided), `X-NNN` (rejected)
+- **AC5:** `docs/decisions/README.md` exists explaining the board system, ID scheme, column meanings, and how to propose entries
+- **AC6:** CLAUDE.md includes instruction: "Before implementing, check `docs/decisions/BOARD.md` for relevant prior decisions, rejected options, and active research"
+- **AC7:** Board references the decision management research as its founding decision (self-referential entry)
+- **AC8:** `docs/ADRs/README.md` cross-references the decisions board for non-ADR decisions
+
+## Tasks
+
+- [ ] Create `docs/decisions/` directory
+- [ ] Create `docs/decisions/BOARD.md` with column structure and table templates
+- [ ] Read all 28 ADRs and extract: title, date, status, brief rationale
+- [ ] Seed "Decided" column with all 28 ADR entries (D-001 through D-028)
+- [ ] Add self-referential entry: the decision to create the board itself
+- [ ] Create `docs/decisions/README.md` with:
+  - Board purpose and philosophy
+  - Column definitions and lifecycle flow
+  - ID scheme explanation
+  - How to propose new entries (via PR)
+  - Relationship to ADRs
+- [ ] Add board-checking instruction to CLAUDE.md (one line in appropriate section)
+- [ ] Add cross-reference from `docs/ADRs/README.md` to the decisions board
+- [ ] Verify board renders correctly in GitHub markdown
+
+---
+
+## Test Criteria
+
+- BOARD.md contains exactly 28+ entries in the "Decided" column (one per ADR minimum)
+- All ADR links in the board resolve correctly
+- CLAUDE.md contains the board-checking instruction
+- Board column tables have consistent formatting
+- README.md accurately describes the board system
+- `make lint` passes (no code changes, but verify no CLAUDE.md formatting issues)
+
+## Dependencies
+
+- None — this is the foundation for stories 0.26 and 0.27
+
+## References
+
+- Research: `docs/research/decision-management-research.md` (PR #235)
+- Party Mode: `_bmad-output/planning-artifacts/decision-management-party-mode.md`
+- Sprint Change Proposal: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-decisions-board.md`
+- Existing ADRs: `docs/ADRs/` (28 records)

--- a/docs/stories/0.26.story.md
+++ b/docs/stories/0.26.story.md
@@ -1,0 +1,99 @@
+# Story 0.26: Artifact Format Standardization & Board Backfill
+
+## Story
+
+As the ThreeDoors development team,
+I want party mode artifacts to have standardized Decisions Summary tables and existing decisions backfilled into the board,
+So that all past and future decisions are discoverable through the Knowledge Decisions Board.
+
+**Status:** Not Started
+
+---
+
+## Background
+
+The Knowledge Decisions Board (Story 0.25) provides the structure. This story populates it with historical decisions from existing artifacts and ensures future artifacts maintain a consistent format that makes extraction mechanical.
+
+Currently ~46 party mode artifacts exist in `_bmad-output/planning-artifacts/`. Some include "Key Decisions" or "Decisions Summary" tables (inconsistent format), others embed decisions inline without a summary. Research docs in `docs/research/` (21 files) contain recommendations that should be tracked on the board.
+
+**Research:** `docs/research/decision-management-research.md` (PR #235)
+**Party Mode Artifact:** `_bmad-output/planning-artifacts/decision-management-party-mode.md`
+
+---
+
+## Phase 1: Artifact Format Standardization
+
+### Acceptance Criteria
+
+- **AC1:** Standardized Decisions Summary table format is documented in `docs/decisions/README.md`:
+  ```markdown
+  ## Decisions Summary
+  | Decision | Status | Rationale | Alternatives Rejected |
+  |----------|--------|-----------|----------------------|
+  ```
+- **AC2:** Standing orders in supervisor memory include requirement for Decisions Summary table in all party mode artifacts
+- **AC3:** At least 3 existing party mode artifacts are updated to use the standardized format as exemplars
+
+### Tasks
+
+- [ ] Define the canonical Decisions Summary table format
+- [ ] Update `docs/decisions/README.md` with artifact format requirements
+- [ ] Identify 3 representative artifacts to update as exemplars (different types: sprint change, architecture, consensus)
+- [ ] Update the 3 exemplar artifacts with standardized Decisions Summary tables
+
+---
+
+## Phase 2: Board Backfill from Party Mode Artifacts
+
+### Acceptance Criteria
+
+- **AC4:** All party mode artifacts with extractable decisions have corresponding entries in BOARD.md
+- **AC5:** Entries include: ID, decision title, date, source artifact link, status (Decided/Rejected)
+- **AC6:** Rejected approaches from party mode artifacts are captured in the "Rejected" column
+- **AC7:** No duplicate entries — decisions already captured via ADR seeding (Story 0.25) are not re-added
+
+### Tasks
+
+- [ ] Scan all ~46 party mode artifacts for decisions (adopted and rejected)
+- [ ] Extract decisions into board entries with proper IDs (continuing from Story 0.25's numbering)
+- [ ] Add entries to appropriate BOARD.md columns (Decided, Rejected)
+- [ ] Cross-reference: link board entries back to source artifacts
+- [ ] Deduplicate against existing ADR-seeded entries
+
+---
+
+## Phase 3: Board Backfill from Research Docs
+
+### Acceptance Criteria
+
+- **AC8:** Research docs with recommendations have corresponding board entries
+- **AC9:** Research docs without clear conclusions are captured as "Pending Recommendations" or "Open Questions"
+- **AC10:** All entries link to the source research document
+
+### Tasks
+
+- [ ] Scan `docs/research/` for files with recommendations or conclusions
+- [ ] Create board entries for each (Decided, Pending Recommendation, or Open Question as appropriate)
+- [ ] Verify no overlap with ADR-seeded or artifact-backfilled entries
+
+---
+
+## Test Criteria
+
+- BOARD.md has significantly more entries after backfill (target: 50+ total)
+- All backfilled entries have valid links to source documents
+- No duplicate entries across ADR seeds, artifact backfill, and research backfill
+- 3 exemplar artifacts have standardized Decisions Summary tables
+- `docs/decisions/README.md` documents the standardized format
+
+## Dependencies
+
+- Story 0.25 (Knowledge Decisions Board must exist before backfill)
+
+## References
+
+- Research: `docs/research/decision-management-research.md` (PR #235)
+- Party Mode: `_bmad-output/planning-artifacts/decision-management-party-mode.md`
+- Sprint Change Proposal: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-decisions-board.md`
+- Existing artifacts: `_bmad-output/planning-artifacts/` (~46 files)
+- Existing research: `docs/research/` (~21 files)

--- a/docs/stories/0.27.story.md
+++ b/docs/stories/0.27.story.md
@@ -1,0 +1,70 @@
+# Story 0.27: Board Hygiene Sweep Process
+
+## Story
+
+As the ThreeDoors supervisor,
+I want a defined board hygiene sweep process that periodically identifies unindexed decisions and stale entries,
+So that the Knowledge Decisions Board stays current and complete without manual tracking.
+
+**Status:** Not Started
+
+---
+
+## Background
+
+The Knowledge Decisions Board (Story 0.25) and backfill (Story 0.26) create the initial state. Over time, new artifacts and research will be created that need board entries. Without a hygiene process, the board will drift out of sync — the same problem it was designed to solve.
+
+The sweep agent reports findings to the supervisor — it does NOT auto-create ADRs or auto-modify the board. This preserves human/supervisor judgment about what deserves formal documentation.
+
+**Research:** `docs/research/decision-management-research.md` (PR #235)
+**Party Mode Artifact:** `_bmad-output/planning-artifacts/decision-management-party-mode.md`
+
+---
+
+## Acceptance Criteria
+
+- **AC1:** Sweep process definition exists in `docs/decisions/SWEEP.md` documenting: what to scan, what to flag, frequency, escalation paths
+- **AC2:** Sweep checks `_bmad-output/planning-artifacts/` for files not referenced in BOARD.md
+- **AC3:** Sweep checks `docs/research/` for research without a corresponding board entry
+- **AC4:** Sweep flags stale entries: "Active Research" older than 2 weeks without update
+- **AC5:** Sweep identifies ADR candidates from significant decided items (items with broad architectural impact)
+- **AC6:** Sweep produces a markdown report listing findings by category (unindexed artifacts, unindexed research, stale entries, ADR candidates)
+- **AC7:** Sweep report is addressed to supervisor — no auto-creation of entries
+- **AC8:** Process can be run manually or via `/loop` skill
+- **AC9:** Standing orders include sweep schedule (weekly or after major milestones)
+
+## Tasks
+
+- [ ] Create `docs/decisions/SWEEP.md` with:
+  - Sweep purpose and philosophy (report, don't auto-create)
+  - Scan targets: party mode artifacts, research docs, board entries
+  - Staleness criteria (Active Research > 2 weeks, Pending Recommendations > 1 month)
+  - ADR candidate criteria (broad impact, multiple stakeholders, irreversible)
+  - Report format template
+  - Escalation paths (supervisor reviews, decides action)
+  - Run frequency and triggers
+- [ ] Define sweep report markdown template
+- [ ] Document how to run sweep manually vs. via `/loop`
+- [ ] Update `docs/decisions/README.md` with reference to sweep process
+- [ ] Add sweep schedule to standing orders
+
+---
+
+## Test Criteria
+
+- `docs/decisions/SWEEP.md` exists with complete process definition
+- Sweep report template is actionable (someone reading it knows exactly what to do)
+- Process is documented clearly enough for any agent to execute
+- `docs/decisions/README.md` references the sweep process
+- No code changes — documentation only
+
+## Dependencies
+
+- Story 0.25 (BOARD.md must exist)
+- Story 0.26 (backfill should be complete so sweep has a baseline to compare against)
+
+## References
+
+- Research: `docs/research/decision-management-research.md` (PR #235)
+- Party Mode: `_bmad-output/planning-artifacts/decision-management-party-mode.md`
+- Sprint Change Proposal: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-decisions-board.md`


### PR DESCRIPTION
## Summary

- Creates sprint change proposal adding Knowledge Decisions Board to Epic 0 (Infrastructure)
- Adds 3 new stories (0.25, 0.26, 0.27) for implementing the three-component decision management system
- Based on completed research (PR #235) and party mode consensus

## Stories Added

| Story | Title | Depends On |
|-------|-------|------------|
| 0.25 | Knowledge Decisions Board — Create & Seed | None |
| 0.26 | Artifact Format Standardization & Backfill | 0.25 |
| 0.27 | Board Hygiene Sweep Process | 0.25, 0.26 |

## What This Enables

The three-component system (adopted from research):
1. **Knowledge Board** (`docs/decisions/BOARD.md`) — kanban-style columns tracking decision lifecycle from question to resolution
2. **Standardized Artifact Format** — all party mode artifacts get a Decisions Summary table for mechanical extraction
3. **Board Hygiene Sweep** — periodic scan for unindexed decisions, stale entries, ADR candidates

## Planning Artifacts

- Sprint change proposal: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-decisions-board.md`
- Research: `docs/research/decision-management-research.md` (PR #235)
- Party mode: `_bmad-output/planning-artifacts/decision-management-party-mode.md`

## Scope

- **No code changes** — planning/docs only
- **No ROADMAP.md changes** — supervisor updates after merge
- Stories are implementable via `/implement-story` after merge

## Test plan

- [x] All story files have correct format matching existing stories
- [x] Sprint change proposal follows established template
- [x] Story dependencies are sequential and logical
- [x] No code or configuration changes