### PR TITLE
fix: CI release duplicate asset error (#283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,7 @@ jobs:
           rm -rf unsigned-binaries
 
       - name: List release files
-        run: ls -la threedoors-* *.pkg *.dmg 2>/dev/null || true
+        run: ls -la threedoors-* 2>/dev/null || true
 
       - name: Create GitHub Release
         env:
@@ -483,7 +483,7 @@ jobs:
           **Homebrew (alpha):** \`brew install arcaven/tap/threedoors-a\`"
 
           ASSETS=()
-          for f in threedoors-* *.pkg *.dmg; do
+          for f in threedoors-*; do
             [ -f "$f" ] && ASSETS+=("$f")
           done
 


### PR DESCRIPTION
## Summary

- Fix duplicate asset error in the CI release job caused by overlapping glob patterns
- The glob `threedoors-* *.pkg *.dmg` double-matched `.pkg` and `.dmg` files because `threedoors-*` already matches `threedoors-arm64.pkg`, `threedoors-amd64.pkg`, `threedoors-arm64.dmg`, and `threedoors-amd64.dmg` — then `*.pkg` and `*.dmg` matched them again
- Simplified to just `threedoors-*` in both the `ls` diagnostic step and the asset-gathering loop

Closes #283

## Note

This PR modifies `.github/workflows/ci.yml` and will require manual merge (OAuth token lacks `workflow` scope).

## Test plan

- [x] `make test` passes — workflow-only change, no Go code modified
- [ ] Verify next merge-to-main release job succeeds without duplicate asset errors