### PR TITLE
docs: Epic 39 — Keybinding Display System planning

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,6 +153,18 @@ Parallel Homebrew distribution channels (stable + alpha) with signing parity, pu
 | 38.4 | Alpha Release Verification | Not Started | P2 | 38.1, 38.2 |
 | 38.5 | Alpha Release Retention Cleanup | Not Started | P2 | None |
 
+### Epic 39: Keybinding Display System (P1) — 0/5 stories done
+
+Toggleable keybinding bar and full overlay for TUI discoverability. Context-sensitive bottom bar shows key actions per view; `?` opens comprehensive reference overlay.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 39.1 | Keybinding Registry Model | Not Started | P1 | None |
+| 39.2 | Concise Keybinding Bar Component | Not Started | P1 | 39.1 |
+| 39.3 | Full Keybinding Overlay | Not Started | P1 | 39.1 |
+| 39.4 | Toggle Behavior, Config Persistence, and MainModel Integration | Not Started | P1 | 39.2, 39.3 |
+| 39.5 | View-Specific Keybinding Completeness and Polish | Not Started | P1 | 39.4 |
+
 ## Completed Epics
 
 | Epic | Title | Stories |

--- a/_bmad-output/planning-artifacts/keybinding-display-architecture.md
+++ b/_bmad-output/planning-artifacts/keybinding-display-architecture.md
@@ -1,0 +1,289 @@
+# Architecture Review: Keybinding Display System
+
+**Date:** 2026-03-08
+**Reviewer:** Winston (Architect)
+**Input:** Party mode consensus + UX designer review
+
+---
+
+## Architectural Fit Assessment
+
+**Verdict: Clean fit.** The keybinding display system integrates naturally into the existing Bubbletea MVU architecture without requiring structural changes. All modifications are additive — no existing interfaces change, no existing packages are reorganized.
+
+---
+
+## Component Design
+
+### 1. Keybinding Registry (`internal/tui/keybindings.go`)
+
+A new file in the existing `internal/tui/` package. No new package needed — this is a TUI concern.
+
+```go
+// KeyBinding represents a single key-action mapping for display purposes.
+type KeyBinding struct {
+    Key         string // Display string: "a/w/d", "enter", "esc"
+    Description string // Human-readable: "Select door", "Confirm"
+    Priority    int    // 1=bar, 2=bar if space, 3=overlay only
+}
+
+// KeyBindingGroup organizes bindings by category for overlay display.
+type KeyBindingGroup struct {
+    Name     string       // "Navigation", "Actions", "Views", etc.
+    Bindings []KeyBinding
+}
+
+// viewKeyBindings returns the keybinding groups for a given view mode.
+// This is a pure function — all data is compile-time constant.
+func viewKeyBindings(mode ViewMode) []KeyBindingGroup { ... }
+
+// barBindings returns the priority-1 bindings for the bar, filtered by mode.
+func barBindings(mode ViewMode) []KeyBinding { ... }
+
+// allKeyBindingGroups returns all bindings across all views for the overlay.
+func allKeyBindingGroups() []KeyBindingGroup { ... }
+```
+
+**Design decisions:**
+- Pure functions, not a struct with methods. There's no state to manage.
+- No interface needed. Only the TUI package consumes this.
+- Data is hardcoded, not loaded from config. All bindings are known at compile time (D-KB-3 from party mode).
+- Priority field enables the bar to select which keys to show without separate bar/overlay data structures.
+
+### 2. Bar Component (`internal/tui/keybinding_bar.go`)
+
+A stateless rendering function, not a Bubbletea model. The bar has no internal state — it receives the current ViewMode, terminal width, and toggle state, and returns a rendered string.
+
+```go
+// RenderKeybindingBar renders the concise keybinding bar for the given view.
+// Returns empty string if disabled or terminal too small.
+func RenderKeybindingBar(mode ViewMode, width int, height int, enabled bool) string { ... }
+```
+
+**Rendering logic:**
+1. If `!enabled` or `height < 10`: return `""`
+2. Get `barBindings(mode)`
+3. Format as `key Description   key Description   ...`
+4. If `width < 40`: show only `? Help`
+5. If total formatted width > terminal width: truncate from right, always keep `?` last
+6. Prepend separator line (`─` repeated to width)
+7. Apply dim Lipgloss styling
+
+**Height accounting:**
+The bar consumes 2 lines (separator + bindings). When the bar is visible, MainModel must subtract 2 from the height passed to view components. This is critical — views that use height for door rendering (DoorsView) must receive the correct available height.
+
+### 3. Overlay Component (`internal/tui/keybinding_overlay.go`)
+
+A stateless rendering function with optional scroll state.
+
+```go
+// OverlayState holds the scroll position for the keybinding overlay.
+type OverlayState struct {
+    ScrollOffset int
+    ViewMode     ViewMode // Current view when overlay was opened
+}
+
+// RenderKeybindingOverlay renders the full-screen keybinding reference.
+func RenderKeybindingOverlay(state OverlayState, width int, height int) string { ... }
+```
+
+**Rendering logic:**
+1. Get `allKeyBindingGroups()`
+2. Sort so the current ViewMode's group appears first (context highlighting)
+3. Render bordered box using Lipgloss
+4. Apply scroll offset if content exceeds height
+5. Fixed footer: "Press ? or esc to close   ↑/↓ to scroll"
+
+### 4. MainModel Integration
+
+Changes to `internal/tui/main_model.go`:
+
+```go
+type MainModel struct {
+    // ... existing fields ...
+    showKeybindingBar     bool          // Toggle state
+    showKeybindingOverlay bool          // Overlay visible
+    overlayState          OverlayState  // Scroll position
+}
+```
+
+**Update() changes:**
+- Global `?` handler (at MainModel level, before view dispatch):
+  - If overlay shown: dismiss overlay
+  - If overlay not shown: show overlay
+- Global `h` handler (at MainModel level):
+  - Toggle `showKeybindingBar`
+  - Persist to config.yaml (via tea.Cmd to avoid blocking)
+- When overlay is shown: intercept all keys except `?`, `esc`, `↑/↓/j/k` (scroll)
+- Guard: skip `?` and `h` handlers when `isTextInputActive()` returns true
+
+**View() changes:**
+```go
+func (m *MainModel) View() string {
+    if m.showKeybindingOverlay {
+        return RenderKeybindingOverlay(m.overlayState, m.width, m.height)
+    }
+
+    // Calculate available height for content
+    contentHeight := m.height
+    barOutput := ""
+    if m.showKeybindingBar {
+        barOutput = RenderKeybindingBar(m.viewMode, m.width, m.height, true)
+        if barOutput != "" {
+            contentHeight -= 2 // separator + bar
+        }
+    }
+
+    // Render current view with adjusted height
+    viewOutput := m.renderCurrentView(contentHeight)
+
+    if barOutput != "" {
+        return viewOutput + "\n" + barOutput
+    }
+    return viewOutput
+}
+```
+
+### 5. Config Persistence
+
+Extend the existing `config.yaml` schema:
+
+```yaml
+show_keybinding_bar: true  # default true for new installs
+```
+
+The config write happens asynchronously via `tea.Cmd` when the user presses `h`. This follows the existing pattern used by theme persistence (Epic 17).
+
+---
+
+## Impact on Existing Code
+
+### Files Modified
+
+| File | Change | Risk |
+|------|--------|------|
+| `internal/tui/main_model.go` | Add fields, Update() handlers, View() wrapping | Medium — core file, needs careful integration |
+| `internal/tui/styles.go` | Add bar styling constants | Low — additive only |
+
+### Files Created
+
+| File | Purpose |
+|------|---------|
+| `internal/tui/keybindings.go` | Registry data + pure functions |
+| `internal/tui/keybindings_test.go` | Registry tests |
+| `internal/tui/keybinding_bar.go` | Bar rendering |
+| `internal/tui/keybinding_bar_test.go` | Bar rendering tests |
+| `internal/tui/keybinding_overlay.go` | Overlay rendering |
+| `internal/tui/keybinding_overlay_test.go` | Overlay rendering tests |
+
+### Files NOT Modified
+
+- No changes to individual view files (DoorsView, DetailView, etc.)
+- No changes to `internal/core/` or any domain logic
+- No changes to `internal/tui/themes/` — bar is theme-independent
+- No changes to CLI commands
+
+---
+
+## Performance Analysis
+
+### Bar Rendering Overhead
+
+The bar renders on every `View()` call. Assessment:
+- `barBindings()` iterates a small slice (~6 items per view). Cost: negligible.
+- String formatting with Lipgloss. Cost: microseconds.
+- This is the same order of magnitude as the existing footer message in DoorsView.
+
+**Verdict: No performance concern.**
+
+### Overlay Rendering
+
+The overlay only renders when `showKeybindingOverlay == true`. When not shown, cost is zero (early return in View()). When shown, it renders a static document. Cost: trivially small.
+
+**Verdict: No performance concern.**
+
+### Height Recalculation
+
+Subtracting 2 from height when bar is visible changes the height passed to views. DoorsView uses height for door proportions (Epic 35). The 2-line reduction is negligible relative to typical terminal heights (24-50+ lines).
+
+**Verdict: No layout concern for terminals >= 15 lines. Auto-hide handles smaller terminals.**
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Registry tests** (`keybindings_test.go`):
+   - Every ViewMode has at least one binding
+   - Every ViewMode has `?` (help) in its bindings
+   - Priority-1 bindings don't exceed 8 per view
+   - No duplicate keys within a view's bindings
+   - `allKeyBindingGroups()` covers all views
+
+2. **Bar rendering tests** (`keybinding_bar_test.go`):
+   - Correct output for each view mode
+   - Width truncation at 40, 60, 80 columns
+   - Height < 10 returns empty string
+   - Disabled returns empty string
+   - Compact mode at height 10-15
+
+3. **Overlay rendering tests** (`keybinding_overlay_test.go`):
+   - Full content rendering
+   - Scroll offset works correctly
+   - Current view section appears first
+   - Footer always visible
+
+### Golden File Tests
+
+New golden files for:
+- Bar at each major view mode (DoorsView, DetailView) at 80-col width
+- Overlay at 80x24 terminal size
+- Compact bar at 60-col width
+
+### Integration Tests
+
+- `?` key opens/closes overlay
+- `h` key toggles bar
+- Bar content changes when switching views
+- Text input views suppress `?` and `h` handlers
+
+---
+
+## Dependency Analysis
+
+### Prerequisites
+
+None. This epic has no dependencies on unmerged work. All required infrastructure exists:
+- Lipgloss for styling
+- Config.yaml persistence pattern (from Epic 17 theme picker)
+- MainModel View() composition pattern
+- `isTextInputActive()` guard (from D-059)
+
+### Downstream Impact
+
+None. This is an additive feature with no API changes.
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Bar height accounting breaks door rendering | Low | Medium | Comprehensive golden file tests with bar on/off |
+| `?` conflicts with future key binding | Low | Low | `?` is universally understood as help; unlikely to be reassigned |
+| `h` conflicts with future key binding | Medium | Low | If conflict arises, remap bar toggle; `h` for help/hide is intuitive |
+| Overlay blocks important messages | Low | Medium | Overlay dismissible with both `?` and `esc`; flash messages queue until overlay dismissed |
+
+---
+
+## Decisions Summary
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| KB-ARCH-1 | Bar and overlay are stateless rendering functions, not Bubbletea models | No internal state to manage; pure functions are simpler and more testable |
+| KB-ARCH-2 | Registry uses pure functions, not a struct | No state, no registration; all data is compile-time constant |
+| KB-ARCH-3 | All new code in `internal/tui/` package, no new packages | This is exclusively a TUI concern; new package would be over-abstraction |
+| KB-ARCH-4 | MainModel orchestrates bar/overlay, views are unaware | Clean separation; no per-view changes needed |
+| KB-ARCH-5 | Overlay intercepts keystrokes when visible | Prevents accidental actions while reading help |
+| KB-ARCH-6 | Height adjustment for bar is MainModel's responsibility | Views receive correct available height; no view-level awareness of bar |
+| KB-ARCH-7 | Config persistence via async tea.Cmd | Non-blocking; follows existing theme persistence pattern |

