### PR TITLE
docs: governance sync — Epic 33 at 3/4

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -142,7 +142,7 @@ Complete Expand (manual sub-task creation) and Fork (variant creation) TUI featu
 | 31.4 | Enhanced Fork — Variant Creation with ForkTask Factory | Not Started | P2 | None |
 | 31.5 | Design Decision H9 Status Update | Not Started | P2 | 31.1-31.4 |
 
-### Epic 33: Seasonal Door Theme Variants (P2) — 2/4 stories done
+### Epic 33: Seasonal Door Theme Variants (P2) — 3/4 stories done
 
 Time-based seasonal theme variants that auto-switch based on current date. Extends Epic 17's theme infrastructure.
 


### PR DESCRIPTION
## Summary

- Epic 33 header count: 2/4 → 3/4 (Story 33.3 merged via PR #410, table was correct but header wasn't bumped)

## Test plan

- [ ] Verify ROADMAP.md shows Epic 33 at 3/4