### PR TITLE
docs: sync ROADMAP.md status for Story 0.28

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Pin golangci-lint version, replace third-party release action with gh CLI, add p
 
 ### Story 0.28: Issue Tracker & Authority Configuration (P1)
 
-**Status:** Story created. Implementation not started.
+**Status:** Done (PR #255).
 
 Local issue tracker file (`docs/issue-tracker.md`) with authority tier configuration for the envoy agent. Operationalizes party mode research from PRs #227, #232.
 


### PR DESCRIPTION
## Summary

- Updates ROADMAP.md to reflect that Story 0.28 (Issue Tracker & Authority Configuration) is already Done (PR #255)
- PR #255 was merged on 2026-03-08 but ROADMAP.md was never updated to reflect completion

## Context

Story 0.28 was fully implemented in PR #255 which created `docs/issue-tracker.md` with:
- Authority tier configuration (HTML comment header)
- Patrol watermark
- Open/Recently Resolved issue tables
- SOUL.md Alignment Reference section

This PR is a doc-only fix to keep ROADMAP.md in sync with actual story status.

## Test plan

- [x] Verify ROADMAP.md renders correctly
- [x] Confirm story count (11/13) for Epic 0 is still accurate