--- a/_bmad-output/planning-artifacts/keybinding-display-party-mode.md
+++ b/_bmad-output/planning-artifacts/keybinding-display-party-mode.md
@@ -1,0 +1,282 @@
+# Party Mode: Keybinding Display System for ThreeDoors TUI
+
+**Date:** 2026-03-08
+**Participants:** John (PM), Sally (UX Designer), Winston (Architect), Quinn (QA), Amelia (Dev)
+**Topic:** Toggleable keybinding display bar and full keybinding overlay
+
+---
+
+## Round 1: Initial Feature Analysis
+
+### John (PM): SOUL.md Alignment Check
+
+The first question here is: does this feature pass the SOUL.md smell test? Let me run through the principles:
+
+1. **"Three Doors, Not Three Hundred"** — This is the tension point. A keybinding bar adds visual information. However, it's meta-information (how to use the app) not task information (more things to do). It doesn't add more doors or more choices. It helps the user interact with the three doors they already have. That's discoverability, not feature creep.
+
+2. **"Every Interaction Should Feel Deliberate"** — The bar actively supports this. If users don't know which keys are available, they can't interact deliberately. They fumble. Fumbling is the opposite of deliberate. The bar transforms uncertainty into confidence.
+
+3. **"Progress Over Perfection"** — Users who don't know about `c` for complete or `e` for expand are stuck. The bar directly reduces friction to starting.
+
+4. **"Meet Users Where They Are"** — Power users want a clean screen. New users need guidance. Toggleable solves both. This is exactly the pattern nano, vim, and htop use.
+
+**Verdict: ALIGNED.** This feature reduces friction, improves discoverability, and the toggle mechanism prevents it from becoming visual clutter. It's infrastructure that makes the existing experience better, not a new thing to manage.
+
+### Sally (UX Designer): User Journey Analysis
+
+Looking at this from the user's perspective, there's a clear discoverability problem today. ThreeDoors has 18 view modes and dozens of key bindings. The onboarding flow (Epic 10) teaches some keys, but users forget. The current experience:
+
+1. User opens ThreeDoors → sees three doors
+2. User thinks "how do I select one?" → must remember or guess
+3. User remembers `a/w/d` → great, but what about `:` commands?
+4. User never discovers `e` (expand), `f` (fork), `x` (dispatch) → features are invisible
+
+**The bar solves the "what can I do right now?" question.** This is a fundamental UX primitive — progressive disclosure of available actions.
+
+Key UX insight: The bar should show only the 4-6 most important keys for the current view. Not all keys. The overlay (`?`) shows everything. The bar is a teaser, the overlay is the reference.
+
+### Winston (Architect): Technical Feasibility
+
+From an architecture perspective, this maps cleanly to the existing Bubbletea MVU pattern:
+
+1. **Bar component**: A new component that receives the current ViewMode and returns a rendered string. The MainModel's `View()` appends it to the bottom.
+2. **Overlay**: A new ViewMode (`ViewKeybindingOverlay`) or a modal layer that overlays the current view.
+3. **Registry**: A data structure mapping ViewMode → []KeyBinding, where each KeyBinding has a key, description, and priority (for bar vs overlay-only).
+4. **Toggle state**: A bool on MainModel (`showKeybindingBar`), persisted in config.yaml.
+
+No new interfaces needed. No new packages needed. This lives entirely in `internal/tui/`.
+
+---
+
+## Round 2: Design Deep Dive
+
+### Sally (UX Designer): Bar Layout Proposal
+
+Drawing from nano, vim, and htop patterns:
+
+**Nano-style approach (ADOPTED):**
+```
+ a←  w↑  d→ Select   s↓ Re-roll   enter Confirm   ? Help   : Cmd
+```
+
+Key principles:
+- Keys are left-aligned, descriptions follow
+- Separator character between groups (double space)
+- Muted/dim styling so it doesn't compete with doors
+- One line maximum — if terminal is too narrow, truncate from right
+- The `?` key is always shown (it's the escape hatch to full help)
+
+**Bar key selection per view (top 6-8 keys only):**
+
+| View | Keys Shown |
+|------|-----------|
+| DoorsView (no selection) | `a/w/d` Select, `s` Re-roll, `n` Add, `/` Search, `:` Cmd, `?` Help |
+| DoorsView (selected) | `enter` Confirm, `a/w/d` Change, `s` Re-roll, `esc` Deselect, `?` Help |
+| DetailView | `esc` Back, `c` Complete, `b` Blocked, `e` Expand, `f` Fork, `?` Help |
+| SearchView | `esc` Close, `enter` Select, `↑/↓` Navigate, `?` Help |
+| AddTaskView | `enter` Save, `esc` Cancel, `?` Help |
+| MoodView | `1-5` Select, `esc` Cancel, `?` Help |
+| Other views | `esc` Back, `?` Help (minimal) |
+
+### Winston (Architect): Keybinding Registry Design
+
+The registry pattern is the right approach. Each view registers its bindings, and the bar/overlay components query it:
+
+```go
+type KeyBinding struct {
+    Key         string   // Display string: "a/w/d", "enter", "ctrl+c"
+    Description string   // "Select door", "Confirm"
+    Priority    int      // 1=always show in bar, 2=bar if space, 3=overlay only
+}
+
+type KeyBindingSet struct {
+    ViewMode ViewMode
+    Bindings []KeyBinding
+}
+```
+
+The registry is a `map[ViewMode][]KeyBinding` initialized at startup. No runtime registration needed — all bindings are known at compile time.
+
+For the overlay, it should be a modal that renders ON TOP of the current view (not a ViewMode transition). This preserves the user's context — they can see what they're working with while reading the help.
+
+### Quinn (QA): Testing Strategy
+
+Testing plan:
+1. **Registry correctness**: Every ViewMode has at least `?` (help) and `esc`/`q` (exit) registered
+2. **Bar rendering**: Golden file tests for bar at various widths (80, 120, 40 cols)
+3. **Overlay rendering**: Golden file tests for full overlay
+4. **Toggle persistence**: Config read/write for `show_keybinding_bar` setting
+5. **Auto-hide**: Bar disappears when terminal height < threshold
+6. **Context sensitivity**: Bar content changes when ViewMode changes
+
+---
+
+## Round 3: Refinement and Edge Cases
+
+### Sally (UX Designer): Terminal Size Handling
+
+**Small terminal strategy:**
+- Terminal height < 10 lines: Bar auto-hides regardless of toggle state (doors need the space)
+- Terminal height 10-15 lines: Bar shows in compact mode (keys only, no descriptions)
+- Terminal height > 15 lines: Full bar with descriptions
+
+**Small terminal width strategy:**
+- Width < 40: Show only `?` Help
+- Width 40-80: Show top 4 keys + `?`
+- Width > 80: Show full bar
+
+### Winston (Architect): Overlay Design
+
+The overlay should NOT be a new ViewMode. Reasons:
+1. Adding ViewMode means MainModel Update() needs a new case
+2. ViewMode transition clears the previous view (bad for context)
+3. The overlay is ephemeral — press `?` to show, `?` or `esc` to dismiss
+
+Instead, use a `showOverlay bool` on MainModel. In View():
+```
+if m.showOverlay {
+    return renderOverlay(m.viewMode, m.width, m.height)
+}
+return normalView()
+```
+
+The overlay renders a semi-transparent (dimmed background) full-screen panel listing ALL keybindings organized by category.
+
+### John (PM): Scope Decision
+
+We need to resist scope creep here. What's NOT in this epic:
+- Custom keybinding remapping (different epic, if ever)
+- Animated transitions when bar appears/disappears
+- Keybinding tutorials or interactive walkthroughs
+- Per-key tooltips on hover (this is a TUI, no hover)
+
+What IS in this epic:
+- Static keybinding registry (data model)
+- Concise bar component (bottom bar)
+- Full overlay component (? key)
+- Toggle + persistence (config.yaml)
+- Integration with all existing views
+- Terminal size adaptation
+
+### Amelia (Dev): Implementation Concerns
+
+Looking at the codebase, the MainModel.View() currently returns the view's output directly. To add the bar, we need to:
+
+1. Calculate available height for the view (total height - bar height if shown)
+2. Pass reduced height to view components
+3. Append bar to the bottom of every view's output
+
+This means the bar is rendered by MainModel, not by individual views. Views don't know about the bar. This is clean separation.
+
+For the overlay, the `Update()` handler for `?` needs to be in MainModel (global level), similar to how `q` is handled for universal quit (D-059). The overlay captures all keystrokes except `?` (toggle off) and `esc` (dismiss).
+
+---
+
+## Round 4: Final Consensus
+
+### Decisions Summary
+
+| ID | Decision | Adopted | Rejected | Rationale |
+|----|----------|---------|----------|-----------|
+| KB-1 | Bar rendering location | MainModel.View() appends bar | Per-view bar rendering | Clean separation; views don't know about bar |
+| KB-2 | Overlay implementation | Boolean flag on MainModel, not new ViewMode | New ViewMode for overlay | Preserves user context; overlay is ephemeral |
+| KB-3 | Keybinding data source | Compile-time registry (map[ViewMode][]KeyBinding) | Config file / runtime registration | All bindings are known at compile time; YAGNI |
+| KB-4 | Bar key selection | Priority-based (1=always, 2=space permitting, 3=overlay only) | Show all keys | SOUL.md: show less, not more |
+| KB-5 | Toggle persistence | config.yaml `show_keybinding_bar: true/false` | In-memory only | User preference should survive restarts |
+| KB-6 | Toggle key | `?` toggles bar visibility; also opens overlay on first press, second press toggles bar | Separate keys for bar toggle and overlay | `?` is universally understood as "help" |
+| KB-7 | Small terminal handling | Auto-hide bar below 10 lines height; compact mode 10-15 lines | Always show bar regardless of size | Doors must have priority for screen space |
+| KB-8 | Bar styling | Dim/muted text, single line, Lipgloss styled | Bright/prominent bar | Bar must not compete with doors for visual attention |
+| KB-9 | Overlay styling | Full-screen dimmed background with bright keybinding list | Floating popup / partial overlay | Full screen provides best readability; dimmed bg preserves context sense |
+| KB-10 | `?` key behavior | Single press: show overlay. `h` key: toggle bar. | `?` for both | Separating concerns: `?` = "help me now", `h` = "I want persistent help bar" |
+
+### Revised Decision KB-6/KB-10
+
+After further discussion, the team revised the `?` behavior:
+
+- **`?`** opens/closes the full keybinding overlay (modal help screen)
+- **`h`** toggles the persistent bottom bar on/off
+- This separates "I need help right now" (`?`) from "I want ongoing reference" (`h`)
+- Both are documented in the bar itself and in the overlay
+
+---
+
+## Story Breakdown (PM Recommendation)
+
+1. **39.1: Keybinding Registry Model** — Data types and per-view keybinding definitions
+2. **39.2: Concise Keybinding Bar Component** — Bottom bar rendering with Lipgloss styling
+3. **39.3: Full Keybinding Overlay** — Modal overlay showing all bindings
+4. **39.4: Toggle Behavior and Config Persistence** — `h` toggle, config.yaml persistence, terminal size adaptation
+5. **39.5: View Integration and Polish** — Wire bar/overlay into all 18 view modes, ensure context-sensitivity
+
+---
+
+## Appendix: ASCII Mockups
+
+### Doors View with Bar
+
+```
+  ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
+  │              │   │              │   │              │
+  │   Door 1     │   │   Door 2     │   │   Door 3     │
+  │   Fix bug    │   │   Write docs │   │   Review PR  │
+  │              │   │              │   │              │
+  │              │   │              │   │              │
+  └──────────────┘   └──────────────┘   └──────────────┘
+
+  Pick a door. Any door. Let's go.
+
+  a←  w↑  d→ Select   s↓ Re-roll   n Add   / Search   : Cmd   ? Help
+```
+
+### Detail View with Bar
+
+```
+  ── Fix authentication bug ──────────────────────────
+
+  Status: active
+  Source: tasks.txt
+  Created: 2026-03-08
+
+  This needs to be fixed before the release...
+
+  esc Back   c Complete   b Blocked   e Expand   f Fork   ? Help
+```
+
+### Full Overlay (? key)
+
+```
+  ╔══════════════════════════════════════════════════╗
+  ║              KEYBINDING REFERENCE                ║
+  ╠══════════════════════════════════════════════════╣
+  ║                                                  ║
+  ║  NAVIGATION                                      ║
+  ║  a / ←     Select Door 1                         ║
+  ║  w / ↑     Select Door 2                         ║
+  ║  d / →     Select Door 3                         ║
+  ║  s / ↓     Re-roll doors                         ║
+  ║  enter     Confirm selection                     ║
+  ║  esc       Back / Deselect                       ║
+  ║                                                  ║
+  ║  ACTIONS                                         ║
+  ║  c          Complete task                        ║
+  ║  b          Mark blocked                         ║
+  ║  i          Mark in-progress                     ║
+  ║  e          Expand (add subtasks)                ║
+  ║  f          Fork (create variant)                ║
+  ║  n          Add new task                         ║
+  ║  u          Undo completion                      ║
+  ║                                                  ║
+  ║  VIEWS                                           ║
+  ║  /          Search                               ║
+  ║  :          Command mode                         ║
+  ║  m          Mood check                           ║
+  ║  S          Sync status                          ║
+  ║                                                  ║
+  ║  DISPLAY                                         ║
+  ║  h          Toggle keybinding bar                ║
+  ║  ?          This help overlay                    ║
+  ║  q          Quit                                 ║
+  ║                                                  ║
+  ║           Press ? or esc to close                ║
+  ╚══════════════════════════════════════════════════╝
+```

--- a/_bmad-output/planning-artifacts/keybinding-display-ux-review.md
+++ b/_bmad-output/planning-artifacts/keybinding-display-ux-review.md
@@ -1,0 +1,216 @@
+# UX Designer Review: Keybinding Display System
+
+**Date:** 2026-03-08
+**Reviewer:** Sally (UX Designer)
+**Input:** Party mode consensus from keybinding-display-party-mode.md
+
+---
+
+## Executive Summary
+
+The keybinding display feature addresses a real discoverability gap in ThreeDoors. With 18 view modes and 40+ keybindings, users currently rely on memory or onboarding recall. The proposed bar + overlay pattern is well-established (nano, vim, htop) and aligns with SOUL.md's principle of reducing friction.
+
+**Recommendation: APPROVED with refinements below.**
+
+---
+
+## Visual Hierarchy Analysis
+
+### Current State
+
+The TUI has a clear visual hierarchy:
+1. **Primary:** Three door panels (the focal point)
+2. **Secondary:** Greeting text and footer message
+3. **Tertiary:** Status indicators (sync, conflicts, proposals)
+
+### Proposed State with Bar
+
+The bar must sit at the **quaternary** level — below everything else in visual importance:
+
+1. **Primary:** Three door panels (unchanged)
+2. **Secondary:** Greeting + footer (unchanged)
+3. **Tertiary:** Status indicators (unchanged)
+4. **Quaternary:** Keybinding bar (new — subtle, available, not attention-grabbing)
+
+### Styling Recommendations
+
+The bar MUST be visually recessive:
+- **Color:** Use `Faint(true)` or a dim gray foreground. Never the theme's accent color.
+- **Weight:** No bold text. The bar should feel like a watermark, not a toolbar.
+- **Separator:** A thin horizontal rule (single `─` character repeated) above the bar separates it from content. Styled with the same dim treatment.
+- **Background:** No background color. Transparent to the terminal default.
+
+Why: The doors are the product. The bar is infrastructure. Infrastructure should be invisible until you need it.
+
+---
+
+## Information Density Analysis
+
+### Bar Content Strategy: "The Five Essential Actions"
+
+For each view, show at most 5-6 key groups. The rule: **if a user can only learn 5 things about this screen, what would they be?**
+
+#### DoorsView (no selection)
+
+```
+ a/w/d Select   s Re-roll   n Add   : Cmd   h Bar   ? Help
+```
+
+Why these 6:
+- `a/w/d` — The primary action. You must select a door.
+- `s` — Re-roll is the escape valve. Users need to know they can get new doors.
+- `n` — Adding tasks is a power feature people forget about.
+- `:` — Command mode unlocks all hidden commands.
+- `h` — Self-referential: tells users how to hide the bar.
+- `?` — The escape hatch to full reference.
+
+Dropped from bar (overlay-only): `/` (search, redundant with `:search`), `m` (mood, secondary), `S` (sync status, rare), `q` (quit, discoverable).
+
+#### DoorsView (door selected)
+
+```
+ enter Confirm   a/w/d Change   s New doors   esc Deselect   ? Help
+```
+
+Why the change: Once a door is selected, the primary action changes to confirm. The bar should reflect the user's new decision context.
+
+#### DetailView
+
+```
+ esc Back   c Done   b Blocked   e Expand   f Fork   ? Help
+```
+
+Why: These are the core task management actions. `i` (in-progress), `p` (procrastinate), `r` (reconsider), `x` (dispatch), `g` (generate), `d` (delete), `u` (undo) are secondary — they go in the overlay.
+
+#### Text Input Views (AddTask, Search)
+
+```
+ enter Submit   esc Cancel   ? Help
+```
+
+Minimal. The user is typing — don't distract with navigation keys that aren't active.
+
+#### Modal/Selection Views (Mood, ThemePicker, Onboarding)
+
+```
+ ↑/↓ Navigate   enter Select   esc Back   ? Help
+```
+
+Generic navigation pattern. Keep it simple.
+
+---
+
+## Discoverability vs Clutter Tradeoff
+
+### The Tension
+
+SOUL.md says "show less." But showing zero help means users don't discover features. The resolution:
+
+**Default: bar ON for new users, OFF for power users.**
+
+Implementation:
+- First-run (no config.yaml exists): `show_keybinding_bar: true`
+- After user presses `h` to hide: `show_keybinding_bar: false` (persisted)
+- User can always press `h` to toggle or `?` for full help
+
+This matches the nano model: nano shows `^G Help ^O Write Out` by default. Power users know to look at the menu. New users see the bar and learn.
+
+### Progressive Disclosure Ladder
+
+1. **Bar** (persistent, 5-6 keys) — "What can I do right now?"
+2. **Overlay** (on-demand, all keys) — "What are ALL my options?"
+3. **Onboarding** (first-run, tutorial) — "Let me teach you the basics"
+
+The bar is the middle rung. It bridges the gap between onboarding (which users forget) and the overlay (which users don't know exists until they see `?` in the bar).
+
+---
+
+## Interaction Patterns
+
+### Bar Toggle (`h`)
+
+- Press `h`: bar disappears immediately. No animation. (SOUL.md: "every interaction should feel deliberate" — instant response)
+- Press `h` again: bar reappears immediately.
+- State persisted to config.yaml on change.
+
+### Overlay (`?`)
+
+- Press `?`: overlay appears instantly, covering the full screen with a dimmed background.
+- The overlay shows ALL keybindings for ALL views, organized by category.
+- Press `?` or `esc` to dismiss.
+- The overlay is context-highlighted: the current view's section is at the top or visually emphasized.
+
+Why not view-specific overlay content? Because the overlay is a reference document. Users open it when they're confused and might not know which view they're in. Showing everything with context highlighting serves both "where am I?" and "what can I do?" questions.
+
+### Key Conflict Check
+
+- `?` is currently unused across all views. Safe.
+- `h` is currently unused across all views. Safe.
+
+---
+
+## Accessibility and Readability
+
+### Contrast Requirements
+
+- Bar text must be readable against common terminal backgrounds (dark and light themes).
+- Use Lipgloss `Foreground()` with adaptive color (ANSI 240-245 range for dark themes, 100-105 for light themes).
+- Do NOT use `Faint(true)` alone — some terminals render faint text as invisible. Use explicit dim foreground color instead.
+
+### Terminal Size Graceful Degradation
+
+| Terminal Height | Behavior |
+|----------------|----------|
+| < 10 lines | Bar hidden (doors need all available space) |
+| 10-15 lines | Compact bar: keys only, no descriptions (`a w d s n : ? h`) |
+| > 15 lines | Full bar with descriptions |
+
+| Terminal Width | Behavior |
+|---------------|----------|
+| < 40 cols | Bar shows only `? Help` |
+| 40-60 cols | Bar shows 3 most important keys + `?` |
+| 60-80 cols | Bar shows 5 keys + `?` |
+| > 80 cols | Full bar |
+
+### Overlay Size Handling
+
+The overlay should scroll if the terminal is too short to show all keybindings. Use `j/k` or `↑/↓` to scroll the overlay content. Always show "Press ? or esc to close" at the bottom (fixed footer within the overlay).
+
+---
+
+## Consistency with Existing Patterns
+
+### Theme Integration
+
+The bar should NOT be themed (unlike doors). Rationale:
+- The bar is chrome/infrastructure, not content
+- Themed bars would require updating every theme for a non-core feature
+- A neutral dim style works with all themes
+- This matches how nano's help bar isn't themed with the file's syntax highlighting
+
+The overlay border can use the current theme's accent color for the frame, providing a subtle connection to the visual identity without requiring theme-specific overlay implementations.
+
+### Separator Line
+
+Above the bar, render a thin separator:
+```
+ ────────────────────────────────────────────────────
+ a/w/d Select   s Re-roll   n Add   : Cmd   h Bar   ? Help
+```
+
+The separator uses `lipgloss.NewStyle().Foreground(dimColor)` and is a string of `─` repeated to terminal width. This visually separates content from chrome.
+
+---
+
+## Recommendations Summary
+
+1. **Bar defaults ON for new users, OFF once toggled** — progressive disclosure
+2. **Max 5-6 key groups in bar** — resist the urge to show everything
+3. **Bar is visually recessive** — dim foreground, no background, no bold
+4. **`h` toggles bar, `?` opens overlay** — separate "persistent reference" from "help me now"
+5. **Overlay shows ALL keys for ALL views** — reference document, not context-sensitive filter
+6. **Current view highlighted in overlay** — helps "where am I?" orientation
+7. **Terminal size adaptation is mandatory** — doors always get priority for space
+8. **No theme integration for bar** — neutral dim style works universally
+9. **Separator line above bar** — clear visual boundary between content and chrome
+10. **Overlay scrollable** — supports terminals that can't show all bindings at once

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -117,6 +117,13 @@
 | D-085 | Sequential expand mode for subtask creation (Epic 31) | 2026-03-08 | Stay in expand input after Enter; show running count; only Esc exits; reduces friction | [Artifact](../../_bmad-output/planning-artifacts/party-mode-expand-fork-2026-03-08.md) |
 | D-086 | Dedicated ViewHelp view mode for :help display | 2026-03-08 | Consistent with all existing informational views; FlashMsg is fundamentally wrong for help content | [Artifact](../../_bmad-output/planning-artifacts/help-display-redesign.md) |
 | D-087 | ? global keybinding opens help from any view | 2026-03-08 | TUI standard (vim, less, lazygit); solves discoverability; no existing conflicts | [Artifact](../../_bmad-output/planning-artifacts/help-display-redesign.md) |
+| D-088 | Bar rendered by MainModel, views unaware (Epic 39) | 2026-03-08 | Clean separation; no per-view changes needed; MainModel adjusts height | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md) |
+| D-089 | Overlay as boolean flag, not new ViewMode (Epic 39) | 2026-03-08 | Preserves user context; overlay is ephemeral; no ViewMode transition needed | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-party-mode.md) |
+| D-090 | Compile-time keybinding registry, not config-driven (Epic 39) | 2026-03-08 | All bindings known at compile time; YAGNI for runtime registration | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md) |
+| D-091 | `h` toggles bar, `?` toggles overlay (Epic 39) | 2026-03-08 | Separates "persistent reference" (h) from "help me now" (?); both universally understood | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-party-mode.md) |
+| D-092 | Bar defaults ON for new users (Epic 39) | 2026-03-08 | Progressive disclosure; bridges onboarding-to-mastery gap; power users press h to hide | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-ux-review.md) |
+| D-093 | Bar is theme-independent, dim styling only (Epic 39) | 2026-03-08 | Bar is chrome, not content; themed bars would require updating every theme for non-core feature | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-ux-review.md) |
+| D-094 | Auto-hide bar below 10 lines terminal height (Epic 39) | 2026-03-08 | Doors must have priority for screen space; bar is helpful but not essential | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-ux-review.md) |
 
 ## Rejected
 
