### PR TITLE
docs: Epic 42 — Door-Like Doors planning (4 stories)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -216,6 +216,19 @@ Systematically adopt underutilized charmbracelet ecosystem components to reduce 
 | 41.5 | Harmonica Door Transition Spike | Done (PR #369) | P2 | None |
 | 41.6 | Adaptive Color Profile Support | Done (PR #373) | P2 | None |
 
+### Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement (P2) — 0/4 stories done
+
+Transform rectangular card/panel doors into visually convincing doors using side-mounted handles, hinge marks, threshold lines, crack-of-light selection feedback, and handle turn micro-animations. Based on 5-round party mode research with 7 agents.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 42.1 | Side-Mounted Handle + Hinge Marks | Not Started | P2 | Epic 35 (done), Epic 17 (done) |
+| 42.2 | Continuous Threshold / Floor Line | Not Started | P2 | None |
+| 42.3 | Crack of Light Effect on Selection | Not Started | P2 | 42.1 |
+| 42.4 | Handle Turn Micro-Animation | Not Started | P2 | 42.1 |
+
+**Dependency graph:** Stories 42.1 & 42.2 can parallelize. Stories 42.3 & 42.4 can parallelize after 42.1 completes.
+
 ### Epic 36: Door Selection Interaction Feedback (P1) — 4/4 stories done — COMPLETE
 
 Make door selection feel responsive and satisfying. Reopened for Story 36.4 (space/enter toggle).

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -238,6 +238,7 @@
 | D-135 | Proactive persistent agent restart policy | 2026-03-09 | Context exhaustion caused 30-min merge outage; restart every 4-6 hours or ~15-20 merges | [Ops Guide](../operations/persistent-agent-ops.md) |
 | D-136 | GO: Harmonica spring animations for door transitions | 2026-03-09 | Spike validated: spring physics works well for door selection emphasis; animation model is fully deterministic and testable; zero performance impact (~180 float ops/sec); testing pattern documented; recommend limited adoption (selection emphasis only, not view transitions). Rejected: full animation system (overkill for 3-door UI), mid-animation golden files (non-deterministic in CI) | [Testing Guide](../architecture/frame-animation-testing.md) |
 | D-137 | Space/Enter as toggle in DetailView (Story 36.4) | 2026-03-09 | Consistent with a/w/d toggle pattern (D-105, Story 36.2); SOUL.md "physical objects" — doors open AND close with same gesture; `isTextInputActive()` guard prevents text input conflicts; ~3-line change; preserves escape as alternative | [Party Mode](../../_bmad-output/planning-artifacts/space-enter-toggle-party-mode.md) |
+| D-141 | Adopt 5 proposals (B, C, D, F, G) for door-like doors (Epic 42) | 2026-03-09 | Selected proposals maximize door-feel with minimum friction, zero-to-minimal width cost (~200-250 LOC total). Rejected: Nested Frame (A, high width cost), Wall Context (E, 4 chars/side too expensive), Door Swing (H, high complexity/friction), Light Spill (I, achievable more simply via C). SOUL.md: "the UI should feel like physical objects" | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
 
 ## Rejected
 
@@ -282,6 +283,10 @@
 | X-071 | Exemption list for 'q' quit (Option A for #330) | 2026-03-09 | Growing maintenance list; wrong default (quit is dangerous, should require opt-in not opt-out) | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
 | X-072 | Sub-view consumes 'q' before universal handler (Option B for #330) | 2026-03-09 | Architecturally impossible — universal handler at line 910 fires before view delegation at line 921 | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
 | X-073 | Different key for universal quit (Option D for #330) | 2026-03-09 | 'q' is THE standard TUI quit key; problem is scope not key choice; changing it violates muscle memory | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
+| X-080 | Nested Frame for doors (Proposal A, Epic 42) | 2026-03-09 | High width cost (-4 chars) at minimum 15-char doors leaves only 7 for content; benefits achievable through hinge marks + side handle at lower cost | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
+| X-081 | Wall Context with shade characters (Proposal E, Epic 42) | 2026-03-09 | 4 chars per side too expensive; threshold line achieves grounding at zero width cost; conflicts with some themes | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
+| X-082 | Door Swing perspective animation (Proposal H, Epic 42) | 2026-03-09 | Highest complexity (~200+ LOC), text reflow risk, adds animation latency = friction; SOUL.md prioritizes reducing friction | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
+| X-083 | Light Spill per-cell background colors (Proposal I, Epic 42) | 2026-03-09 | Per-cell background colors require theme-specific tuning; Crack of Light achieves similar effect more simply | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
 
 ## Epic Number Registry
 
@@ -290,7 +295,8 @@
 | Epic | Feature | Allocated | Status |
 |------|---------|-----------|--------|
 | 41 | Charm Ecosystem Adoption & TUI Polish | 2026-03-09 | Proposed (pending PM approval) |
-| 42 | *(next available)* | — | — |
+| 42 | Door-Like Doors — Visual Door Metaphor Enhancement | 2026-03-09 | Stories created |
+| 43 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -513,7 +513,20 @@
 - **Research:** See `_bmad-output/planning-artifacts/bubbletea-feature-audit-party-mode.md`
 - **Decisions:** D-128 (viewport), D-129 (spinner), D-130 (layout), D-131 (harmonica spike), D-132 (reject list), D-133 (reject textarea/table/etc.), D-134 (epic number 41)
 
-**Epic 42+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement** (P2)
+- **Goal:** Transform rectangular card/panel doors into visually convincing doors using side-mounted handles, hinge marks, threshold lines, crack-of-light selection feedback, and handle turn micro-animations
+- **Prerequisites:** Epic 35 (Door Visual Appearance — complete), Epic 17 (Door Theme System — complete)
+- **Status:** Not Started
+- **Deliverables:**
+  - Side-mounted handle at right edge + hinge marks on left edge (asymmetry)
+  - Continuous threshold/floor line grounding all doors in shared space
+  - Crack of light effect on door selection (door becomes "ajar")
+  - Handle turn micro-animation synced with spring physics
+- **Stories:** 42.1-42.4 (4 stories)
+- **Research:** See `_bmad-output/planning-artifacts/doors-more-doorlike-research.md` (5-round party mode, 7 agents)
+- **Decisions:** D-141 (adopt 5 proposals), X-080 through X-083 (4 rejected alternatives)
+
+**Epic 43+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -566,5 +579,6 @@
 | Epic 39: Keybinding Display System | 13 | COMPLETE (12/13, 1 cancelled) |
 | Epic 40: Beautiful Stats Display | 10 | Complete |
 | Epic 41: Charm Ecosystem Adoption | 6 | Not Started |
-| **Total** | **216** | **146 complete, 4 epics in progress, 70 not started** |
+| Epic 42: Door-Like Doors | 4 | Not Started |
+| **Total** | **220** | **146 complete, 4 epics in progress, 74 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -4345,3 +4345,81 @@ Terminal-aware color degradation via lipgloss color profiles. Replace hardcoded 
 ### Research
 
 - Audit & Party Mode: `_bmad-output/planning-artifacts/bubbletea-feature-audit-party-mode.md`
+
+---
+
+## Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement
+
+**Priority:** P2
+**Status:** Not Started
+**Dependencies:** Epic 35 (Door Visual Appearance — complete), Epic 17 (Door Theme System — complete), Story 41.5 (Harmonica spike — complete, D-136 GO decision)
+
+### Epic Goal
+
+Transform rectangular card/panel doors into visually convincing doors by implementing 5 adopted proposals from the "doors more door-like" party mode research (5 rounds, 7 agents). The key insight: a door is defined by **asymmetry** (hinge vs opening side), **hardware** (a handle you can grab), **behavior** (it opens/closes), and **context** (it exists on a floor). Current rendering captures almost none of these.
+
+The 5 adopted proposals collectively raise "doorness" from ~3.5/7 (Classic) to ~6.5/7 across all themes, at a total cost of ~200-250 LOC and 0-1 character of width.
+
+### Stories
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 42.1 | Side-Mounted Handle + Hinge Marks | Not Started | P2 | Epic 35 (done), Epic 17 (done) |
+| 42.2 | Continuous Threshold / Floor Line | Not Started | P2 | None |
+| 42.3 | Crack of Light Effect on Selection | Not Started | P2 | 42.1 |
+| 42.4 | Handle Turn Micro-Animation | Not Started | P2 | 42.1 |
+
+**Dependency graph:**
+```
+Story 42.1 (Handle + Hinge) ──┬──→ Story 42.3 (Crack of Light)
+                               └──→ Story 42.4 (Handle Turn)
+Story 42.2 (Threshold) ──────────→ (independent)
+```
+
+Stories 42.1 & 42.2 can parallelize. Stories 42.3 & 42.4 can parallelize after 42.1.
+
+### Story Details
+
+#### Story 42.1: Side-Mounted Handle + Hinge Marks (Proposals B + G)
+
+Move doorknob from centered inline content to right edge at HandleRow. Add double-weight box-drawing characters on left border for hinge visual asymmetry. Update all 4 themes with per-theme hinge/handle characters. Extend DoorAnatomy with HingeCol. Zero width cost.
+
+**AC:** Handle at right edge in all themes, hinge marks (heavier left border) in all themes, DoorAnatomy has HingeCol, minimum width (15 chars) still works, golden files updated.
+
+#### Story 42.2: Continuous Threshold / Floor Line (Proposal F)
+
+Render continuous floor line after `JoinHorizontal()` in doors_view.go spanning full width. Uses `▔` or `─` character. Respects theme colors. ~15 LOC, very low risk.
+
+**AC:** Threshold line spans full door row width, uses theme colors, appears below shadow layer, renders at various widths.
+
+#### Story 42.3: Crack of Light Effect on Selection (Proposal C)
+
+Highest-scoring proposal (15/15). On selection, replace right border chars with crack chars (╎) and append shade (░). Synchronize with spring animation emphasis. Reverse on deselect. 1 character width cost when selected.
+
+**AC:** Crack effect on selection, reversed on deselect, synced with spring emphasis, minimum width works with crack, golden files updated.
+
+#### Story 42.4: Handle Turn Micro-Animation (Proposal D)
+
+4-frame handle character sequence synced with spring emphasis: ● (0.0) → ◐ (0.3) → ○ (0.6+). Reverse on deselect: ○ → ◑ → ●. ~20 LOC.
+
+**AC:** Handle animates on selection, reverses on deselect, deterministic frame selection based on emphasis value, all themes support animated handle.
+
+### Design Decisions
+
+- D-141: Adopt 5 proposals (B, C, D, F, G) for door-like doors; reject 4 (A, E, H, I)
+- X-080: Reject Nested Frame (A) — high width cost
+- X-081: Reject Wall Context (E) — 4 chars/side too expensive
+- X-082: Reject Door Swing (H) — high complexity, friction
+- X-083: Reject Light Spill (I) — achievable more simply via Crack of Light
+
+### Noted Opportunities (Out of Scope)
+
+1. Door-Opening Transition Animation (perspective shrink on Enter → detail view; ~200+ LOC, separate spike)
+2. Light Spill Enhancement (warm gradient layered on Crack of Light; future polish story)
+3. Nested Frame for Wide Terminals (frame-within-frame when width > 30; width-adaptive)
+4. Wall Context for Wide Terminals (shade characters flanking doors)
+
+### Research
+
+- Party Mode (5 rounds, 7 agents): `_bmad-output/planning-artifacts/doors-more-doorlike-research.md`
+- Prior: `_bmad-output/planning-artifacts/door-appearance-party-mode.md` (Epic 35)

--- a/docs/stories/42.1.story.md
+++ b/docs/stories/42.1.story.md
@@ -1,0 +1,111 @@
+# Story 42.1: Side-Mounted Handle + Hinge Marks
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/doors-more-doorlike-research.md` (Proposals B + G)
+- Decisions: D-141 (Adopt 5 proposals for door-like doors)
+- Prior Art: Epic 35 (Door Visual Appearance — Door-Like Proportions), D-031 (Portrait door proportions)
+- Architecture: `internal/tui/themes/anatomy.go` (DoorAnatomy struct)
+
+## Story
+
+As a user,
+I want doors to have side-mounted handles at the right edge and hinge marks on the left edge,
+So that the doors visually read as actual doors rather than rectangular cards/panels.
+
+## Background
+
+Current doors render the handle (●) centered inline with content, which reads as a decorative element rather than functional door hardware. Real doors have handles at the edge where you grab them, and hinges on the opposite side creating asymmetry. This is the single highest-impact static change for "doorness" — it makes every door immediately read as "door" rather than "card." Zero width cost.
+
+```
+Current:              Proposed:
+┌──────────────┐      ╓──────────────┐
+│              │      ║              │
+│  Buy milk    │      ║  Buy milk    │
+│     ●        │  →   ╟              ●
+│              │      ║              │
+└──────────────┘      ╙──────────────┘
+```
+
+## Acceptance Criteria
+
+**Given** a door is rendered in any theme
+**When** the handle row is displayed
+**Then** the handle character (● or theme equivalent) is positioned at the rightmost content column, not centered
+
+**Given** a door is rendered in any theme
+**When** the left border is displayed
+**Then** hinge marks use heavier/double-weight box-drawing characters on the left edge (e.g., ╓, ║, ╟, ╙ for Classic)
+**And** the right edge uses standard-weight characters (e.g., ┐, │, ┘)
+**And** this creates visible left-right asymmetry
+
+**Given** the DoorAnatomy struct
+**When** handle position is calculated
+**Then** a new HingeCol field exists to support hinge placement
+
+**Given** all 4 themes (Classic, Modern, Sci-Fi, Shoji)
+**When** rendered with hinge marks and side handle
+**Then** each theme uses theme-appropriate characters for hinges and handles
+**And** the visual asymmetry is consistent across themes
+
+**Given** a door at minimum width (15 chars)
+**When** rendered with side handle and hinge marks
+**Then** content area is not reduced (zero width cost)
+**And** the door still displays correctly
+
+**Given** existing golden file tests
+**When** the rendering changes are applied
+**Then** golden files are regenerated to match the new rendering
+
+## Technical Notes
+
+- Modify `DoorAnatomy` in `internal/tui/themes/anatomy.go` to add `HingeCol` calculation
+- Update `Render()` in each theme file: `classic.go`, `modern.go`, `scifi.go`, `shoji.go`
+- Handle placement: move from centered inline to right edge at `HandleRow` (already at 60% height)
+- Hinge characters by theme — choose per-theme Unicode box-drawing characters
+- Left border: heavier weight (double-line). Right border: lighter weight (single-line)
+- ~50 LOC per theme, low risk
+- Must pass `go test -race ./internal/tui/...`
+
+## Tasks
+
+### Task 1: Extend DoorAnatomy with HingeCol
+- Add `HingeCol` field to `DoorAnatomy` struct
+- Calculate hinge column position (always column 0)
+
+### Task 2: Update Classic theme
+- Replace left border characters with double-weight hinge marks (╓, ║, ╟, ╙)
+- Move handle to right edge at HandleRow
+- Keep right border as standard-weight
+
+### Task 3: Update Modern theme
+- Theme-appropriate hinge and handle characters
+- Side-mounted handle at right edge
+
+### Task 4: Update Sci-Fi theme
+- Theme-appropriate hinge and handle characters
+- Side-mounted handle at right edge
+
+### Task 5: Update Shoji theme
+- Theme-appropriate hinge and handle characters
+- Side-mounted handle at right edge
+
+### Task 6: Regenerate golden files
+- Update all affected golden file snapshots
+- Verify visual output at multiple widths
+
+### Task 7: Tests
+- Table-driven tests for hinge mark rendering per theme
+- Verify handle position at right edge
+- Test at minimum width (15 chars)
+- Race detector: `go test -race ./internal/tui/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.2.story.md
+++ b/docs/stories/42.2.story.md
@@ -1,0 +1,81 @@
+# Story 42.2: Continuous Threshold / Floor Line
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/doors-more-doorlike-research.md` (Proposal F)
+- Decisions: D-141 (Adopt 5 proposals for door-like doors)
+- Prior Art: Epic 35 (Door Visual Appearance), D-031 (Portrait door proportions)
+
+## Story
+
+As a user,
+I want a continuous floor/threshold line rendered beneath all three doors,
+So that the doors appear grounded in a shared physical space rather than floating as disconnected elements.
+
+## Background
+
+Real doors exist in context — they sit on a floor, within a wall. Currently, each door floats independently with no shared visual baseline. A continuous threshold line beneath all three doors creates the perception of a shared floor/hallway, grounding the metaphor. This is extremely low cost (~15 LOC) with zero width impact.
+
+```
+ ┌─────┐   ┌─────┐   ┌─────┐
+ │     │   │     │   │     │
+ │     ●   │     ●   │     ●
+ │     │   │     │   │     │
+ └─────┘   └─────┘   └─────┘
+ ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+```
+
+## Acceptance Criteria
+
+**Given** the doors view is rendered
+**When** three doors are displayed horizontally
+**Then** a continuous horizontal line is rendered below all doors spanning the full width
+**And** the line uses `▔` or theme-appropriate floor character
+
+**Given** the threshold line
+**When** rendered with any theme
+**Then** the line color respects the current theme's color palette
+
+**Given** the terminal width varies
+**When** doors are rendered at different widths
+**Then** the threshold line always spans the full width of the door row
+
+**Given** shadows are enabled
+**When** the threshold line is rendered
+**Then** it appears below the shadow layer (threshold is the "floor")
+
+## Technical Notes
+
+- Render the threshold line in `doors_view.go` after `lipgloss.JoinHorizontal()` produces the door row
+- Line spans full width of the joined door output
+- Use `▔` character (U+2594 UPPER ONE EIGHTH BLOCK) or `─` depending on theme
+- Respect theme colors for the threshold line
+- ~15 LOC, very low risk
+- Independent of Story 42.1 — can parallelize
+
+## Tasks
+
+### Task 1: Add threshold rendering
+- After door row join in `doors_view.go`, append threshold line
+- Use `strings.Repeat()` for the line character
+- Match line width to door row width
+
+### Task 2: Theme color integration
+- Apply theme-appropriate color to threshold line
+- Use existing theme color accessors
+
+### Task 3: Tests
+- Verify threshold renders at various terminal widths
+- Verify threshold appears below shadows
+- Golden file update if affected
+- Race detector: `go test -race ./internal/tui/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.3.story.md
+++ b/docs/stories/42.3.story.md
@@ -1,0 +1,96 @@
+# Story 42.3: Crack of Light Effect on Selection
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/doors-more-doorlike-research.md` (Proposal C — highest-scoring)
+- Decisions: D-141 (Adopt 5 proposals for door-like doors)
+- Prior Art: Epic 36 (Door Selection Interaction Feedback), Story 41.5 (Harmonica spring physics spike)
+
+## Story
+
+As a user,
+I want a "crack of light" effect to appear on the right edge of a door when I select it,
+So that the door visually communicates "slightly ajar" — the metaphor IS the interaction.
+
+## Background
+
+This was the highest-scoring proposal (15/15) in the party mode research. When a door is selected, the right border characters are replaced with crack/gap characters (╎) and a thin shade column (░) appears beyond the edge, suggesting light leaking through a door that's been cracked open. The effect reverses on deselect. This delivers immediate, visible, metaphorically coherent feedback at a cost of only 1 character width.
+
+```
+Unselected:           Selected:
+┌──────────┐          ┌──────────╮
+│          │          │          ╎░
+│  Task    │    →     │  Task    ╎░
+│          │          │          ╎░
+└──────────┘          └──────────╯
+```
+
+## Acceptance Criteria
+
+**Given** a door is not selected
+**When** it is rendered
+**Then** the right border uses standard border characters (│, ┐, ┘ or theme equivalent)
+
+**Given** a door becomes selected
+**When** it is rendered
+**Then** the right border characters are replaced with crack characters (╎ or theme equivalent)
+**And** a thin shade column (░) appears to the right of the crack
+**And** the top-right and bottom-right corners use rounded characters (╮, ╯ or theme equivalent)
+
+**Given** a selected door is deselected
+**When** it is rendered
+**Then** the crack of light effect is removed
+**And** standard border characters are restored
+
+**Given** the spring animation system (from Story 41.5)
+**When** the crack effect is rendered
+**Then** the crack synchronizes with the spring emphasis value (appears as emphasis increases)
+
+**Given** a door at minimum width (15 chars)
+**When** the crack of light effect is active
+**Then** the door content area is reduced by 1 character (for the ░ shade column)
+**And** the door still renders correctly
+
+## Technical Notes
+
+- Depends on Story 42.1 (side handle must be at right edge first for coherent visuals)
+- Update animation state machine with crack state in `internal/tui/animation.go`
+- Replace right border chars with ╎ when selected
+- Append ░ shade column to right of cracked border
+- Synchronize with existing spring physics emphasis value
+- Corner characters change: ┐→╮, ┘→╯ when cracked (suggesting the door edge has swung away)
+- ~50 LOC, low risk
+- Width cost: 1 char when selected (the ░ column)
+
+## Tasks
+
+### Task 1: Add crack-of-light state to animation model
+- Extend `DoorAnimation` with crack state tracking
+- Tie crack appearance to spring emphasis threshold
+
+### Task 2: Implement crack rendering per theme
+- Replace right border characters when selected
+- Append shade column (░) on selection
+- Reverse on deselection
+- Per-theme crack characters
+
+### Task 3: Synchronize with spring animation
+- Crack appears as emphasis value crosses threshold
+- Smooth transition (not instant toggle)
+
+### Task 4: Tests
+- Animation state transition tests
+- Visual output tests for cracked vs uncracked state
+- Minimum width behavior with crack active
+- Golden file updates
+- Race detector: `go test -race ./internal/tui/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.4.story.md
+++ b/docs/stories/42.4.story.md
@@ -1,0 +1,89 @@
+# Story 42.4: Handle Turn Micro-Animation
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/doors-more-doorlike-research.md` (Proposal D)
+- Decisions: D-141 (Adopt 5 proposals for door-like doors), D-136 (Harmonica spring animations validated)
+- Prior Art: Story 41.5 (Harmonica spring physics spike — GO decision)
+
+## Story
+
+As a user,
+I want the door handle to visually "turn" when I select a door,
+So that the interaction feels like grabbing and turning a real doorknob — a delightful micro-interaction.
+
+## Background
+
+A 4-frame handle character rotation synced with the existing spring physics animation. When a door is selected, the handle rotates from closed (●) through turning states (◐, ○) to fully turned. On deselect, it springs back (◑ → ●). This is ~20 LOC, trivially implementable, and delivers high satisfaction.
+
+```
+Frame 0: ●    (at rest)
+Frame 1: ◐    (turning)
+Frame 2: ○    (turned — door ajar)
+Deselect: ◑ → ●  (spring back)
+```
+
+## Acceptance Criteria
+
+**Given** a door is not selected
+**When** it is rendered
+**Then** the handle displays as ● (at rest)
+
+**Given** a door becomes selected
+**When** the spring animation plays
+**Then** the handle character cycles through: ● → ◐ → ○
+**And** the character at each frame corresponds to the spring emphasis value
+
+**Given** a selected door is deselected
+**When** the spring animation reverses
+**Then** the handle character cycles back: ○ → ◑ → ●
+
+**Given** the spring emphasis value
+**When** mapped to handle frames
+**Then** emphasis 0.0 = ● (at rest)
+**And** emphasis ~0.3 = ◐ (turning)
+**And** emphasis ~0.6+ = ○ (turned)
+**And** reverse emphasis ~0.5 = ◑ (spring back)
+
+**Given** the handle turn animation
+**When** the door is at any emphasis state
+**Then** the correct handle character is deterministically selected based on emphasis value
+
+## Technical Notes
+
+- Depends on Story 42.1 (handle must be side-mounted first)
+- Extend animation model with handle frame selection based on emphasis value
+- 4 Unicode characters: ● (U+25CF), ◐ (U+25D0), ○ (U+25CB), ◑ (U+25D1)
+- Map emphasis value to character: thresholds at 0.0, 0.3, 0.6
+- Reverse mapping for deselection
+- Reuses existing spring physics tick mechanism — no new animation infrastructure
+- ~20 LOC, low risk
+- Per-theme handle characters if themes use different knob styles
+
+## Tasks
+
+### Task 1: Add handle frame selection to animation model
+- Map spring emphasis to handle character index
+- Define forward and reverse frame sequences
+- Export frame selection function
+
+### Task 2: Integrate with theme rendering
+- Each theme's handle rendering reads current frame from animation state
+- Replace static ● with animated character
+
+### Task 3: Tests
+- Table-driven tests: emphasis value → expected handle character
+- Forward sequence test (selection)
+- Reverse sequence test (deselection)
+- Deterministic frame selection (same emphasis = same character)
+- Race detector: `go test -race ./internal/tui/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

- Formalizes the 5-round party mode research (`_bmad-output/planning-artifacts/doors-more-doorlike-research.md`) into Epic 42 with 4 implementation stories
- Creates story files `docs/stories/42.1-42.4.story.md` with full acceptance criteria, technical notes, and task breakdowns
- Updates all three planning doc sources of truth: `ROADMAP.md`, `docs/prd/epic-list.md`, `docs/prd/epics-and-stories.md`
- Adds decision D-141 (adopt 5 proposals) and X-080 through X-083 (4 rejected alternatives) to `docs/decisions/BOARD.md`
- Reserves Epic 42 in the Epic Number Registry

## Epic 42: Door-Like Doors — Visual Door Metaphor Enhancement (P2)

Transforms rectangular card/panel doors into visually convincing doors:

| Story | Title | ~LOC | Width Cost | Depends On |
|-------|-------|------|------------|------------|
| 42.1 | Side-Mounted Handle + Hinge Marks (B+G) | ~200 | 0 chars | None |
| 42.2 | Continuous Threshold / Floor Line (F) | ~15 | 0 chars | None |
| 42.3 | Crack of Light Effect on Selection (C) | ~50 | 1 char | 42.1 |
| 42.4 | Handle Turn Micro-Animation (D) | ~20 | 0 chars | 42.1 |

**Parallelism:** 42.1 & 42.2 independent. 42.3 & 42.4 independent after 42.1.

## Decisions Recorded

- **D-141:** Adopt proposals B (side handle), C (crack of light), D (handle turn), F (threshold), G (hinge marks)
- **X-080:** Reject Nested Frame (A) — width cost too high
- **X-081:** Reject Wall Context (E) — 4 chars/side too expensive
- **X-082:** Reject Door Swing (H) — high complexity, adds friction
- **X-083:** Reject Light Spill (I) — achievable more simply via C

## Noted Opportunities (not implemented)

1. Door-Opening Transition Animation (~200+ LOC, separate spike)
2. Light Spill Enhancement (future polish on top of 42.3)
3. Nested Frame for Wide Terminals (width-adaptive, lower priority)
4. Wall Context for Wide Terminals (shade characters flanking doors)

## Test plan

- [ ] No implementation code — planning artifacts only
- [ ] Story files have complete acceptance criteria
- [ ] All three planning docs updated consistently
- [ ] BOARD.md has decision + rejected alternatives
- [ ] Epic Number Registry updated (42 reserved, 43 next available)