### PR TITLE
feat: BMAD planning — persistent agent architecture adoption

### DIFF
--- a/_bmad-output/planning-artifacts/architecture-persistent-agent-infrastructure.md
+++ b/_bmad-output/planning-artifacts/architecture-persistent-agent-infrastructure.md
@@ -1,0 +1,307 @@
+# Architecture Decision: Persistent BMAD Agent Infrastructure
+
+**Date:** 2026-03-08
+**Status:** Proposed
+**Context:** PR #249 research + course correction party mode validation
+**Scope:** Agent communication, lifecycle, resource management, and coordination for persistent BMAD governance agents
+
+---
+
+## 1. Overview
+
+This document extends the existing ThreeDoors architecture to cover the persistent agent infrastructure that enables autonomous project governance. It does NOT modify the ThreeDoors application architecture — this is purely development infrastructure.
+
+### Problem
+
+With 210+ merged PRs across 30+ epics, manual governance doesn't scale. Planning documents (story status, ROADMAP.md, PRD alignment) and architecture documents drift from reality after every merge. The current 3 persistent agents (merge-queue, pr-shepherd, envoy) handle operational concerns but not governance.
+
+### Solution
+
+Add 2 persistent agents (project-watchdog, arch-watchdog) and 2 cron jobs (SM sprint health, QA coverage audit) to create a self-governing project lifecycle.
+
+---
+
+## 2. Agent Communication Architecture
+
+### Decision: Message-Driven Communication via multiclaude
+
+**Pattern:** Point-to-point messaging using `multiclaude message send`
+
+**Rationale:**
+- Established multiclaude primitive — no new infrastructure needed
+- Each message is explicit and traceable
+- No shared state files (prevents race conditions across worktrees)
+- No webhook infrastructure required (polling + messages is sufficient at current scale)
+
+### Rejected Alternatives
+
+| Alternative | Why Rejected |
+|------------|-------------|
+| Shared file protocol | Race conditions in separate worktrees; file-based coordination adds complexity |
+| Webhook-based events | multiclaude doesn't support webhook triggers; over-engineering for scale |
+| Dense agent mesh (N*N channels) | Combinatorial explosion; hub-and-spoke is simpler and sufficient |
+
+### Communication Topology
+
+```
+                    ┌─────────────────┐
+                    │   supervisor     │
+                    │  (human/agent)   │
+                    └────────┬────────┘
+                             │ escalations only
+                    ┌────────┴────────┐
+                    │                 │
+         ┌─────────▼──────┐  ┌──────▼─────────┐
+         │ project-watchdog│  │  arch-watchdog  │
+         │  (PM - persist) │  │ (Arch - persist)│
+         │                 │  │                 │
+         │ Monitors:       │  │ Monitors:       │
+         │ - Merged PRs    │◄─┤ - Code changes  │
+         │ - Story status  │──►- Arch docs      │
+         │ - ROADMAP.md    │  │ - New patterns   │
+         │ - PRD alignment │  │ - Design records │
+         └────────┬────────┘  └──────┬─────────┘
+                  │                   │
+         ┌────────┴───────────────────┴────────┐
+         │           Message Bus               │
+         │    (multiclaude message send)        │
+         └────────┬───────────────────┬────────┘
+                  │                   │
+    ┌─────────────▼──┐          ┌─────▼──────────┐
+    │  merge-queue    │          │  pr-shepherd   │
+    │  (persist)      │          │  (persist)     │
+    │  Merges PRs     │          │  Rebases PRs   │
+    └─────────────────┘          └────────────────┘
+                  │
+    ┌─────────────▼──┐
+    │    envoy        │
+    │  (persist)      │
+    │  Issue triage   │
+    └─────────────────┘
+
+    ┌─────────────────┐          ┌────────────────┐
+    │  SM cron (4h)   │          │ QA cron (weekly)│
+    │  Sprint health  │          │ Coverage audit  │
+    └─────────────────┘          └────────────────┘
+```
+
+### Message Flow: PR Merge Cascade
+
+The primary governance flow triggered on every PR merge:
+
+```
+1. merge-queue merges PR #NNN
+   │
+2. project-watchdog detects merge (polling every 10-15 min)
+   ├── Updates story X.Y status → "Done (PR #NNN)"
+   ├── Updates ROADMAP.md epic progress
+   ├── Checks PRD alignment
+   │   └── If drift: messages arch-watchdog
+   │         └── arch-watchdog reviews architecture docs
+   │             └── If update needed: updates docs, messages project-watchdog
+   │                 └── project-watchdog flags affected stories
+   │
+3. envoy cross-checks open issues (existing behavior)
+   └── If PR fixes open issue: comments and closes
+```
+
+### Cascade Prevention
+
+Each message includes a **correlation ID** (the PR number). Agents track processed PR numbers and skip already-processed ones. This prevents:
+- Circular notifications (A messages B, B messages A about the same PR)
+- Duplicate processing on agent restart
+- Amplification loops
+
+**Implementation:** Each agent maintains a local list of recently processed PR numbers (last 50). On restart, re-scan last 10 merged PRs to catch any missed during downtime, but skip those already in the processed list.
+
+---
+
+## 3. Agent Lifecycle Management
+
+### Decision: multiclaude-Native Lifecycle
+
+Agents are spawned, monitored, and restarted using existing multiclaude infrastructure.
+
+### Startup
+
+```bash
+# Spawn persistent agents
+multiclaude agents spawn --name project-watchdog --class persistent --prompt-file agents/project-watchdog.md
+multiclaude agents spawn --name arch-watchdog --class persistent --prompt-file agents/arch-watchdog.md
+
+# Start cron jobs
+# SM: via /loop skill (runs in supervisor or dedicated session)
+/loop 4h /bmad-bmm-sprint-status
+
+# QA: via system cron (weekly is too long for /loop)
+# crontab entry: 0 9 * * 1 multiclaude work "Run weekly QA coverage audit" --repo ThreeDoors
+```
+
+### Startup Ordering
+
+**No ordering required.** project-watchdog and arch-watchdog operate independent polling loops with message bridges. Either can start first. If one sends a message before the other is ready, multiclaude queues the message for delivery when the recipient starts.
+
+### Monitoring
+
+- **Health check:** `multiclaude worker list` shows agent status
+- **Logs:** `multiclaude logs <agent-name>` for troubleshooting
+- **Metrics:** Each agent logs its polling cycle count and actions taken
+
+### Restart and Recovery
+
+- **Crash recovery:** `multiclaude agent restart <name>` restarts a crashed agent
+- **Idempotent operations:** All agent actions are idempotent — re-processing a PR produces the same result
+- **Catch-up on restart:** On startup, agents re-scan the last 10 merged PRs to catch anything missed during downtime
+- **No data loss:** Agents don't maintain critical state that would be lost on crash — they derive state from git history and GitHub API
+
+### Shutdown
+
+```bash
+# Stop individual agent
+multiclaude worker rm <agent-name>
+
+# Stop all (including persistent agents)
+multiclaude stop-all
+```
+
+---
+
+## 4. Resource Management
+
+### Decision: Conservative Polling with Adaptive Intervals
+
+### Resource Budget (5 Persistent Agents)
+
+| Agent | Poll Interval | Est. API Calls/Hour | Notes |
+|-------|---------------|---------------------|-------|
+| merge-queue | 5-10 min | 6-12 | Existing |
+| pr-shepherd | 10-15 min | 4-6 | Existing |
+| envoy | 15-20 min | 3-4 | Existing |
+| project-watchdog | 10-15 min | 4-6 | **New** |
+| arch-watchdog | 20-30 min | 2-3 | **New** |
+| **Total** | | **19-31/hour** | |
+
+Cron additions:
+- SM (every 4h): ~6 calls/day
+- QA (weekly): ~1 call/week
+
+### tmux Session Management
+
+Each persistent agent runs in its own tmux window managed by multiclaude. 5 persistent agents = 5 tmux windows. Each agent has its own git worktree, preventing file conflicts.
+
+### Scaling Limits
+
+- **Recommended max:** 6-7 persistent agents before coordination overhead dominates
+- **Current proposal:** 5 persistent agents — well within limits
+- **Scaling strategy:** If adding more agents, evaluate consolidation (merging roles) before adding new agents
+
+### Adaptive Polling (Future Enhancement)
+
+Not implemented in MVP, but noted for Phase 2 tuning:
+- Increase polling frequency during high-merge periods (multiple PRs merged in 1 hour)
+- Decrease polling frequency during quiet periods (no merges in 2+ hours)
+- Backoff on API errors or rate limits
+
+---
+
+## 5. Conflict Resolution
+
+### Decision: Authority Boundaries + Separate Worktrees
+
+### File Domain Separation
+
+Each agent edits only files within its authority domain. There is NO overlap:
+
+| Agent | Editable Files | Read-Only Access |
+|-------|---------------|-----------------|
+| project-watchdog | `docs/stories/*.md`, `ROADMAP.md` | All code, all docs |
+| arch-watchdog | `docs/architecture/*.md` | All code, all docs |
+| merge-queue | None (merges PRs, doesn't edit files) | All |
+| pr-shepherd | None (rebases branches, doesn't edit files) | All |
+| envoy | None (comments on issues, doesn't edit files) | All |
+
+### Why This Prevents Conflicts
+
+1. **No overlapping write domains:** project-watchdog writes to story files; arch-watchdog writes to architecture docs. They never edit the same file.
+2. **Separate worktrees:** Each agent operates in its own git worktree via multiclaude. File system isolation prevents race conditions.
+3. **No shared state files:** Communication is via messages, not shared files.
+
+### Edge Case: Both Agents Process Same PR
+
+If both agents detect the same merged PR simultaneously:
+- project-watchdog updates story status and ROADMAP.md
+- arch-watchdog checks code changes against architecture docs
+- These are independent operations on different files — no conflict
+- If arch-watchdog finds drift and messages project-watchdog, the message includes the correlation PR number, so project-watchdog knows the context
+
+### Edge Case: Agent Creates a Commit While Another Agent's PR is Being Merged
+
+- Each agent operates in its own worktree on its own branch
+- Agents that create commits (project-watchdog updating story files, arch-watchdog updating arch docs) should create PRs, not push directly to main
+- merge-queue handles merging these PRs through the normal process
+
+---
+
+## 6. Integration with multiclaude Infrastructure
+
+### Agent Definition Files
+
+Agent behavior is defined in markdown files at `agents/<agent-name>.md`. These files specify:
+- **Monitoring surface:** What to poll and how often
+- **Trigger model:** What events trigger action
+- **Authority boundaries:** What files can be edited
+- **Escalation rules:** When to message supervisor
+- **Restart behavior:** How to recover from downtime
+
+### Existing Agent Compatibility
+
+The new agents complement existing agents without modification:
+
+| Existing Agent | Interaction with New Agents |
+|---------------|---------------------------|
+| merge-queue | Triggers project-watchdog and arch-watchdog indirectly (they detect merges via polling) |
+| pr-shepherd | No interaction — rebasing is orthogonal to governance |
+| envoy | Parallel operation — envoy checks issues, project-watchdog checks story/PRD alignment |
+
+### multiclaude Message Protocol
+
+Messages follow the existing `multiclaude message send <recipient> <message>` format:
+
+```bash
+# project-watchdog notifies arch-watchdog of PRD drift
+multiclaude message send arch-watchdog "PRD drift detected: PR #NNN changed scope of Epic 28. Verify architecture docs for alignment. Correlation: PR-NNN"
+
+# arch-watchdog notifies project-watchdog of architecture update
+multiclaude message send project-watchdog "Architecture docs updated for pattern change in internal/tasks/. Stories referencing old pattern may need tech notes. Correlation: PR-NNN"
+
+# Either agent escalates to supervisor
+multiclaude message send supervisor "Scope change detected: PR #NNN introduces feature not in ROADMAP.md. Needs human decision. Correlation: PR-NNN"
+```
+
+---
+
+## 7. Key Design Decisions Summary
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Communication model | Message-driven (multiclaude messages) | Established primitive; no new infrastructure |
+| Topology | Hub-and-spoke (PM hub + Architect independent loop) | Simpler than mesh; covers both governance gaps |
+| Polling intervals | 10-15 min (PM), 20-30 min (Architect) | Balances freshness with API cost |
+| Conflict prevention | Authority boundaries + separate worktrees | Zero overlap in write domains |
+| Cascade prevention | Correlation ID per PR | Prevents circular notifications |
+| Recovery model | Idempotent operations + catch-up scan | No critical state to lose on crash |
+| Lifecycle management | multiclaude-native (spawn, restart, rm) | Uses existing infrastructure |
+| Scaling limit | 6-7 persistent agents max | Beyond this, coordination overhead dominates |
+| SM/QA model | Cron jobs, not persistent agents | Periodic summarization, not continuous monitoring |
+
+---
+
+## 8. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Agent creates incorrect doc updates | Medium | Low | All updates go through PRs; merge-queue validates |
+| API rate limiting from too many agents | Low | Medium | Conservative polling intervals; backoff on errors |
+| Agent stuck in infinite loop | Very Low | Low | multiclaude monitors agent health; manual restart available |
+| Stale correlation ID list on long downtime | Low | Low | Re-scan last 10 PRs on restart covers typical gaps |
+| Agent worktree diverges from main | Low | Medium | Agents should rebase before creating commits |

--- a/_bmad-output/planning-artifacts/persistent-agents-course-correction-party-mode.md
+++ b/_bmad-output/planning-artifacts/persistent-agents-course-correction-party-mode.md
@@ -1,0 +1,121 @@
+# Party Mode Artifact: Persistent Agent Course Correction Validation
+
+**Date:** 2026-03-08
+**Topic:** Validate PM's sprint change proposal for persistent BMAD agent infrastructure
+**Context:** Course correction based on PR #249 research (3 prior party mode rounds)
+**Participants:** John (PM), Winston (Architect), Bob (SM), Murat (TEA), Amelia (Dev), Mary (Analyst)
+
+---
+
+## Adopted Approach
+
+### 1. Two Persistent Agents — CONFIRMED
+
+The party unanimously confirmed the research recommendation: add **project-watchdog** (PM role) and **arch-watchdog** (Architect role) as persistent agents.
+
+**Rationale reinforced:**
+- These two cover the highest-frequency governance gaps (PRD drift at ~90%, architecture divergence at ~80%)
+- 5 total persistent agents (3 existing + 2 new) is within the recommended 6-7 agent limit
+- Both have continuous monitoring surfaces that justify always-on status
+- Independent monitoring loops with message bridges avoid single-point-of-failure
+
+### 2. SM as 4-Hour Cron — CONFIRMED
+
+Bob (SM) confirmed that the SM role's value is in periodic *pattern detection* ("3 stories blocked for 48h"), not continuous monitoring. 4-hourly cron via `/loop 4h /bmad-bmm-sprint-status` achieves ~70% of persistent value at ~10% of cost.
+
+### 3. QA as Weekly Cron — CONFIRMED
+
+Murat (TEA) confirmed that CI catches per-PR regressions; the weekly cron fills the *trend analysis* gap. Added requirement: define coverage baseline storage location and comparison mechanism in Story 37.2.
+
+### 4. Epic 37 with 4 Stories — CONFIRMED (with refinements)
+
+Bob proposed reducing to 3 stories by folding 37.3 into 37.1. After cross-talk, Winston and John agreed to keep 4 stories but clarified the scope distinction:
+- **37.1:** Agent definition files in `agents/` directory (operational artifacts)
+- **37.3:** Architecture documentation in `docs/architecture/` (design documentation — interaction diagram, authority boundaries, anti-patterns)
+
+These are different artifacts in different locations serving different purposes.
+
+### 5. PRD Scope Addition — CONFIRMED
+
+Add "Autonomous Governance Infrastructure" to PRD product-scope.md under a new Phase 5+ section. All agents agreed this is correctly scoped as infrastructure, not product feature.
+
+### 6. Agent Authority Boundaries — STRENGTHENED
+
+Winston recommended embedding authority boundaries directly in each agent definition file, not just in documentation. This makes boundaries enforceable at the agent level, not just advisory.
+
+**Adopted authority model:**
+
+| Agent | Can Directly Edit | Must Spawn Worker | Must Escalate |
+|-------|-------------------|-------------------|---------------|
+| project-watchdog | Story files, ROADMAP.md | New story creation | Scope decisions, priority changes |
+| arch-watchdog | Architecture docs | Code refactoring | Design decision overrides |
+| SM cron | Sprint status doc | Nothing | Blocked items, risk alerts |
+| QA cron | Coverage reports | Test improvements | Coverage policy changes |
+
+### 7. Idempotency as Explicit Test Case — ADOPTED
+
+Murat's recommendation: add to Story 37.1 acceptance criteria: "Verify that re-processing a previously-seen PR produces no duplicate messages or file edits." Makes the correlation ID anti-pattern testable.
+
+### 8. Restart Recovery Behavior — ADOPTED
+
+Murat's recommendation: agent definitions should document restart behavior — "On restart, re-scan last 10 merged PRs to catch any missed during downtime." This makes recovery automatic.
+
+### 9. QA Cron Baseline Specification — ADOPTED
+
+Amelia's recommendation: Story 37.2 must specify where the coverage baseline is stored and how comparison works. Not just "run `go test -cover`" — define the full mechanism.
+
+### 10. Analyst Function Absorption — CONFIRMED
+
+Mary confirmed that the analyst role generates research episodically, not continuously. Correctly absorbed into PM's monthly research sweep. Deferred evaluation: revisit if research backlog grows beyond monthly sweep capacity.
+
+---
+
+## Rejected Options
+
+### Reduce to 3 Stories (fold 37.3 into 37.1)
+- **Proposed by:** Bob (SM)
+- **Why rejected:** Winston and John clarified that 37.1 (agent definitions in `agents/`) and 37.3 (architecture documentation in `docs/architecture/`) are distinct artifacts. Agent definitions are operational; architecture docs explain the design rationale, interaction patterns, and anti-patterns. Keeping them separate allows independent implementation and review.
+
+### Add SM as Third Persistent Agent
+- **Proposed by:** No one (evaluated in prior research rounds)
+- **Why rejected:** Bob himself confirmed that SM's value is in periodic summarization, not continuous monitoring. Merge-queue and pr-shepherd already handle mechanical process health. The 4-hourly cron achieves ~70% of persistent value at minimal cost.
+
+### Make Analyst Persistent
+- **Proposed by:** No one
+- **Why rejected:** Mary confirmed research docs accumulate slowly (days/weeks). Monthly sweep by PM is sufficient. Revisit only if backlog grows beyond monthly capacity.
+
+### Defer All to Cron (No New Persistent Agents)
+- **Proposed by:** No one (evaluated in prior research rounds)
+- **Why rejected:** Cron jobs lack contextual awareness and message-reactivity. The PR merge cascade (merge → story update → ROADMAP update → PRD check → architect notification) requires persistent state across cascading checks.
+
+### Single Hub Architecture (PM Only)
+- **Proposed by:** No one (evaluated in prior research rounds)
+- **Why rejected:** PM can't assess code-level architecture compliance. Architect needs an independent monitoring loop for code-to-doc divergence that requires domain expertise PM doesn't have.
+
+---
+
+## Refinements to Sprint Change Proposal
+
+Based on party mode discussion, the following refinements should be incorporated:
+
+1. **Story 37.1 ACs:** Add idempotency verification ("re-processing a seen PR produces no duplicates") and restart recovery behavior documentation
+2. **Story 37.2 ACs:** Add coverage baseline storage location and comparison mechanism specification
+3. **Story 37.3 scope:** Clarify this creates `docs/architecture/agent-communication.md` (or similar) — distinct from agent definition files
+4. **Agent definitions:** Embed authority boundaries directly in each agent's definition file
+5. **Architecture doc:** Document startup ordering (independent), failure recovery (idempotent + re-scan), and conflict resolution (separate worktrees, separate file domains)
+
+---
+
+## Consensus Summary
+
+| Item | Decision | Votes |
+|------|----------|-------|
+| 2 persistent agents (PM + Architect) | Adopt | 6/6 |
+| SM as 4h cron | Adopt | 6/6 |
+| QA as weekly cron | Adopt | 6/6 |
+| Epic 37 with 4 stories | Adopt (with refinements) | 5/6 (Bob initially proposed 3, accepted 4 after discussion) |
+| PRD scope addition | Adopt | 6/6 |
+| Authority boundaries in agent defs | Adopt (strengthened) | 6/6 |
+| Idempotency test case | Adopt | 6/6 |
+| Restart recovery spec | Adopt | 6/6 |
+| QA baseline specification | Adopt | 6/6 |

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-persistent-agents.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-persistent-agents.md
@@ -1,0 +1,197 @@
+# Sprint Change Proposal: Persistent BMAD Agent Infrastructure
+
+**Date:** 2026-03-08
+**Triggered By:** Research spike PR #249 — Persistent BMAD Agent Architecture
+**Scope Classification:** Moderate — backlog expansion with new epic
+**Mode:** Direct Adjustment
+
+---
+
+## 1. Issue Summary
+
+### Problem Statement
+
+ThreeDoors has grown to 210+ merged PRs across 30+ completed epics. The project currently operates with 3 persistent agents (merge-queue, pr-shepherd, envoy) handling operational concerns — but core governance functions are entirely manual:
+
+- **PRD drift:** After every PR merge, planning docs (story status, ROADMAP.md, PRD alignment) only get updated when the supervisor manually dispatches audits
+- **Architecture divergence:** New code patterns and interfaces introduced in PRs aren't reflected in architecture docs — nobody monitors for this
+- **Story status staleness:** Completed stories often remain marked "In Progress" or "Not Started" until the next manual PM audit
+- **Sprint health blindness:** No systematic monitoring for blocked stories, stale PRs, or idle workers
+
+### Discovery Context
+
+PR #249 conducted 3 rounds of party mode with all BMAD agents to evaluate which roles should become persistent. The research produced unanimous consensus on a focused approach: 2 new persistent agents + 2 cron jobs.
+
+### Evidence
+
+- 3 party mode artifacts documenting the evaluation, collaboration patterns, and MVP selection
+- Governance gap analysis showing PRD drift as highest-frequency gap (every merged PR)
+- Resource budget analysis showing 5 persistent agents (3 existing + 2 new) is well within limits
+- Projected coverage: 90% of PRD drift, 80% of architecture divergence
+
+---
+
+## 2. Impact Analysis
+
+### Epic Impact
+
+**No existing epics are affected.** This is purely additive infrastructure work.
+
+| Existing Entity | Impact |
+|----------------|--------|
+| Epics 25-35 (feature epics) | No impact — persistent agents will *support* these by keeping docs in sync |
+| Epic 0 (Infrastructure) | Could house infrastructure stories, but a new epic is cleaner |
+| Agents: merge-queue, pr-shepherd, envoy | No changes needed — new agents complement, don't overlap |
+
+### Story Impact
+
+No existing stories require modification.
+
+### Artifact Conflicts
+
+| Artifact | Change Needed | Severity |
+|----------|--------------|----------|
+| PRD product-scope.md | Add "Autonomous Governance" section under new phase | Medium |
+| Architecture docs | Add agent communication architecture section | Medium |
+| ROADMAP.md | Add new Epic 37 with stories | Low (after stories created) |
+| Agent definitions (agents/) | Create project-watchdog.md, arch-watchdog.md | Core deliverable |
+| Cron configuration | Set up SM (4h) and QA (weekly) cron jobs | Core deliverable |
+
+### Technical Impact
+
+- **No code changes** to the ThreeDoors application itself
+- **Agent definitions:** New markdown files in `agents/` directory
+- **Cron setup:** Uses existing multiclaude `/loop` skill and/or system cron
+- **Resource usage:** +2 persistent agents, ~6-9 additional API calls/hour (well within budget)
+
+---
+
+## 3. Recommended Approach
+
+### Selected Path: Direct Adjustment
+
+Add a new **Epic 37: Persistent BMAD Agent Infrastructure** with 4 stories covering the full lifecycle from agent definition to tuning.
+
+### Rationale
+
+- **Low risk:** No code changes, only agent definitions and documentation
+- **High value:** Automates the #1 and #2 governance gaps (PRD drift, architecture divergence)
+- **Reversible:** Persistent agents can be stopped instantly if they cause issues
+- **Well-researched:** 3 rounds of party mode with all BMAD agents produced unanimous consensus
+- **Incremental:** Start with 2 persistent agents, add more only if clear gap emerges
+
+### Effort Estimate
+
+- **Overall:** Medium (4 stories, primarily documentation and configuration)
+- **Timeline:** 1-2 days for implementation, 2 weeks for tuning/observation
+
+### Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Agents create noise (excessive messages) | Low | Polling intervals are conservative (10-30 min); chatty agent anti-pattern explicitly addressed |
+| Agents conflict on file edits | Very Low | Authority boundaries prevent overlap (PM edits planning docs, Architect edits architecture docs) |
+| Resource overhead too high | Low | Budget analysis shows 19-31 API calls/hour total (5 agents); well within limits |
+| Circular notification loops | Low | Correlation ID per PR prevents reprocessing |
+
+---
+
+## 4. Detailed Change Proposals
+
+### 4.1 PRD: Add Autonomous Governance Phase
+
+**File:** `docs/prd/product-scope.md`
+
+**Section:** Add after Phase 5 (or as sub-section of Phase 5)
+
+**NEW:**
+```markdown
+## Phase 5+: Autonomous Project Governance
+
+**In Scope:**
+- Persistent project-watchdog agent (PM role): merged PR monitoring, story status updates, ROADMAP.md sync, PRD drift detection, monthly research sweep
+- Persistent arch-watchdog agent (Architect role): code-to-architecture-doc alignment, undocumented pattern detection, architectural drift flagging
+- Sprint health cron (SM role): 4-hourly sprint status summary, blocked story detection, stale PR alerts
+- Coverage audit cron (QA/TEA role): weekly test coverage trend analysis, regression flagging
+- Agent communication via multiclaude message bus (no shared state files)
+- Agent authority boundaries: each agent edits only its designated docs
+- Idempotent, rate-limited polling with correlation IDs for cascade prevention
+
+**Out of Scope for this Phase:**
+- Tech Writer persistent agent (fold into PM's monitoring loop)
+- Analyst persistent agent (fold into PM's monthly research sweep)
+- UX Designer persistent agent (no continuous monitoring surface for CLI/TUI)
+- Webhook-based event triggers (polling is sufficient at current scale)
+```
+
+### 4.2 Architecture: Agent Communication Architecture
+
+**File:** New section in `docs/architecture/` or addendum to existing infrastructure docs
+
+**Content:** Document the agent interaction architecture from the research:
+- Message-driven communication via `multiclaude message send`
+- Hub topology: PM as primary hub, Architect as independent loop
+- PR merge cascade: merge-queue → project-watchdog → arch-watchdog → envoy
+- Authority boundaries table
+- Anti-patterns: circular notifications, authority creep, chatty agents
+- Resource budget and scaling limits
+
+### 4.3 New Epic 37: Persistent BMAD Agent Infrastructure
+
+**Stories:**
+
+| Story | Title | Priority | Depends On |
+|-------|-------|----------|------------|
+| 37.1 | Agent Definitions — project-watchdog and arch-watchdog | P1 | None |
+| 37.2 | Cron Configuration — SM Sprint Health and QA Coverage Audit | P1 | None |
+| 37.3 | Agent Communication Protocol and Authority Boundaries | P1 | 37.1 |
+| 37.4 | Monitoring, Tuning, and Phase 1 Evaluation | P1 | 37.1, 36.2 |
+
+---
+
+## 5. Implementation Handoff
+
+### Scope Classification: Moderate
+
+This requires backlog expansion (new epic + stories) plus documentation updates to PRD and architecture docs.
+
+### Handoff Recipients
+
+| Role | Responsibility |
+|------|---------------|
+| PM (John) | Edit PRD to add autonomous governance scope; create story files |
+| Architect (Winston) | Review/create agent communication architecture documentation |
+| SM (Bob) | Validate story sequencing and add to sprint plan |
+| Supervisor | Update ROADMAP.md with Epic 37 after stories are created |
+| Workers | Implement stories 36.1-36.4 via `/implement-story` |
+
+### Success Criteria
+
+1. Two new persistent agents (project-watchdog, arch-watchdog) running and polling
+2. SM cron running every 4 hours via `/loop`
+3. QA cron running weekly
+4. Story status updates happening automatically on PR merge
+5. ROADMAP.md staying current without manual intervention
+6. Architecture docs updated when code patterns change
+7. No circular notification loops or authority boundary violations after 2 weeks
+
+### Next Steps (Pipeline)
+
+1. **Party Mode** — Validate this course correction proposal with all BMAD agents
+2. **Architect Review** — Create agent communication architecture document
+3. **PRD Edit** — Incorporate adopted changes from party mode
+4. **Epic/Story Planning** — Create story files for Epic 37
+5. **ROADMAP Update** — Add Epic 37 to ROADMAP.md
+
+---
+
+## Checklist Summary
+
+| Section | Status |
+|---------|--------|
+| 1. Trigger & Context | [x] Complete |
+| 2. Epic Impact | [x] Complete — 1 new epic needed |
+| 3. Artifact Conflicts | [x] Complete — PRD, Architecture, Agent defs need updates |
+| 4. Path Forward | [x] Complete — Direct Adjustment selected |
+| 5. Proposal Components | [x] Complete |
+| 6. Review & Handoff | [x] Complete |

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -2645,6 +2645,98 @@ All three stories are independent and can be implemented in parallel.
 
 ---
 
+## Epic 37: Persistent BMAD Agent Infrastructure
+
+**Epic Goal:** Enable autonomous project governance by adding persistent BMAD agents (project-watchdog, arch-watchdog) and cron jobs (SM sprint health, QA coverage audit) that automatically maintain story status, ROADMAP accuracy, architecture doc currency, and quality metrics.
+
+**Prerequisites:** None (infrastructure epic, independent of all feature epics)
+**FRs covered:** N/A (development infrastructure, not product features)
+**Status:** Not Started
+
+### Story 37.1: Agent Definitions — project-watchdog and arch-watchdog
+
+As a project supervisor,
+I want persistent project-watchdog and arch-watchdog agents with well-defined monitoring surfaces, authority boundaries, and restart behavior,
+So that project governance happens automatically after every PR merge.
+
+**Acceptance Criteria:**
+
+**Given** the `agents/` directory
+**When** implementation is complete
+**Then** `agents/project-watchdog.md` and `agents/arch-watchdog.md` exist with monitoring surfaces, trigger models, authority boundaries, escalation rules, restart behavior, and correlation ID tracking
+
+**Given** either agent re-processes a previously-seen PR
+**When** the correlation ID matches an already-processed PR
+**Then** no duplicate messages or file edits are produced (idempotency verified)
+
+**Quality Gate:** AC-Q5 (scope)
+
+---
+
+### Story 37.2: Cron Configuration — SM Sprint Health and QA Coverage Audit
+
+As a project supervisor,
+I want automated sprint health checks every 4 hours and weekly QA coverage audits,
+So that blocked stories, stale PRs, and coverage regressions are surfaced without manual intervention.
+
+**Acceptance Criteria:**
+
+**Given** the SM sprint health cron
+**When** running every 4 hours
+**Then** it queries stale PRs, blocked stories, and worker activity, reporting risks to supervisor
+
+**Given** the QA coverage audit cron
+**When** running weekly
+**Then** it compares per-package coverage against a stored baseline at `docs/quality/coverage-baseline.json` and flags regressions >5 percentage points
+
+**Quality Gate:** AC-Q5 (scope)
+
+---
+
+### Story 37.3: Agent Communication Architecture Documentation
+
+As a developer or agent maintainer,
+I want comprehensive architecture documentation for persistent agent communication patterns, authority boundaries, and anti-patterns,
+So that agent behavior is predictable, debuggable, and extensible.
+
+**Acceptance Criteria:**
+
+**Given** the `docs/architecture/` directory
+**When** implementation is complete
+**Then** `docs/architecture/agent-governance.md` exists with: agent interaction architecture, communication protocol, authority boundaries, anti-patterns and safeguards, resource budget and scaling, lifecycle management
+**And** `docs/architecture/index.md` references the new file
+
+**Quality Gate:** AC-Q5 (scope)
+
+---
+
+### Story 37.4: Monitoring, Tuning, and Phase 1 Evaluation
+
+As a project supervisor,
+I want a 2-week evaluation framework with clear success metrics and tuning criteria,
+So that I can objectively assess persistent agent value and adjust accordingly.
+
+**Acceptance Criteria:**
+
+**Given** the evaluation framework
+**When** implementation is complete
+**Then** `docs/operations/agent-evaluation.md` exists with success metrics, tuning guidelines, Phase 1 evaluation checklist, and escalation criteria
+
+**Quality Gate:** AC-Q5 (scope)
+
+---
+
+### Epic 37 Story Dependencies
+
+```
+37.1 Agent Definitions (independent)
+37.2 Cron Configuration (independent)
+37.3 Agent Communication Architecture Documentation (depends on 37.1)
+37.4 Monitoring, Tuning, and Phase 1 Evaluation (depends on 37.1, 37.2)
+```
+
+---
+
 ## Appendix: PR-Analysis-Derived Quality Acceptance Criteria
 
 > **Source:** Systematic analysis of all 49 PRs (#1–#49) in arcaven/ThreeDoors, examining every delta between initial PR submission and final merge. These ACs are derived from recurring defect patterns and MUST be included in all future stories.

--- a/docs/prd/product-scope.md
+++ b/docs/prd/product-scope.md
@@ -172,3 +172,24 @@
 - Voice interface
 
 ---
+
+## Phase 5+: Autonomous Project Governance
+
+**In Scope:**
+- Persistent project-watchdog agent (PM role): merged PR monitoring, story status updates, ROADMAP.md sync, PRD drift detection, monthly research document sweep
+- Persistent arch-watchdog agent (Architect role): code-to-architecture-doc alignment, undocumented pattern detection, architectural drift flagging via GitHub issues
+- Sprint health cron (SM role): 4-hourly sprint status summary, blocked story detection, stale PR alerts, idle worker monitoring
+- Coverage audit cron (QA/TEA role): weekly test coverage trend analysis, regression flagging against stored baseline
+- Agent communication via multiclaude message bus (`multiclaude message send`) — no shared state files
+- Agent authority boundaries: each agent edits only its designated doc domain (PM → story files/ROADMAP, Architect → architecture docs)
+- Idempotent, rate-limited polling with correlation IDs for cascade prevention
+- Restart recovery: agents re-scan last 10 merged PRs on startup to catch gaps
+
+**Out of Scope for this Phase:**
+- Tech Writer persistent agent (fold doc staleness checks into PM's monitoring loop)
+- Analyst persistent agent (fold research sweep into PM's monthly cycle)
+- UX Designer persistent agent (no continuous monitoring surface for CLI/TUI project)
+- Webhook-based event triggers (polling is sufficient at current project scale)
+- Adaptive polling intervals (deferred to tuning phase)
+
+---

--- a/docs/stories/37.1.story.md
+++ b/docs/stories/37.1.story.md
@@ -1,0 +1,72 @@
+# Story 37.1: Agent Definitions — project-watchdog and arch-watchdog
+
+## Status: Not Started
+
+## Epic
+
+Epic 37: Persistent BMAD Agent Infrastructure
+
+## References
+
+- Research: PR #249 (persistent BMAD agent architecture research)
+- Architecture: `_bmad-output/planning-artifacts/architecture-persistent-agent-infrastructure.md`
+- Party Mode: `_bmad-output/planning-artifacts/persistent-agents-course-correction-party-mode.md`
+
+## Story
+
+As a project supervisor,
+I want persistent project-watchdog and arch-watchdog agents with well-defined monitoring surfaces, authority boundaries, and restart behavior,
+So that project governance (story status, ROADMAP sync, architecture alignment) happens automatically after every PR merge.
+
+## Background
+
+Currently, 3 persistent agents handle operational concerns (merge-queue, pr-shepherd, envoy), but core governance functions only happen when the supervisor manually dispatches BMAD PM/Architect audits. This story creates the agent definition files that enable autonomous governance.
+
+## Acceptance Criteria
+
+**Given** the `agents/` directory
+**When** story implementation is complete
+**Then** `agents/project-watchdog.md` exists with:
+  - Monitoring surface: merged PRs, story file status, ROADMAP.md, PRD alignment
+  - Trigger model: polling every 10-15 minutes via `gh pr list --state merged`
+  - Authority boundaries: CAN edit `docs/stories/*.md` and `ROADMAP.md`; CANNOT create stories, modify code, or make scope decisions
+  - Escalation rules: scope changes and priority changes escalate to supervisor
+  - Restart behavior: on startup, re-scan last 10 merged PRs to catch gaps
+  - Correlation ID tracking: maintain list of processed PR numbers to prevent duplicates
+
+**Given** the `agents/` directory
+**When** story implementation is complete
+**Then** `agents/arch-watchdog.md` exists with:
+  - Monitoring surface: code changes in `internal/` and `cmd/` vs `docs/architecture/`
+  - Trigger model: polling every 20-30 minutes for recently merged code PRs
+  - Authority boundaries: CAN edit `docs/architecture/*.md`; CANNOT refactor code or override design decisions
+  - Escalation rules: design decision overrides escalate to supervisor
+  - Restart behavior: on startup, re-scan last 10 merged PRs
+  - Message reactivity: responds to messages from project-watchdog about PRD changes
+
+**Given** the project-watchdog agent definition
+**When** the agent detects a merged PR that completes a story
+**Then** the agent updates the corresponding story file status to "Done (PR #NNN)"
+**And** updates ROADMAP.md epic progress
+
+**Given** either agent re-processes a previously-seen PR
+**When** the correlation ID matches an already-processed PR
+**Then** no duplicate messages are sent and no duplicate file edits are made
+**And** the operation is fully idempotent
+
+**Given** the agents are spawned via `multiclaude agents spawn`
+**When** both agents are running
+**Then** both appear in `multiclaude worker list` with active status
+**And** both begin polling on their defined intervals
+
+## Technical Notes
+
+- Agent definition files follow the format of existing agents (`agents/merge-queue.md`, etc.)
+- Authority boundaries must be embedded in the agent definition file itself, not just external docs
+- The correlation ID list should track the last 50 processed PR numbers
+- Use `gh pr list --state merged --limit 10` for polling recent merges
+- Use `gh pr diff <number>` to analyze what files changed in a merged PR
+
+## Quality Gate
+
+AC-Q5 (scope) — documentation and configuration only, no application code changes

--- a/docs/stories/37.2.story.md
+++ b/docs/stories/37.2.story.md
@@ -1,0 +1,70 @@
+# Story 37.2: Cron Configuration — SM Sprint Health and QA Coverage Audit
+
+## Status: Not Started
+
+## Epic
+
+Epic 37: Persistent BMAD Agent Infrastructure
+
+## References
+
+- Research: PR #249 (persistent BMAD agent architecture research)
+- Architecture: `_bmad-output/planning-artifacts/architecture-persistent-agent-infrastructure.md`
+
+## Story
+
+As a project supervisor,
+I want automated sprint health checks every 4 hours and weekly QA coverage audits,
+So that blocked stories, stale PRs, and coverage regressions are surfaced without manual intervention.
+
+## Background
+
+The SM and QA/TEA roles don't justify persistent agents — their value is in periodic summarization, not continuous monitoring. Cron jobs achieve ~70% of persistent value at ~10% of the resource cost. This story sets up the two cron jobs with clear specifications for what they check and where they report.
+
+## Acceptance Criteria
+
+**Given** the SM sprint health cron
+**When** configured and running
+**Then** every 4 hours it:
+  - Queries open PRs for staleness (>24h without activity)
+  - Checks for blocked stories (status "blocked" in `docs/stories/`)
+  - Summarizes active worker count and status via `multiclaude worker list`
+  - Reports to supervisor via `multiclaude message send` if risks detected
+  - Produces a brief summary even when no risks found (so supervisor knows it ran)
+
+**Given** the QA coverage audit cron
+**When** configured and running
+**Then** weekly (Monday 9am) it:
+  - Runs `go test -cover ./...` and captures per-package coverage percentages
+  - Compares results against the stored coverage baseline
+  - Flags packages where coverage dropped by >5 percentage points
+  - Reports findings to supervisor via `multiclaude message send`
+  - Updates the coverage baseline file after reporting
+
+**Given** the QA coverage audit
+**When** determining the coverage baseline
+**Then** the baseline is stored at `docs/quality/coverage-baseline.json`
+**And** the baseline format records per-package coverage percentages with timestamps
+**And** the first run establishes the initial baseline (no regression possible on first run)
+
+**Given** the SM cron implementation
+**When** the implementation is complete
+**Then** it is runnable via `/loop 4h /bmad-bmm-sprint-status` or equivalent
+**And** the setup instructions are documented
+
+**Given** the QA cron implementation
+**When** the implementation is complete
+**Then** it is runnable via system cron (`crontab -e`) or `multiclaude work` command
+**And** the setup instructions are documented
+
+## Technical Notes
+
+- SM cron: use `/loop 4h /bmad-bmm-sprint-status` skill for 4-hour intervals
+- QA cron: use system crontab for weekly schedule (`0 9 * * 1 multiclaude work "Run QA coverage audit" --repo ThreeDoors`)
+- Coverage baseline format example: `{"internal/tasks": {"coverage": 78.5, "updated": "2026-03-08"}, ...}`
+- `go test -cover ./...` output needs parsing — extract per-package percentage from `coverage: XX.X% of statements`
+- Create `docs/quality/` directory if it doesn't exist
+
+## Quality Gate
+
+AC-Q5 (scope) — configuration and documentation only, no application code changes

--- a/docs/stories/37.3.story.md
+++ b/docs/stories/37.3.story.md
@@ -1,0 +1,78 @@
+# Story 37.3: Agent Communication Architecture Documentation
+
+## Status: Not Started
+
+## Epic
+
+Epic 37: Persistent BMAD Agent Infrastructure
+
+## References
+
+- Research: PR #249 (persistent BMAD agent architecture research)
+- Architecture: `_bmad-output/planning-artifacts/architecture-persistent-agent-infrastructure.md`
+- Party Mode: `_bmad-output/planning-artifacts/persistent-agents-course-correction-party-mode.md`
+
+## Story
+
+As a developer or agent maintainer,
+I want comprehensive architecture documentation for the persistent agent communication patterns, authority boundaries, and anti-patterns,
+So that agent behavior is predictable, debuggable, and extensible.
+
+## Background
+
+The persistent agent infrastructure introduces inter-agent communication, authority boundaries, and cascade patterns that need formal documentation in `docs/architecture/`. This is distinct from the agent definition files (Story 37.1) — those are operational; this is the design rationale and reference documentation.
+
+## Acceptance Criteria
+
+**Given** the `docs/architecture/` directory
+**When** story implementation is complete
+**Then** a new file `docs/architecture/agent-governance.md` exists with:
+
+**Section 1: Agent Interaction Architecture**
+  - Topology diagram (hub-and-spoke: PM as primary hub, Architect as independent loop)
+  - Message flow diagram for PR merge cascade
+  - All 5 persistent agents and their relationships
+
+**Section 2: Communication Protocol**
+  - Message format and delivery mechanism (`multiclaude message send`)
+  - Correlation ID pattern for cascade prevention
+  - Message types: notification, escalation, cross-agent query
+  - Rate limiting: no agent polls more frequently than once per 10 minutes
+
+**Section 3: Authority Boundaries**
+  - Table: agent → editable files → read-only access → must escalate
+  - Rationale for each boundary assignment
+  - What happens when an agent needs to change a file outside its domain (spawn worker or escalate)
+
+**Section 4: Anti-Patterns and Safeguards**
+  - Circular notification prevention (correlation IDs)
+  - Authority creep prevention (boundaries in agent definitions)
+  - Chatty agent prevention (messages on state changes only, never status pings)
+  - Idempotency requirement for all agent operations
+
+**Section 5: Resource Budget and Scaling**
+  - API calls/hour budget table for all agents
+  - tmux session management
+  - Recommended scaling limits (6-7 max persistent agents)
+  - When to consolidate vs. add agents
+
+**Section 6: Lifecycle Management**
+  - Startup (no ordering required)
+  - Monitoring (`multiclaude worker list`, `multiclaude logs`)
+  - Restart recovery (re-scan last 10 PRs)
+  - Shutdown procedures
+
+**Given** the architecture index file
+**When** the new file is created
+**Then** `docs/architecture/index.md` is updated to include a reference to `agent-governance.md`
+
+## Technical Notes
+
+- Content is largely drawn from `_bmad-output/planning-artifacts/architecture-persistent-agent-infrastructure.md` — formalize it into project architecture docs
+- Follow existing architecture doc style and format (see `docs/architecture/high-level-architecture.md` for reference)
+- Include Mermaid diagrams where appropriate (topology, message flow)
+- Do NOT duplicate content from agent definition files — reference them instead
+
+## Quality Gate
+
+AC-Q5 (scope) — documentation only, no application code changes

--- a/docs/stories/37.4.story.md
+++ b/docs/stories/37.4.story.md
@@ -1,0 +1,72 @@
+# Story 37.4: Monitoring, Tuning, and Phase 1 Evaluation
+
+## Status: Not Started
+
+## Epic
+
+Epic 37: Persistent BMAD Agent Infrastructure
+
+## References
+
+- Research: PR #249 (persistent BMAD agent architecture research)
+- Depends On: Story 37.1 (agent definitions), Story 37.2 (cron configuration)
+
+## Story
+
+As a project supervisor,
+I want a 2-week evaluation framework for the persistent agents with clear success metrics and tuning criteria,
+So that I can objectively assess whether the agents are providing value and adjust accordingly.
+
+## Background
+
+The research recommends a 3-phase rollout: MVP (week 1), tuning (weeks 2-3), and evaluation (week 4). This story creates the evaluation framework and tuning guidelines so the Phase 1 deployment can be assessed objectively.
+
+## Acceptance Criteria
+
+**Given** the evaluation framework
+**When** story implementation is complete
+**Then** a file `docs/operations/agent-evaluation.md` exists with:
+
+**Section 1: Success Metrics**
+  - Story status accuracy: % of merged PRs with corresponding story status updates within 1 hour
+  - ROADMAP freshness: ROADMAP.md matches actual epic progress within 24 hours
+  - Architecture doc currency: new patterns documented within 48 hours of merge
+  - False positive rate: % of agent messages that didn't require action
+  - Noise level: average messages per day to supervisor
+
+**Section 2: Tuning Guidelines**
+  - When to increase polling frequency (high-merge periods)
+  - When to decrease polling frequency (quiet periods, excessive API usage)
+  - When to adjust authority boundaries (agent consistently needs to escalate the same type of change)
+  - When to promote a cron job to persistent (SM or QA cron proves insufficient)
+
+**Section 3: Phase 1 Evaluation Checklist**
+  - [ ] Both persistent agents running for 2+ weeks without crash
+  - [ ] Story status updates happening automatically on PR merge
+  - [ ] ROADMAP.md staying current without manual intervention
+  - [ ] Architecture docs updated when code patterns change
+  - [ ] No circular notification loops observed
+  - [ ] No authority boundary violations observed
+  - [ ] API usage within budget (19-31 calls/hour)
+  - [ ] SM cron producing useful sprint summaries
+  - [ ] QA cron baseline established and first comparison run
+
+**Section 4: Escalation Criteria**
+  - When to stop an agent (persistent errors, excessive noise)
+  - When to add a third persistent agent (clear governance gap not covered by cron)
+  - When to consolidate agents (two agents doing overlapping work)
+
+**Given** the `docs/operations/` directory
+**When** the directory does not exist
+**Then** it is created
+
+## Technical Notes
+
+- This is a planning/documentation story — no code changes
+- The evaluation document should be actionable (checklists, metrics, thresholds)
+- Reference the research findings for baseline expectations (90% PRD drift coverage, 80% architecture divergence coverage)
+- Include concrete examples of what "success" looks like for each metric
+
+## Quality Gate
+
+AC-Q5 (scope) — documentation only, no application code changes


### PR DESCRIPTION
## Summary

- Course correction and architectural planning for adding persistent BMAD agents based on PR #249 research (3 rounds of party mode with all BMAD agents)
- Adds **Epic 37: Persistent BMAD Agent Infrastructure** with 4 stories
- Updates PRD product-scope.md with "Autonomous Governance" phase
- Updates epics-and-stories.md with Epic 37 breakdown

## What's Proposed

Based on PR #249's research finding that manual governance doesn't scale at 210+ PRs:

**2 New Persistent Agents:**
- **project-watchdog** (PM role): monitors merged PRs, updates story status, syncs ROADMAP.md, detects PRD drift
- **arch-watchdog** (Architect role): monitors code changes vs architecture docs, flags undocumented patterns

**2 Cron Jobs:**
- **SM sprint health** (every 4h): blocked stories, stale PRs, idle workers
- **QA coverage audit** (weekly): per-package coverage trend analysis vs stored baseline

**Key Architecture Decisions:**
- Message-driven communication via `multiclaude message send` (no shared state files)
- Hub-and-spoke topology (PM hub + Architect independent loop)
- Authority boundaries: each agent edits only its designated doc domain
- Correlation IDs prevent circular notification loops
- Idempotent operations enable safe restart/recovery

## Artifacts Created

| File | Purpose |
|------|---------|
| `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-08-persistent-agents.md` | PM course correction with full checklist analysis |
| `_bmad-output/planning-artifacts/persistent-agents-course-correction-party-mode.md` | Party mode validation with adopted/rejected options |
| `_bmad-output/planning-artifacts/architecture-persistent-agent-infrastructure.md` | Architecture decision document |
| `docs/stories/37.1.story.md` | Agent definitions (project-watchdog + arch-watchdog) |
| `docs/stories/37.2.story.md` | Cron configuration (SM + QA) |
| `docs/stories/37.3.story.md` | Agent communication architecture documentation |
| `docs/stories/37.4.story.md` | Monitoring, tuning, and Phase 1 evaluation |
| `docs/prd/product-scope.md` | Updated with "Phase 5+: Autonomous Project Governance" |
| `docs/prd/epics-and-stories.md` | Updated with Epic 37 breakdown |

## Opportunities (Not Implemented)

- Adaptive polling intervals (increase during high-merge, decrease during quiet periods)
- Promoting SM/QA cron to persistent if cron proves insufficient
- Webhook-based triggers if multiclaude adds support
- Tech Writer persistent agent if doc staleness remains a problem

## Test Plan

- [ ] All planning artifacts have both adopted AND rejected options documented
- [ ] Story files follow existing story format (status, epic, ACs, technical notes, quality gate)
- [ ] PRD scope addition is consistent with existing phase numbering
- [ ] Epic 37 in epics-and-stories.md matches story files
- [ ] No Epic number conflicts (confirmed Epic 36 was already taken)
- [ ] Stories reference the research PR #249 and planning artifacts