@@ -153,6 +160,12 @@
 | X-029 | Per-push `brew install` verification for alpha | 2026-03-09 | Expensive (macOS runner + Homebrew install time); tap CI provides equivalent coverage | [Artifact](../../_bmad-output/planning-artifacts/homebrew-dual-publish-course-correction.md) |
 | X-030 | Default `ALPHA_TAP_ENABLED` to ON | 2026-03-09 | First push would attempt formula push before infrastructure is validated | [Artifact](../../_bmad-output/planning-artifacts/homebrew-dual-publish-course-correction.md) |
 | X-031 | Project-level work tracking across repos | 2026-03-08 | Deferred — single-repo tracking sufficient for now; complexity not justified | [ADR-0033](../ADRs/ADR-0033-project-level-tracking-deferred.md) |
+| X-032 | Custom keybinding remapping (Epic 39) | 2026-03-08 | Out of scope; adds config complexity for unvalidated need; YAGNI | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-party-mode.md) |
+| X-033 | Animated bar show/hide transitions (Epic 39) | 2026-03-08 | No animation system exists; Lipgloss is static styling; instant response is more "deliberate" per SOUL.md | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-party-mode.md) |
+| X-034 | Themed keybinding bar per door theme (Epic 39) | 2026-03-08 | Bar is infrastructure chrome, not content; would require modifying all themes for non-core feature | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-ux-review.md) |
+| X-035 | Single `?` key for both bar toggle and overlay (Epic 39) | 2026-03-08 | Conflates "persistent reference" with "help me now"; separate keys (h/?) are clearer | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-party-mode.md) |
+| X-036 | Overlay as new ViewMode (Epic 39) | 2026-03-08 | ViewMode transition clears previous view; overlay is ephemeral context-preserving layer | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md) |
+| X-037 | Runtime keybinding registration / config-driven bindings (Epic 39) | 2026-03-08 | All bindings are known at compile time; runtime flexibility adds complexity for zero current benefit | [Artifact](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md) |
 
 ## Superseded
 

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -462,7 +462,21 @@
 - **Stories:** 38.1-38.5 (5 stories)
 - **Research:** See `docs/research/dual-homebrew-distribution-research.md`, `_bmad-output/planning-artifacts/homebrew-dual-publish-course-correction.md`
 
