### PR TITLE
docs: Add Homebrew Installation Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,19 @@ Traditional task lists create **choice paralysis**. Staring at 50+ tasks makes i
 
 ## 📦 Installation
 
-### Option 1: Homebrew (macOS)
+### Option 1: Homebrew (recommended)
 
 ```bash
 brew install arcaven/tap/threedoors
 ```
+
+**Alpha channel** — latest development builds from `main`:
+
+```bash
+brew install arcaven/tap/threedoors-a
+```
+
+Both can be installed side-by-side. Stable runs as `threedoors`, alpha runs as `threedoors-a`.
 
 ### Option 2: Download Pre-built Binary
 


### PR DESCRIPTION
## Summary
- Updates the Installation section of `README.md` to document the alpha Homebrew channel (`arcaven/tap/threedoors-a`)
- Notes that stable and alpha can be installed side-by-side, with stable running as `threedoors` and alpha as `threedoors-a`
- Changes "Homebrew (macOS)" label to "Homebrew (recommended)" to reflect cross-platform intent

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `brew install arcaven/tap/threedoors` and `brew install arcaven/tap/threedoors-a` instructions are accurate