### PR TITLE
docs: triage issue #330 — dashboard q key regression

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,6 +50,12 @@ Operations documentation for the envoy agent: patrol workflows, cross-agent prot
 
 Replace broken `:help` flash message with dedicated scrollable help view. Content runs off-screen and disappears after 3 seconds. Fix: new `ViewHelp` mode, categorized two-column layout, `?` global keybinding.
 
+### Story 0.34: Fix 'q' Key in Sub-Views — Go Back Instead of Quit (P1)
+
+**Status:** Ready. Triage complete (issue #330). Story created.
+
+Story 36.3 (PR #276) universal quit handler causes sub-views (dashboard, health, synclog, etc.) to exit on 'q' instead of going back. Fix: scope 'q' quit to doors view only; sub-views treat 'q' as go-back (D-128).
+
 ## Active Epics
 
 ### Epic 25: Todoist Integration (P1) — 3/4 stories done

--- a/_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md
+++ b/_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md
@@ -1,0 +1,80 @@
+# Party Mode Triage: Issue #330 — Dashboard 'q' Key Exits App Instead of Going Back
+
+**Date:** 2026-03-09
+**Issue:** #330
+**Participants:** Sally (UX Designer), Winston (Architect), Amelia (Developer)
+**Rounds:** 2
+
+## Problem Statement
+
+Story 36.3 (PR #276) added a universal quit handler that intercepts 'q' from all non-text-input views. This causes sub-views (insights/dashboard, health, synclog, next steps, avoidance prompt) to exit the app when the user presses 'q', instead of going back to the previous view.
+
+## Options Evaluated
+
+### Option A: Add dashboard to an exemption list in the universal handler
+
+Add sub-views to an `isQuitAllowed()` or similar check so `q` only triggers quit from non-exempted views.
+
+**Pros:** Targeted, easy to implement initially.
+**Cons:** Creates a growing maintenance list. Every new view must remember to add itself. The default behavior (quit) is the dangerous one, violating fail-safe defaults. Fragile.
+
+**Verdict:** REJECTED. Maintenance burden grows with every new view. Wrong default.
+
+### Option B: Have dashboard view consume the 'q' key before it reaches the universal handler
+
+Modify sub-views to handle 'q' in their own Update() methods before the universal handler fires.
+
+**Pros:** Per-view control.
+**Cons:** Does not work with Bubbletea's message flow. The universal handler at `main_model.go:910-913` fires BEFORE view delegation at line 921. Sub-views never see the 'q' key. Would require restructuring the entire Update pipeline.
+
+**Verdict:** REJECTED. Architecturally impossible without major refactor.
+
+### Option C: Change universal quit to only work from the doors view (ADOPTED)
+
+Remove the universal `q` quit handler (lines 910-913) entirely. The doors view already handles `q` as quit at line 977. In each sub-view's Update method, add `case "q":` that triggers a go-back message (equivalent to Esc).
+
+**Pros:**
+- Matches TUI conventions (vim, lazygit, htop, ranger): `q` = "close current thing"
+- At root (doors), closing = quit. In sub-view, closing = go back.
+- No exemption list. No new abstractions. Clean separation.
+- Redundant handler removed (doors already has `q` at line 977).
+- Aligns with SOUL.md "work with human nature" principle.
+
+**Cons:**
+- Overrides Story 36.3 AC ("q quits from any view").
+- Sub-views that forget to add `q` handler will have `q` as no-op (safe default, Esc still works).
+
+**Verdict:** ADOPTED. Best UX, cleanest architecture, safest defaults.
+
+### Option D: Use a different key for universal quit
+
+Change universal quit to a different key (e.g., `Q`, `ctrl+q`).
+
+**Pros:** Avoids the conflict entirely.
+**Cons:** `q` is THE standard TUI quit key. Changing it violates user expectations and muscle memory. The problem is not the key, it is the scope.
+
+**Verdict:** REJECTED. Solves wrong problem. Users expect `q` to work.
+
+## Decision
+
+**Option C adopted.** Three-tier `q` key behavior:
+1. **Doors view (root):** `q` = quit app
+2. **Sub-views (non-input):** `q` = go back to previous view (same as Esc)
+3. **Text input views:** `q` = type the character 'q'
+
+This creates a consistent mental model: `q` always means "close what I'm looking at."
+
+## Affected Files (for implementation)
+
+- `internal/tui/main_model.go` — Remove lines 910-913 (universal quit handler)
+- `internal/tui/insights_view.go` — Add `q` as go-back in Update()
+- `internal/tui/health_view.go` — Add `q` as go-back in Update()
+- `internal/tui/synclog_view.go` — Add `q` as go-back in Update()
+- `internal/tui/next_steps_view.go` — Add `q` as go-back in Update()
+- `internal/tui/avoidance_prompt_view.go` — Add `q` as go-back in Update()
+- `internal/tui/main_model_test.go` — Update `TestUniversalQuit_InsightsView_QKeyQuits` to expect go-back; add table-driven test for q-as-back across all sub-views
+- `internal/tui/keybindings.go` — Add `q: back` to sub-view bindings
+
+## Story Reference
+
+Story 0.33 created for implementation (Decision D-125). This overrides Story 36.3's "q quits from any view" AC.

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -161,6 +161,7 @@
 | D-125 | Inline hints as frame decoration (doorknob metaphor), separate from bar toggle | 2026-03-09 | Hints are onboarding scaffolding (auto-fade), bar is reference tool (manual toggle); Approach B preserves door metaphor; no runtime toggle key — `:hints` command only; avoids 39.4 `h` toggle collision | [Artifact](../../_bmad-output/planning-artifacts/default-tooltips-mode-party-mode.md) |
 | D-126 | Session-based auto-fade for inline hints (default 5 sessions) | 2026-03-09 | Simpler than per-key tracking; 90% as effective; graceful dim at N-1 then disable at N; `:hints on` re-enables | [Artifact](../../_bmad-output/planning-artifacts/default-tooltips-mode-party-mode.md) |
 | D-127 | Inline tooltips as Epic 39 stories 39.9-39.12, not a new epic | 2026-03-09 | Same keybinding registry data source (39.1); same config infrastructure; same toggle ecosystem; new epic would fragment discoverability | [Artifact](../../_bmad-output/planning-artifacts/default-tooltips-mode-party-mode.md) |
+| D-128 | Scope 'q' quit to doors view only; sub-views treat 'q' as go-back (overrides Story 36.3) | 2026-03-09 | Matches TUI conventions (vim, lazygit, htop); 'q' = "close current thing"; quit at root, back in sub-views; SOUL.md "work with human nature" | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
 
 ## Rejected
 
@@ -268,6 +269,9 @@
 | X-068 | `bubbles/list` for command autocomplete | 2026-03-09 | Heavyweight for 16 items; fuzzy matching wrong for command completion (users expect prefix matching from vim muscle memory) | [Artifact](../../_bmad-output/planning-artifacts/global-command-mode-analysis.md) |
 | X-069 | Overlay-style dropdown for command suggestions | 2026-03-09 | No overlay rendering system exists; all existing patterns use inline rendering; would require Z-ordering infrastructure | [Artifact](../../_bmad-output/planning-artifacts/global-command-mode-analysis.md) |
 | X-070 | Argument-level completion for commands (MVP) | 2026-03-09 | Only 2 commands benefit (`:insights mood\|avoidance`, `:goals edit`); disproportionate complexity for MVP | [Artifact](../../_bmad-output/planning-artifacts/global-command-mode-analysis.md) |
+| X-071 | Exemption list for 'q' quit (Option A for #330) | 2026-03-09 | Growing maintenance list; wrong default (quit is dangerous, should require opt-in not opt-out) | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
+| X-072 | Sub-view consumes 'q' before universal handler (Option B for #330) | 2026-03-09 | Architecturally impossible — universal handler at line 910 fires before view delegation at line 921 | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
+| X-073 | Different key for universal quit (Option D for #330) | 2026-03-09 | 'q' is THE standard TUI quit key; problem is scope not key choice; changing it violates muscle memory | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
 
 ## Epic Number Registry
 

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -508,7 +508,7 @@
 
 | Epic | Stories | Status |
 |------|---------|--------|
-| Epic 0: Infrastructure & Process (Backfill) | 13 | Partial (10/13) |
+| Epic 0: Infrastructure & Process (Backfill) | 14 | Partial (10/14) |
 | Epic 1: Technical Demo | 7 | Complete |
 | Epic 2: Apple Notes Integration | 6 | Complete |
 | Epic 3: Enhanced Interaction | 7 | Complete |

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -236,7 +236,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 ### Epic 0: Infrastructure & Process (Backfill)
 Retroactive stories covering CI, documentation, tooling, quality standards, and research work from 29 unstory'd PRs. Now also includes forward-looking infrastructure improvements.
 **FRs covered:** None (cross-cutting infrastructure)
-**Status:** 10 of 13 stories complete. Stories 0.24 (Renovate + Dependabot), 0.31, 0.32 not started.
+**Status:** 10 of 14 stories complete. Stories 0.24 (Renovate + Dependabot), 0.31, 0.32, 0.34 not started.
 
 ### Epic 1: Three Doors Technical Demo ✅ COMPLETE
 Build and validate the Three Doors interface with minimal viable functionality to prove the UX concept.
@@ -407,7 +407,7 @@ Time-based seasonal theme variants that auto-switch based on the current date, e
 
 **Epic Goal:** Retroactively track infrastructure, documentation, tooling, and process work that was performed outside of story-level planning. These backfill stories capture work from 29 merged PRs that had no backing story. Now also includes forward-looking infrastructure improvements.
 
-**Status:** 10 of 13 stories complete. Stories 0.24 (Renovate + Dependabot), 0.31, 0.32 not started.
+**Status:** 10 of 14 stories complete. Stories 0.24 (Renovate + Dependabot), 0.31, 0.32, 0.34 not started.
 
 **Origin:** PR-Story Gap Analysis (2026-03-03), see `../../_bmad-output/planning-artifacts/pr-story-gap-analysis.md`
 
@@ -780,6 +780,22 @@ So that I can learn keybindings and commands without content disappearing or run
 - **AC5:** Scrollable via j/k, PgUp/PgDn; dismissed via Esc/q
 - **AC6:** `?` global keybinding opens help from any non-text-input view
 - **AC7:** Unit tests, golden file test, race detector passes
+
+### Story 0.34: Fix 'q' Key in Sub-Views — Go Back Instead of Quit
+
+As a user navigating a sub-view (dashboard, health, synclog, etc.),
+I want pressing 'q' to return me to the doors view,
+So that 'q' means "close what I'm looking at" — quit at root, back in sub-views.
+
+**Status:** Ready
+
+**Acceptance Criteria:**
+- **AC1:** Universal quit handler (main_model.go:910-913) removed
+- **AC2:** Sub-views (ViewInsights, ViewHealth, ViewSyncLog, ViewNextSteps, ViewAvoidancePrompt) treat 'q' as go-back
+- **AC3:** Doors view still quits on 'q' (existing handler unchanged)
+- **AC4:** Text input views unchanged ('q' = text input)
+- **AC5:** Keybindings updated to show 'q: back' in sub-views
+- **AC6:** Tests updated, race detector passes
 
 ---
 

--- a/docs/stories/0.34.story.md
+++ b/docs/stories/0.34.story.md
@@ -1,0 +1,80 @@
+# Story 0.34: Fix 'q' Key Behavior in Sub-Views — Go Back Instead of Quit
+
+## Status: Ready
+
+## References
+
+- GitHub Issue: #330
+- Regression from: Story 36.3 (PR #276)
+- Party Mode Triage: `_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md`
+- Decision: D-128 on `docs/decisions/BOARD.md`
+
+## Story
+
+As a user navigating a sub-view (dashboard, health, synclog, etc.),
+I want pressing 'q' to return me to the doors view,
+So that 'q' means "close what I'm looking at" — quit at root, back in sub-views.
+
+## Background
+
+Story 36.3 (PR #276) added a universal quit handler at `main_model.go:910-913` that intercepts 'q' in all non-text-input views. This causes sub-views like `:dashboard` to exit the app instead of going back. The doors view already handles 'q' as quit at line 977, making the universal handler redundant for doors and harmful for sub-views.
+
+Party mode triage (3 agents, 2 rounds) unanimously chose Option C: scope quit to doors view only, make sub-views treat 'q' as go-back.
+
+## Acceptance Criteria
+
+**AC-1: Remove universal quit handler**
+**Given** the universal quit handler at `main_model.go:910-913`
+**When** the fix is applied
+**Then** lines 910-913 are removed (the doors view already handles 'q' as quit at line 977)
+
+**AC-2: Sub-views treat 'q' as go-back**
+**Given** the user is in any sub-view (ViewInsights, ViewHealth, ViewSyncLog, ViewNextSteps, ViewAvoidancePrompt)
+**When** the user presses 'q'
+**Then** the view returns to the previous view (same behavior as Esc)
+**And** the app does NOT exit
+
+**AC-3: Doors view still quits on 'q'**
+**Given** the user is on the doors view (root)
+**When** the user presses 'q'
+**Then** the app exits cleanly (existing behavior at line 977, unchanged)
+
+**AC-4: Text input views unchanged**
+**Given** the user is in a text input view (search, feedback, quick add)
+**When** the user presses 'q'
+**Then** 'q' is treated as text input (existing behavior, unchanged)
+
+**AC-5: Keybindings updated**
+**Given** the sub-view help/keybindings display
+**When** the user views keybindings for any sub-view
+**Then** `q` is listed as "back" alongside `esc`
+
+**AC-6: Tests updated**
+**Given** the test suite
+**When** tests run
+**Then** `TestUniversalQuit_InsightsView_QKeyQuits` is updated to expect go-back, not quit
+**And** a table-driven test covers 'q' as go-back across all sub-views
+**And** `go test -race ./internal/tui/...` passes
+
+## Technical Notes
+
+- Remove lines 910-913 in `internal/tui/main_model.go`
+- In each sub-view's Update(), add `case "q":` returning the same go-back message as `case "esc":`
+- Update keybindings in `internal/tui/keybindings.go` for sub-views
+- This overrides Story 36.3's AC that says "q quits from any view"
+- Three-tier model: quit at root, back in sub-views, text in input views
+
+## Files to Modify
+
+- `internal/tui/main_model.go`
+- `internal/tui/insights_view.go`
+- `internal/tui/health_view.go`
+- `internal/tui/synclog_view.go`
+- `internal/tui/next_steps_view.go`
+- `internal/tui/avoidance_prompt_view.go`
+- `internal/tui/keybindings.go`
+- `internal/tui/main_model_test.go`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope), AC-Q6 (race detector)


### PR DESCRIPTION
## Summary

- Triaged issue #330: universal quit handler (Story 36.3, PR #276) causes sub-views to exit on 'q' instead of going back
- Party mode triage (Sally/UX, Winston/Architect, Amelia/Dev — 2 rounds) unanimously chose Option C: scope quit to doors view only
- Created Story 0.33 for implementation, Decision D-125, rejected alternatives X-071/X-072/X-073

## Artifacts

- Party mode artifact: `_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md`
- Story file: `docs/stories/0.33.story.md`
- Decision: D-125 on `docs/decisions/BOARD.md`

## Test plan

- [ ] Docs-only PR — no code changes to test
- [ ] Verify story file has complete acceptance criteria
- [ ] Verify decision board entries are consistent