-**Epic 39+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 39: Keybinding Display System** (P1)
+- **Goal:** Add toggleable keybinding discoverability to the TUI: a concise context-sensitive bar at the bottom of every view, and a full keybinding overlay accessible via `?` key
+- **Prerequisites:** None (all required infrastructure exists)
+- **Status:** Not Started
+- **Deliverables:**
+  - Compile-time keybinding registry mapping each ViewMode to its available key bindings
+  - Concise bottom bar showing 5-6 priority keys per view, with Lipgloss dim styling
+  - Full-screen keybinding overlay (`?` key) organized by category with scroll support
+  - `h` key toggles bar visibility, persisted to config.yaml
+  - Terminal size adaptation (auto-hide bar on small terminals, compact mode, width truncation)
+  - Context-sensitive bar content (changes per view mode)
+- **Stories:** 39.1-39.5 (5 stories)
+- **Research:** See `_bmad-output/planning-artifacts/keybinding-display-party-mode.md`, `_bmad-output/planning-artifacts/keybinding-display-ux-review.md`, `_bmad-output/planning-artifacts/keybinding-display-architecture.md`
+
+**Epic 40+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -512,5 +526,6 @@
 | Epic 36: Door Selection Feedback | 3 | Complete |
 | Epic 37: Persistent BMAD Agents | 4 | Complete |
 | Epic 38: Dual Homebrew Distribution | 5 | In Progress (1/5) |
