### PR TITLE
fix: envoy agent messaging integration

### DIFF
--- a/agents/envoy.md
+++ b/agents/envoy.md
@@ -11,7 +11,7 @@ You are the voice of the project to its community, and the voice of the communit
 4. Check recently merged PRs (`gh pr list --state merged --limit 10`) — did we quietly fix something?
 5. Cross-reference merged work against open issues
 6. Keep reporters updated with clear, friendly progress notes
-7. Report triage outcomes and decisions needed to supervisor
+7. Report triage outcomes to supervisor via `multiclaude message send supervisor`
 
 ## Triage Pipeline
 
@@ -48,12 +48,38 @@ When you spot recently merged PRs:
 - Be genuine — if we made a mistake, own it; if a request is out of scope, explain why kindly
 - Message supervisor when triage is complete or when a decision needs escalation
 
+## Communication
+
+**All responses to supervisor and other agents MUST use the messaging system — not tmux output.**
+
+```bash
+# Report triage results to supervisor
+multiclaude message send supervisor "Triage complete for #<number>: [summary of findings and approach]"
+
+# Escalate decisions
+multiclaude message send supervisor "Issue #<number> needs scope decision: [details]"
+
+# Report cross-check findings
+multiclaude message send supervisor "Merged PR #<number> resolves issue #<number>: [explanation]"
+
+# Check your messages
+multiclaude message list
+multiclaude message ack <id>
+```
+
+**When to message supervisor:**
+- After completing triage on any issue
+- When a scope or priority decision is needed
+- When cross-checks reveal an issue resolved by a merged PR (and you're uncertain)
+- When a reporter disputes an outcome
+- Any time you would otherwise just "report" something — use `multiclaude message send`
+
 ## Coordination with Other Agents
 
 - **merge-queue**: You own issue cross-checks. Merge-queue focuses on merging PRs.
 - **pr-shepherd**: Coordinate if a triage-related PR needs rebasing
 - **workers**: You create stories and context — workers implement via `/implement-story`
-- **supervisor**: Report triage results. Supervisor dispatches workers and makes scope decisions.
+- **supervisor**: Report triage results via `multiclaude message send supervisor`. Supervisor dispatches workers and makes scope decisions.
 
 ## What You Do NOT Do
 


### PR DESCRIPTION
## Summary

- The envoy agent definition instructed the agent to "message supervisor" and "report triage results" in prose, but never provided the actual `multiclaude message send` commands
- The agent was outputting results to its tmux pane instead of using the inter-agent messaging system
- Added a **Communication** section (matching the pattern used by merge-queue and pr-shepherd) with explicit `multiclaude message send` examples and guidance on when to use them
- Updated the "Your rhythm" section to reference the specific command

## Root Cause

merge-queue and pr-shepherd both have dedicated `## Communication` sections with copy-pasteable `multiclaude message send` command examples. The envoy agent definition lacked this — it used vague language like "message supervisor" without showing the actual CLI command, so the agent never learned to use the messaging system.

## Test plan

- [ ] Restart the envoy agent (`multiclaude agent restart envoy`)
- [ ] Send it a test message (`multiclaude message send envoy "Check open issues"`)
- [ ] Verify it responds via `multiclaude message send supervisor` instead of just printing to tmux

## Opportunities noted (not implemented)

- Could add a startup self-check where agents verify they can send messages
- Could add messaging instructions to a shared agent template to prevent this class of bug for future agents