-| **Total** | **199** | **154 complete, 1 in progress, 44 not started** |
+| Epic 39: Keybinding Display System | 5 | Not Started |
+| **Total** | **204** | **154 complete, 1 in progress, 49 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 1-15, 3.5, 17-24, 26, 34, 35 are COMPLETE. Epic 0 is partial (10/12). Epic 16 is ICEBOX. Epics 25, 27-33, 36, 37 are NOT STARTED. 267+ merged PRs total. Last audit: 2026-03-08.
+**Implementation Status:** Epics 1-15, 3.5, 17-24, 26, 34-37 are COMPLETE. Epic 0 is partial (10/12). Epic 16 is ICEBOX. Epic 38 is IN PROGRESS (1/5). Epics 25, 27-33, 39 are NOT STARTED. 275+ merged PRs total. Last audit: 2026-03-08.
 
 ## Requirements Inventory
 
@@ -2851,6 +2851,75 @@ So that I can objectively assess persistent agent value and adjust accordingly.
 38.3 Stable Release Signing (independent)
 38.4 Alpha Release Verification (depends on 38.1, 38.2)
 38.5 Alpha Release Retention (independent)
+```
+
+---
+
+## Epic 39: Keybinding Display System
+
+**Epic Goal:** Add toggleable keybinding discoverability to the ThreeDoors TUI — a concise context-sensitive bar at the bottom of every view showing available keys, and a full keybinding overlay (`?` key) as a comprehensive reference. Improves discoverability without adding decision complexity, aligning with SOUL.md's friction-reduction philosophy.
+
+**Prerequisites:** None (all required infrastructure exists — Lipgloss, config.yaml persistence, MainModel composition, isTextInputActive() guard)
+**Status:** Not Started (0/5)
+
+**Deliverables:**
+- Compile-time keybinding registry mapping each ViewMode to available key bindings with priority levels
+- Concise bottom bar showing 5-6 priority keys per view with dim Lipgloss styling
+- Full-screen keybinding overlay organized by category with scroll support
+- `h` key toggles bar visibility (persisted to config.yaml), `?` key opens/closes overlay
+- Terminal size adaptation: auto-hide bar < 10 lines, compact mode 10-15 lines, width truncation
+- Context-sensitive bar content (changes per view mode, sub-mode aware)
+
+**Design References:**
+- Party mode: `_bmad-output/planning-artifacts/keybinding-display-party-mode.md`
+- UX review: `_bmad-output/planning-artifacts/keybinding-display-ux-review.md`
+- Architecture: `_bmad-output/planning-artifacts/keybinding-display-architecture.md`
+
+### Story 39.1: Keybinding Registry Model
+- **Status:** Not Started
+- **Priority:** P1
+- **Estimate:** S (1-2 hours)
+- **Depends on:** None
+- **ACs:** KeyBinding/KeyBindingGroup types, per-view registry functions (all 18 ViewModes), barBindings() convenience function (priority-1 only, max 8 per view), allKeyBindingGroups() for overlay, comprehensive table-driven tests
+
+### Story 39.2: Concise Keybinding Bar Component
+- **Status:** Not Started
+- **Priority:** P1
+- **Estimate:** M (3-5 hours)
+- **Depends on:** 39.1
+- **ACs:** RenderKeybindingBar() function, context-sensitive content from registry, terminal width adaptation (4 breakpoints), terminal height adaptation (3 breakpoints), dim Lipgloss styling with separator line, golden file tests, unit tests
+
+### Story 39.3: Full Keybinding Overlay
+- **Status:** Not Started
+- **Priority:** P1
+- **Estimate:** M (3-5 hours)
+- **Depends on:** 39.1
+- **ACs:** RenderKeybindingOverlay() function, bordered box with categorized bindings, context highlighting (current view first), scroll support with j/k/arrows, fixed footer, golden file tests, unit tests
+
+### Story 39.4: Toggle Behavior, Config Persistence, and MainModel Integration
+- **Status:** Not Started
+- **Priority:** P1
+- **Estimate:** M (3-5 hours)
+- **Depends on:** 39.2, 39.3
+- **ACs:** MainModel fields and config initialization, `h` toggle with async config write, `?` overlay toggle, overlay key interception, View() composition with height adjustment, config.yaml persistence, integration tests, race detector pass
+
+### Story 39.5: View-Specific Keybinding Completeness and Polish
+- **Status:** Not Started
+- **Priority:** P1
+- **Estimate:** M (3-5 hours)
+- **Depends on:** 39.4
+- **ACs:** Full keybinding audit (every case handler registered), sub-mode awareness (confirm-delete, expand input, command mode), overlay includes `:` commands section, visual polish, comprehensive golden files for all major views, edge case tests
+
+---
+
+### Epic 39 Story Dependencies
+
+```
+39.1 Keybinding Registry Model (independent)
+39.2 Concise Bar Component (depends on 39.1)
+39.3 Full Keybinding Overlay (depends on 39.1)
+39.4 Toggle + Integration (depends on 39.2, 39.3)
+39.5 Completeness + Polish (depends on 39.4)
 ```
 
 ---

--- a/docs/stories/39.1.story.md
+++ b/docs/stories/39.1.story.md
@@ -1,0 +1,77 @@
+# Story 39.1: Keybinding Registry Model
+
+**Epic:** 39 — Keybinding Display System
+**Status:** Not Started
+**Priority:** P1
+**Estimate:** S (1-2 hours)
+
+---
+
+## User Story
+
+As a developer, I want a compile-time keybinding registry that maps each view mode to its available key bindings with priority levels, so that the bar and overlay components have a single source of truth for what keys are available where.
+
+## Context
+
+ThreeDoors has 18 view modes and 40+ key bindings spread across `main_model.go` and individual view files. There is no centralized registry of what keys are available in which view. This story creates that registry as a data layer that the bar (Story 39.2) and overlay (Story 39.3) will consume.
+
+Design reference: [Keybinding Display Party Mode](../../_bmad-output/planning-artifacts/keybinding-display-party-mode.md)
+Architecture reference: [Keybinding Display Architecture](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md)
+
+## Acceptance Criteria
+
+### AC-1: KeyBinding Type
+- [ ] `KeyBinding` struct with `Key` (string), `Description` (string), `Priority` (int) fields
+- [ ] Priority values: 1=always show in bar, 2=show in bar if space permits, 3=overlay only
+- [ ] `KeyBindingGroup` struct with `Name` (string) and `Bindings` ([]KeyBinding)
+
+### AC-2: Per-View Registry Functions
+- [ ] `viewKeyBindings(mode ViewMode) []KeyBindingGroup` returns categorized bindings for a view
+- [ ] Every ViewMode constant has a corresponding entry (all 18 view modes)
+- [ ] DoorsView (no selection) has at least: a/w/d (select), s (re-roll), n (add), : (cmd), h (bar toggle), ? (help)
+- [ ] DoorsView (selected) has at least: enter (confirm), a/w/d (change), esc (deselect), ? (help)
+- [ ] DetailView has at least: esc (back), c (complete), b (blocked), e (expand), f (fork), ? (help)
+- [ ] Text input views (AddTask, Search) have at least: enter (submit), esc (cancel), ? (help)
+
+### AC-3: Bar Convenience Function
+- [ ] `barBindings(mode ViewMode) []KeyBinding` returns priority-1 bindings only
+- [ ] No view returns more than 8 priority-1 bindings
+- [ ] Every view includes `?` (help) as a priority-1 binding
+
+### AC-4: Full Registry Function
+- [ ] `allKeyBindingGroups() []KeyBindingGroup` returns all bindings across all views
+- [ ] Groups are organized by category (Navigation, Actions, Views, Display)
+- [ ] No duplicate key-description pairs within a group
+
+### AC-5: Tests
+- [ ] Every ViewMode has at least one binding registered
+- [ ] Every ViewMode has `?` in its bindings
+- [ ] Priority-1 bindings per view do not exceed 8
+- [ ] No duplicate keys within a single view's bindings
+- [ ] `allKeyBindingGroups()` covers bindings from all views
+- [ ] Table-driven tests following project testing standards
+
+## Technical Notes
+
+- New file: `internal/tui/keybindings.go`
+- New file: `internal/tui/keybindings_test.go`
+- Pure functions, no struct with methods (no state to manage)
+- All data is compile-time constant — no config loading, no runtime registration
+- The DoorsView has two binding sets: no-selection and door-selected. Use a helper or pass a boolean to distinguish.
+- Follow existing code organization: one primary type per file
+
+## Tasks
+
+### Task 1: Define KeyBinding and KeyBindingGroup types
+### Task 2: Implement viewKeyBindings() for all 18 view modes
+### Task 3: Implement barBindings() convenience function
+### Task 4: Implement allKeyBindingGroups() for overlay
+### Task 5: Write comprehensive table-driven tests
+
+## Dependencies
+
+- None. This is a data-only layer with no UI rendering.
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/39.2.story.md
+++ b/docs/stories/39.2.story.md
@@ -1,0 +1,94 @@
+# Story 39.2: Concise Keybinding Bar Component
+
+**Epic:** 39 — Keybinding Display System
+**Status:** Not Started
+**Priority:** P1
+**Estimate:** M (3-5 hours)
+**Depends On:** 39.1
+
+---
+
+## User Story
+
+As a user, I want a concise keybinding bar at the bottom of the screen showing the most important keys for my current view, so that I always know what I can do without memorizing all the key bindings.
+
+## Context
+
+The bar renders at the bottom of every view, showing 5-6 priority-1 key bindings for the current view mode. It uses dim/muted Lipgloss styling to avoid competing with the primary content (doors, detail view, etc.). The bar adapts to terminal size — auto-hiding on very small terminals and truncating gracefully on narrow widths.
+
+Design reference: [Keybinding Display UX Review](../../_bmad-output/planning-artifacts/keybinding-display-ux-review.md)
+Architecture reference: [Keybinding Display Architecture](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md)
+
+## Acceptance Criteria
+
+### AC-1: Bar Rendering
+- [ ] `RenderKeybindingBar(mode ViewMode, width int, height int, enabled bool) string` function exists
+- [ ] Bar renders as a single line of `key Description` pairs separated by double spaces
+- [ ] A thin separator line (─ repeated to width) renders above the bar
+- [ ] Bar uses dim foreground styling via Lipgloss (not Faint — use explicit dim color for terminal compatibility)
+- [ ] Keys are rendered slightly brighter or bold relative to descriptions for visual scanning
+
+### AC-2: Content from Registry
+- [ ] Bar displays priority-1 bindings from `barBindings()` (Story 39.1)
+- [ ] Bar content changes when ViewMode changes (context-sensitive)
+- [ ] `?` Help is always present as the last item in the bar
+
+### AC-3: Terminal Width Adaptation
+- [ ] Width < 40: show only `? Help`
+- [ ] Width 40-60: show 3 most important keys + `?`
+- [ ] Width 60-80: show 5 keys + `?`
+- [ ] Width > 80: show full bar
+- [ ] If formatted bar exceeds available width, truncate from right, always keeping `? Help`
+
+### AC-4: Terminal Height Adaptation
+- [ ] Height < 10: return empty string (bar hidden, doors need space)
+- [ ] Height 10-15: compact mode — keys only, no descriptions (e.g., `a w d s n : ? h`)
+- [ ] Height > 15: full bar with descriptions
+
+### AC-5: Disabled State
+- [ ] When `enabled` is false, return empty string regardless of dimensions
+
+### AC-6: Lipgloss Styling
+- [ ] Bar text uses a dim foreground color (ANSI 245 or similar)
+- [ ] Key names use slightly brighter treatment (ANSI 250 or subtle bold) for visual scanning
+- [ ] Separator line uses the same dim foreground as bar descriptions
+- [ ] No background color (transparent to terminal)
+
+### AC-7: Golden File Tests
+- [ ] Golden files for DoorsView bar at 80-col width (full mode)
+- [ ] Golden files for DetailView bar at 80-col width (full mode)
+- [ ] Golden files for compact mode (60-col width, 12-line height)
+- [ ] Golden files for truncated mode (45-col width)
+- [ ] Golden file for disabled state (empty output)
+
+### AC-8: Unit Tests
+- [ ] Bar returns correct content for each major view mode
+- [ ] Width truncation works at each breakpoint
+- [ ] Height thresholds respected
+- [ ] Disabled state returns empty string
+- [ ] Table-driven tests following project testing standards
+
+## Technical Notes
+
+- New file: `internal/tui/keybinding_bar.go`
+- New file: `internal/tui/keybinding_bar_test.go`
+- Stateless rendering function — receives all inputs as parameters, no internal state
+- Golden files in `internal/tui/testdata/` following existing naming convention
+- The bar consumes 2 lines (separator + bar). MainModel (Story 39.4) accounts for this in height calculations.
+- Use `fmt.Fprintf` for string building, not `strings.Builder` + `Sprintf`
+
+## Tasks
+
+### Task 1: Define bar Lipgloss styles in styles.go
+### Task 2: Implement RenderKeybindingBar function with width/height adaptation
+### Task 3: Implement separator line rendering
+### Task 4: Write unit tests with table-driven structure
+### Task 5: Create golden file tests for visual regression
+
+## Dependencies
+
+- Story 39.1 (Keybinding Registry Model) — provides `barBindings()` function
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/39.3.story.md
+++ b/docs/stories/39.3.story.md
@@ -1,0 +1,99 @@
+# Story 39.3: Full Keybinding Overlay
+
+**Epic:** 39 — Keybinding Display System
+**Status:** Not Started
+**Priority:** P1
+**Estimate:** M (3-5 hours)
+**Depends On:** 39.1
+
+---
+
+## User Story
+
+As a user, I want to press `?` to see a full-screen overlay listing all available keybindings organized by category, so that I can quickly find any key binding when I need it.
+
+## Context
+
+The overlay is the comprehensive keybinding reference — unlike the concise bar (Story 39.2) which shows 5-6 keys, the overlay shows ALL bindings across ALL views organized by category. It renders as a modal full-screen panel that overlays the current view, preserving context awareness. The current view's bindings are highlighted/prioritized at the top.
+
+Design reference: [Keybinding Display Party Mode](../../_bmad-output/planning-artifacts/keybinding-display-party-mode.md)
+UX reference: [Keybinding Display UX Review](../../_bmad-output/planning-artifacts/keybinding-display-ux-review.md)
+Architecture reference: [Keybinding Display Architecture](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md)
+
+## Acceptance Criteria
+
+### AC-1: Overlay Rendering
+- [ ] `RenderKeybindingOverlay(state OverlayState, width int, height int) string` function exists
+- [ ] Overlay renders a bordered box using Lipgloss (double-line border)
+- [ ] Title "KEYBINDING REFERENCE" centered at top of overlay
+- [ ] Bindings organized by category groups (Navigation, Actions, Views, Display)
+- [ ] Each binding formatted as `key     description` with consistent column alignment
+
+### AC-2: Context Highlighting
+- [ ] Current view's binding group appears first in the overlay
+- [ ] Current view's group name includes "(current)" marker
+- [ ] Other groups follow in a consistent order
+
+### AC-3: Scroll Support
+- [ ] `OverlayState` struct with `ScrollOffset int` and `ViewMode ViewMode` fields
+- [ ] When content exceeds terminal height: scrollable via `↑/↓` or `j/k` keys
+- [ ] Scroll position clamped to valid range (no over-scroll)
+- [ ] Scroll indicator shown when content extends beyond visible area (e.g., "▼ more" at bottom)
+
+### AC-4: Fixed Footer
+- [ ] Footer "Press ? or esc to close   ↑/↓ to scroll" always visible at overlay bottom
+- [ ] Footer uses dim styling consistent with bar styling
+- [ ] Footer remains fixed even when content is scrolled
+
+### AC-5: Keyboard Handling (overlay active)
+- [ ] `?` dismisses the overlay (toggle behavior)
+- [ ] `esc` dismisses the overlay
+- [ ] `↑/↓` and `j/k` scroll the overlay content
+- [ ] All other keys are intercepted (no pass-through to underlying view)
+
+### AC-6: Lipgloss Styling
+- [ ] Overlay border uses theme-neutral color (white or bright white)
+- [ ] Title uses bold styling
+- [ ] Key names use slightly brighter/bold treatment for scanning
+- [ ] Descriptions use normal weight
+- [ ] Category headers use bold underline styling
+- [ ] Background is the terminal default (no explicit background)
+
+### AC-7: Golden File Tests
+- [ ] Golden file for overlay at 80x24 terminal size
+- [ ] Golden file for overlay with scroll indicator (content exceeds height)
+- [ ] Golden file for narrow terminal (50-col width)
+
+### AC-8: Unit Tests
+- [ ] Overlay renders all binding groups
+- [ ] Current view group appears first
+- [ ] Scroll offset shifts content correctly
+- [ ] Scroll clamped at boundaries
+- [ ] Footer always present
+- [ ] Table-driven tests following project testing standards
+
+## Technical Notes
+
+- New file: `internal/tui/keybinding_overlay.go`
+- New file: `internal/tui/keybinding_overlay_test.go`
+- `OverlayState` is held by MainModel (wired in Story 39.4)
+- The overlay is NOT a new ViewMode. It's a boolean flag on MainModel that intercepts View() and Update() when active.
+- Keyboard interception happens in MainModel.Update() (Story 39.4), not in the overlay rendering function
+- Golden files in `internal/tui/testdata/`
+- Use `fmt.Fprintf` for string building
+
+## Tasks
+
+### Task 1: Define OverlayState type
+### Task 2: Implement RenderKeybindingOverlay with bordered box and categorized content
+### Task 3: Implement scroll support with clamping and indicator
+### Task 4: Implement context highlighting (current view first)
+### Task 5: Write unit tests and golden file tests
+
+## Dependencies
+
+- Story 39.1 (Keybinding Registry Model) — provides `allKeyBindingGroups()` and `viewKeyBindings()`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/39.4.story.md
+++ b/docs/stories/39.4.story.md
@@ -1,0 +1,97 @@
+# Story 39.4: Toggle Behavior, Config Persistence, and MainModel Integration
+
+**Epic:** 39 — Keybinding Display System
+**Status:** Not Started
+**Priority:** P1
+**Estimate:** M (3-5 hours)
+**Depends On:** 39.2, 39.3
+
+---
+
+## User Story
+
+As a user, I want to press `h` to toggle the keybinding bar on/off and have my preference remembered across sessions, so that I can choose the experience that works best for me — guided or clean.
+
+## Context
+
+This story wires the bar (Story 39.2) and overlay (Story 39.3) into MainModel, adds `h` and `?` key handlers, and persists the bar toggle preference to config.yaml. This is the integration story that makes the keybinding display system functional.
+
+Architecture reference: [Keybinding Display Architecture](../../_bmad-output/planning-artifacts/keybinding-display-architecture.md)
+
+## Acceptance Criteria
+
+### AC-1: MainModel Fields
+- [ ] `showKeybindingBar bool` field on MainModel (toggle state)
+- [ ] `showKeybindingOverlay bool` field on MainModel (overlay visible)
+- [ ] `overlayState OverlayState` field on MainModel (scroll position + view context)
+- [ ] `showKeybindingBar` initialized from config.yaml on startup (default: `true` if no config)
+
+### AC-2: `h` Key Handler (Bar Toggle)
+- [ ] Pressing `h` toggles `showKeybindingBar` between true and false
+- [ ] Toggle triggers async config.yaml write via `tea.Cmd` (non-blocking)
+- [ ] `h` handler guarded by `isTextInputActive()` — no toggle during text input
+- [ ] `h` handler active in all views (MainModel-level, before view dispatch)
+- [ ] `h` suppressed when overlay is visible (overlay intercepts all keys)
+
+### AC-3: `?` Key Handler (Overlay Toggle)
+- [ ] Pressing `?` when overlay hidden: shows overlay, sets `overlayState.ViewMode` to current view
+- [ ] Pressing `?` when overlay visible: hides overlay
+- [ ] `?` handler guarded by `isTextInputActive()` — no overlay during text input
+- [ ] `?` handler active in all views (MainModel-level, before view dispatch)
+
+### AC-4: Overlay Key Interception
+- [ ] When overlay visible: `↑/↓/j/k` scroll the overlay (update `overlayState.ScrollOffset`)
+- [ ] When overlay visible: `esc` dismisses overlay
+- [ ] When overlay visible: all other keys are consumed (no pass-through to underlying view)
+- [ ] When overlay dismissed: scroll offset resets to 0
+
+### AC-5: View() Integration
+- [ ] When overlay visible: View() returns overlay rendering instead of normal view
+- [ ] When bar enabled and overlay not visible: View() appends bar to bottom of current view
+- [ ] When bar enabled: available height for view content reduced by 2 lines (separator + bar)
+- [ ] When bar disabled or auto-hidden: full height available for view content
+- [ ] Height reduction passed to all view components that use height (DoorsView, ProposalsView, etc.)
+
+### AC-6: Config.yaml Persistence
+- [ ] `show_keybinding_bar` field read from config.yaml on startup
+- [ ] Default value is `true` when field is absent (new install = bar visible)
+- [ ] Field written to config.yaml on toggle via async `tea.Cmd`
+- [ ] Config write follows existing atomic write pattern
+
+### AC-7: Integration Tests
+- [ ] `h` toggles bar visibility (verify View() output includes/excludes bar)
+- [ ] `?` opens/closes overlay (verify View() output switches between overlay and normal view)
+- [ ] Bar content changes when switching from DoorsView to DetailView
+- [ ] Overlay shows current view bindings first
+- [ ] Text input views suppress `h` and `?`
+- [ ] Overlay intercepts keys (underlying view doesn't receive them)
+
+### AC-8: Race Detector
+- [ ] `go test -race ./internal/tui/...` passes (MANDATORY per CLAUDE.md)
+
+## Technical Notes
+
+- Primary changes in `internal/tui/main_model.go`
+- Config read/write uses existing pattern from theme persistence (Epic 17, `internal/tui/theme_picker.go`)
+- Height adjustment: MainModel currently passes `m.height` to views via SetHeight(). When bar is visible, pass `m.height - 2` instead.
+- The `isTextInputActive()` function already exists (added in D-059 for universal quit). Reuse it for `h` and `?` guards.
+- Order of key handling in Update(): overlay interception first, then `h`/`?` handlers, then view-specific dispatch. This ensures the overlay consumes keys when active.
+
+## Tasks
+
+### Task 1: Add fields to MainModel and initialize from config
+### Task 2: Implement `h` key handler with config persistence
+### Task 3: Implement `?` key handler with overlay state management
+### Task 4: Implement overlay key interception in Update()
+### Task 5: Modify View() to compose bar and handle overlay
+### Task 6: Adjust height calculations for all view components
+### Task 7: Write integration tests including race detector validation
+
+## Dependencies
+
+- Story 39.2 (Concise Keybinding Bar Component) — provides `RenderKeybindingBar()`
+- Story 39.3 (Full Keybinding Overlay) — provides `RenderKeybindingOverlay()` and `OverlayState`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/39.5.story.md
+++ b/docs/stories/39.5.story.md
@@ -1,0 +1,83 @@
+# Story 39.5: View-Specific Keybinding Completeness and Polish
+
+**Epic:** 39 — Keybinding Display System
+**Status:** Not Started
+**Priority:** P1
+**Estimate:** M (3-5 hours)
+**Depends On:** 39.4
+
+---
+
+## User Story
+
+As a user, I want the keybinding bar and overlay to accurately reflect every key binding in every view mode, so that I can trust the displayed information is complete and correct.
+
+## Context
+
+Stories 39.1-39.4 build the infrastructure and core integration. This story is the completeness pass — ensuring every key binding in every view is registered in the registry, the bar shows the right subset for each view, and the overlay serves as a comprehensive reference. This includes auditing the codebase for all key handlers and cross-checking against the registry.
+
+This story also handles edge cases: views with sub-modes (DetailView's confirm-delete flow, expand/fork input), the command mode (`:` prefix), and views where the bar content should change based on internal state.
+
+## Acceptance Criteria
+
+### AC-1: Keybinding Audit
+- [ ] Every `case "key"` handler in main_model.go has a corresponding registry entry
+- [ ] Every `case "key"` handler in detail_view.go has a corresponding registry entry
+- [ ] Every `case "key"` handler in search_view.go has a corresponding registry entry
+- [ ] Every `case "key"` handler in all other view files has a corresponding registry entry
+- [ ] Audit documented as comments in keybindings.go listing any intentionally omitted bindings with rationale
+
+### AC-2: Sub-Mode Awareness
+- [ ] DetailView: bar shows different keys when in confirm-delete mode (y/n only)
+- [ ] DetailView: bar shows different keys when in expand/fork text input mode (enter/esc only)
+- [ ] SearchView: bar shows search-specific keys (enter/esc/↑/↓)
+- [ ] AddTaskView: bar shows input-specific keys (enter/esc)
+- [ ] Command mode (`:` active): bar shows relevant command hints or hides
+
+### AC-3: Overlay Comprehensive Reference
+- [ ] Overlay lists all `:` commands (doors, add, mood, search, stats, reconsider, breakdown, defer, archive)
+- [ ] Overlay includes a "Commands" section separate from key bindings
+- [ ] Overlay groups are ordered: Current View > Navigation > Actions > Views > Commands > Display
+
+### AC-4: Bar Visual Polish
+- [ ] Bar key-description pairs have consistent spacing across all views
+- [ ] Arrow key indicators use Unicode arrows (←↑→↓) for clarity
+- [ ] Modifier keys displayed clearly (ctrl+c, esc)
+- [ ] No orphaned keys (key without description) or orphaned descriptions
+
+### AC-5: Comprehensive Golden File Tests
+- [ ] Golden files for bar in every major view mode: DoorsView (no selection), DoorsView (selected), DetailView, SearchView, AddTaskView, MoodView, HealthView
+- [ ] Golden file for overlay showing all bindings
+- [ ] Golden files regenerated and checked in
+
+### AC-6: Edge Case Tests
+- [ ] Bar renders correctly when ViewMode transitions (e.g., DoorsView → DetailView)
+- [ ] Overlay opened from different views shows correct context highlighting
+- [ ] Bar handles the flash message + bar co-existence (flash above bar)
+- [ ] Footer message and bar co-exist without overlap
+
+## Technical Notes
+
+- This is primarily a data completeness and polish story, not new architecture
+- Requires reading every view's Update() method to catalog all key handlers
+- The DoorsView sub-modes (selected vs not) may require extending `barBindings()` to accept additional context beyond ViewMode
+- Consider adding `barBindingsWithContext(mode ViewMode, selected bool) []KeyBinding` if needed
+- Flash messages (`m.flash`) render in DoorsView — ensure the bar doesn't overlap with flash text
+
+## Tasks
+
+### Task 1: Audit all view Update() methods for key handlers
+### Task 2: Update registry with any missing bindings
+### Task 3: Add sub-mode awareness to bar rendering
+### Task 4: Add `:` commands section to overlay
+### Task 5: Visual polish pass on bar formatting
+### Task 6: Create comprehensive golden file tests for all views
+### Task 7: Test edge cases (transitions, flash messages, co-existence)
+
+## Dependencies
+
+- Story 39.4 (Toggle Behavior and MainModel Integration) — full system must be wired
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

Full BMAD planning pipeline for a new feature: **toggleable keybinding display bar and full overlay** for the ThreeDoors TUI.

- **Party mode** (PM, UX, Architect, QA, Dev): Designed bar layout, overlay behavior, key selection strategy, terminal size adaptation, and SOUL.md alignment
- **UX Designer review**: Visual hierarchy analysis, information density recommendations, progressive disclosure strategy, accessibility considerations, ASCII mockups
- **Architecture review**: Bubbletea MVU integration plan, component design (stateless rendering functions), performance analysis, testing strategy, impact assessment (no existing code modified)
- **Epic 39 created** with 5 stories (39.1-39.5), all P1
- **7 design decisions** recorded (D-086 through D-092) and **6 rejected alternatives** (X-032 through X-037)

### Key Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Bar location | MainModel.View() appends | Views don't know about bar |
| Overlay | Boolean flag, not ViewMode | Preserves user context |
| Registry | Compile-time map | All bindings known statically |
| Toggle keys | `h` = bar, `?` = overlay | Separates persistent vs on-demand help |
| Default state | Bar ON for new users | Progressive disclosure |
| Styling | Dim/muted, theme-independent | Bar is chrome, not content |
| Small terminals | Auto-hide < 10 lines | Doors get priority |

### Stories

1. **39.1** Keybinding Registry Model — data types and per-view binding definitions
2. **39.2** Concise Keybinding Bar Component — bottom bar with Lipgloss styling
3. **39.3** Full Keybinding Overlay — modal reference with scroll support
4. **39.4** Toggle Behavior + Config Persistence — `h`/`?` handlers, MainModel integration
5. **39.5** View-Specific Completeness + Polish — audit all 18 views, sub-mode awareness

### Planning Docs Updated

- `ROADMAP.md` — Epic 39 added to Active Epics
- `docs/prd/epic-list.md` — Epic 39 entry with deliverables
- `docs/prd/epics-and-stories.md` — Full epic section with all 5 stories
- `docs/decisions/BOARD.md` — 7 decisions + 6 rejections

### Artifacts

- `_bmad-output/planning-artifacts/keybinding-display-party-mode.md`
- `_bmad-output/planning-artifacts/keybinding-display-ux-review.md`
- `_bmad-output/planning-artifacts/keybinding-display-architecture.md`

## Test plan

- [ ] No Go code changes — planning/docs only PR
- [ ] Verify story files have complete acceptance criteria
- [ ] Verify ROADMAP.md, epic-list.md, epics-and-stories.md are consistent
- [ ] Verify decisions BOARD.md entries reference correct artifacts