### PR TITLE
docs: Epic 42 — ThreeDoors Doctor self-diagnosis command (planning)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -216,6 +216,23 @@ Systematically adopt underutilized charmbracelet ecosystem components to reduce 
 | 41.5 | Harmonica Door Transition Spike | Done (PR #369) | P2 | None |
 | 41.6 | Adaptive Color Profile Support | Done (PR #373) | P2 | None |
 
+### Epic 42: ThreeDoors Doctor — Self-Diagnosis Command (P1) — 0/10 stories done
+
+Comprehensive self-diagnosis command with flutter-style category-based output, conservative auto-repair, and channel-aware version checking. Supersedes existing `health` command.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 42.1 | Doctor Command Skeleton & Health Alias | Not Started | P1 | None |
+| 42.2 | Environment Checks | Not Started | P1 | 42.1 |
+| 42.3 | Task Data Integrity Checks | Not Started | P1 | 42.1 |
+| 42.4 | Provider Health Checks | Not Started | P1 | 42.1 |
+| 42.5 | Session & Analytics Checks | Not Started | P1 | 42.1 |
+| 42.6 | Sync & Offline Queue Checks | Not Started | P1 | 42.1 |
+| 42.7 | Enrichment Database Checks | Not Started | P1 | 42.1 |
+| 42.8 | Auto-Repair (`--fix` flag) | Not Started | P1 | 42.2-42.7 |
+| 42.9 | Channel-Aware Version Checking | Not Started | P1 | 42.1 |
+| 42.10 | Verbose Mode, Category Filter & Polish | Not Started | P1 | 42.2-42.9 |
+
 ### Epic 36: Door Selection Interaction Feedback (P1) — 4/4 stories done — COMPLETE
 
 Make door selection feel responsive and satisfying. Reopened for Story 36.4 (space/enter toggle).

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -238,6 +238,11 @@
 | D-135 | Proactive persistent agent restart policy | 2026-03-09 | Context exhaustion caused 30-min merge outage; restart every 4-6 hours or ~15-20 merges | [Ops Guide](../operations/persistent-agent-ops.md) |
 | D-136 | GO: Harmonica spring animations for door transitions | 2026-03-09 | Spike validated: spring physics works well for door selection emphasis; animation model is fully deterministic and testable; zero performance impact (~180 float ops/sec); testing pattern documented; recommend limited adoption (selection emphasis only, not view transitions). Rejected: full animation system (overkill for 3-door UI), mid-animation golden files (non-deterministic in CI) | [Testing Guide](../architecture/frame-animation-testing.md) |
 | D-137 | Space/Enter as toggle in DetailView (Story 36.4) | 2026-03-09 | Consistent with a/w/d toggle pattern (D-105, Story 36.2); SOUL.md "physical objects" — doors open AND close with same gesture; `isTextInputActive()` guard prevents text input conflicts; ~3-line change; preserves escape as alternative | [Party Mode](../../_bmad-output/planning-artifacts/space-enter-toggle-party-mode.md) |
+| D-141 | Command name `doctor`; supersedes existing `health` command (Epic 42) | 2026-03-09 | Most widely recognized pattern (brew, flutter, npm); `health` too new to have scripting dependents; absorb into doctor, keep `health` as alias | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| D-142 | Flutter-style icon output as default format (Epic 42) | 2026-03-09 | Best scanability; `[✓]`/`[!]`/`[✗]`/`[i]` well-established UX pattern; rejected: npm table (harder to scan), brew paragraphs (too verbose) | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| D-143 | Conservative auto-fix with `--fix` flag (Epic 42) | 2026-03-09 | Only fix safe, reversible operations (temp files, derived caches, permissions); user data never auto-modified; rejected: aggressive auto-fix (risky), no auto-fix (misses easy wins) | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| D-144 | 24-hour cached version check, gh CLI pattern (Epic 42) | 2026-03-09 | Proven pattern; respects rate limits; non-blocking; opt-out via env var and config; rejected: check every run (chatty), weekly (too stale) | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| D-145 | Channel-aware version: show within channel + cross-channel if higher (Epic 42) | 2026-03-09 | Alpha users should know about newer stable releases; matches rustup approach; rejected: strict isolation (misses important releases), all channels (noisy) | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
 
 ## Rejected
 
@@ -282,6 +287,11 @@
 | X-071 | Exemption list for 'q' quit (Option A for #330) | 2026-03-09 | Growing maintenance list; wrong default (quit is dangerous, should require opt-in not opt-out) | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
 | X-072 | Sub-view consumes 'q' before universal handler (Option B for #330) | 2026-03-09 | Architecturally impossible — universal handler at line 910 fires before view delegation at line 921 | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
 | X-073 | Different key for universal quit (Option D for #330) | 2026-03-09 | 'q' is THE standard TUI quit key; problem is scope not key choice; changing it violates muscle memory | [Triage](../../_bmad-output/planning-artifacts/issue-330-dashboard-q-triage.md) |
+| X-074 | Interactive repair wizard for doctor command (Epic 42) | 2026-03-09 | Too complex for v1; doctor should be non-interactive; if repair needs user input, print instructions | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| X-075 | Doctor as part of every command startup (Epic 42) | 2026-03-09 | Too slow; version check is background-only via cache; doctor is explicit command | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| X-076 | Telemetry/crash reporting in doctor (Epic 42) | 2026-03-09 | Out of scope; doctor is local-only diagnostics; telemetry is a separate concern | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| X-077 | `health` and `doctor` coexist as separate commands (Epic 42) | 2026-03-09 | User confusion about which to run; health is new enough to absorb into doctor | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| X-078 | Command name `check` or `diagnose` instead of `doctor` (Epic 42) | 2026-03-09 | `check` too generic (conflicts with linter terminology); `diagnose` too verbose; `doctor` is the established pattern | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
 
 ## Epic Number Registry
 
@@ -290,7 +300,8 @@
 | Epic | Feature | Allocated | Status |
 |------|---------|-----------|--------|
 | 41 | Charm Ecosystem Adoption & TUI Polish | 2026-03-09 | Proposed (pending PM approval) |
-| 42 | *(next available)* | — | — |
+| 42 | ThreeDoors Doctor — Self-Diagnosis Command | 2026-03-09 | Allocated (stories created) |
+| 43 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -513,7 +513,23 @@
 - **Research:** See `_bmad-output/planning-artifacts/bubbletea-feature-audit-party-mode.md`
 - **Decisions:** D-128 (viewport), D-129 (spinner), D-130 (layout), D-131 (harmonica spike), D-132 (reject list), D-133 (reject textarea/table/etc.), D-134 (epic number 41)
 
-**Epic 42+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 42: ThreeDoors Doctor — Self-Diagnosis Command** (P1)
+- **Goal:** Comprehensive self-diagnosis command (`threedoors doctor`) with flutter-style category-based output, conservative auto-repair, and channel-aware version checking. Supersedes existing `health` command.
+- **Prerequisites:** Epic 23 (CLI Interface — complete)
+- **Status:** Not Started
+- **Deliverables:**
+  - Doctor command skeleton with DoctorChecker framework and `health` alias
+  - 6 check categories: Environment, Task Data, Providers, Sessions, Sync, Database
+  - Channel-aware version checking with 24h cache (gh CLI pattern)
+  - Conservative auto-repair via `--fix` flag (safe/reversible ops only)
+  - Verbose mode (`-v`), category filter (`--category`), JSON output (`--json`)
+  - flutter-style icons: `[✓]` pass, `[!]` warn, `[✗]` fail, `[i]` info, `[ ]` skip
+- **Stories:** 42.1-42.10 (10 stories)
+- **Estimated Effort:** 2-3 weeks at 2-4 hrs/week
+- **Research:** See `_bmad-output/planning-artifacts/threedoors-doctor-research.md`
+- **Decisions:** D-141 (doctor supersedes health), D-142 (flutter-style icons), D-143 (conservative auto-fix), D-144 (24h cached version check), D-145 (channel-aware version)
+
+**Epic 43+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -566,5 +582,6 @@
 | Epic 39: Keybinding Display System | 13 | COMPLETE (12/13, 1 cancelled) |
 | Epic 40: Beautiful Stats Display | 10 | Complete |
 | Epic 41: Charm Ecosystem Adoption | 6 | Not Started |
-| **Total** | **216** | **146 complete, 4 epics in progress, 70 not started** |
+| Epic 42: ThreeDoors Doctor | 10 | Not Started |
+| **Total** | **226** | **146 complete, 4 epics in progress, 80 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 1-15, 3.5, 17-24, 26-29, 32, 34-38, 41 are COMPLETE. Epic 0 is partial (10/13). Epic 16 is ICEBOX. Epics 25, 30-31, 33, 39-40 are NOT STARTED or IN PROGRESS. 390+ merged PRs total. Last audit: 2026-03-09.
+**Implementation Status:** Epics 1-15, 3.5, 17-24, 26-29, 32, 34-38, 41 are COMPLETE. Epic 0 is partial (10/13). Epic 16 is ICEBOX. Epics 25, 30-31, 33, 39-40, 42 are NOT STARTED or IN PROGRESS. 390+ merged PRs total. Last audit: 2026-03-09.
 
 ## Requirements Inventory
 
@@ -4345,3 +4345,103 @@ Terminal-aware color degradation via lipgloss color profiles. Replace hardcoded 
 ### Research
 
 - Audit & Party Mode: `_bmad-output/planning-artifacts/bubbletea-feature-audit-party-mode.md`
+
+---
+
+## Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+**Goal:** Comprehensive self-diagnosis command (`threedoors doctor`) with flutter-style category-based output, conservative auto-repair via `--fix`, and channel-aware version checking. Supersedes existing `health` command (`internal/cli/health.go`).
+
+**Prerequisites:** Epic 23 (CLI Interface — complete)
+
+**Status:** Not Started (0/10 stories)
+
+**Priority:** P1
+
+### Stories
+
+#### Story 42.1: Doctor Command Skeleton & Health Alias
+
+Create `internal/cli/doctor.go` with cobra command, `internal/core/doctor.go` with `DoctorChecker` struct and result types. Implement category-based output with flutter-style icons (`[✓]`/`[!]`/`[✗]`/`[i]`/`[ ]`). Register `doctor` as primary, `health` as alias. Support `--json` output. Implement Environment category only.
+
+**AC:** `threedoors doctor` runs and shows Environment category. `threedoors health` is an alias. `--json` produces valid JSON with envelope pattern.
+
+#### Story 42.2: Environment Checks
+
+Expand environment checks: config directory existence/permissions, config file YAML validation + schema version, terminal capability detection (size, color profile), Go runtime version.
+
+**AC:** Environment category shows config dir, config file, terminal info. Missing dir = FAIL. Bad schema = FAIL. Narrow terminal = WARN. ASCII color = INFO.
+
+#### Story 42.3: Task Data Integrity Checks
+
+Task file existence and YAML validity. Per-task `Validate()`. Duplicate ID detection. Dependency reference validation. Blocker/CompletedAt consistency. Legacy migration detection (`tasks.txt`, `source_provider`).
+
+**AC:** Task Data category reports all validation results. Duplicate IDs = FAIL. Dangling deps = WARN. Blocker/status mismatch = WARN.
+
+#### Story 42.4: Provider Health Checks
+
+Integrate existing `HealthChecker` checks. Multi-provider iteration with per-provider results. Provider-specific connectivity tests with timeout. Aggregate category status from worst individual.
+
+**AC:** Providers category shows health of all configured providers. No provider = FAIL. LoadTasks failure = FAIL. Partial failure = WARN.
+
+#### Story 42.5: Session & Analytics Checks
+
+`sessions.jsonl` line-by-line JSON validation with corrupt line tracking. `patterns.json` validity. Session count and required field checks.
+
+**AC:** Session Data category reports file health and stats. Corrupt lines = WARN with line numbers. Corrupt cache = WARN.
+
+#### Story 42.6: Sync & Offline Queue Checks
+
+Sync state file validation and staleness (>24h). WAL queue validation (stuck entries with retries ≥ 10, size > 10,000). Sync log JSONL validation. Orphaned `.tmp` file detection (age > 1 hour).
+
+**AC:** Sync category reports queue health and temp file status. Stale sync = WARN. Stuck entries = WARN. Orphaned temps = WARN.
+
+#### Story 42.7: Enrichment Database Checks
+
+SQLite open/close test (read-only). Schema version check. `PRAGMA integrity_check`. WAL file presence reporting.
+
+**AC:** Database category reports DB health. Missing DB = WARN. Failed integrity = FAIL. Schema mismatch = WARN.
+
+#### Story 42.8: Auto-Repair (`--fix` flag)
+
+Add `--fix` flag. Auto-repair safe operations: orphaned temp cleanup, corrupt patterns.json deletion, missing config generation, legacy migration (with .bak), stale version cache deletion, directory permission repair. NEVER auto-fix: corrupt tasks/sessions/DB, stuck WAL, provider auth, duplicate IDs, dangling deps.
+
+**AC:** `--fix` repairs safe issues and reports what was fixed. Summary shows fixed vs manual counts.
+
+#### Story 42.9: Channel-Aware Version Checking
+
+GitHub Releases API integration (lightweight, no go-github). Channel-aware filtering (stable/beta/alpha). 24-hour cached background check. Opt-out via `THREEDOORS_NO_UPDATE_CHECK` env var and `update_check` config. CI auto-disable.
+
+**AC:** Version category shows current vs latest, respects channel. Alpha sees newer stable if base semver is higher. Dev build skips check. Opt-out works.
+
+#### Story 42.10: Verbose Mode, Category Filter & Polish
+
+`-v`/`--verbose` for detailed sub-check output. `--category` for selective checking (comma-separated). `--skip-version` flag. Colored icons (green/yellow/red/cyan/gray). Summary line with issue counts. Exit codes (0=clean, 1=warn, 2=error).
+
+**AC:** All flags work. Output matches UX mockups from research. Exit codes set correctly.
+
+### Dependencies
+
+```
+Story 42.1 (skeleton) → Stories 42.2-42.7 (check categories, parallelizable)
+Stories 42.2-42.7 → Story 42.8 (--fix needs checks to exist)
+Story 42.1 → Story 42.9 (version check is independent category)
+Stories 42.2-42.9 → Story 42.10 (polish after all checks exist)
+```
+
+### Design Decisions
+
+- D-141: Command name `doctor`; supersedes `health` (alias kept)
+- D-142: Flutter-style icon output as default format
+- D-143: Conservative auto-fix with `--fix` flag
+- D-144: 24-hour cached version check (gh CLI pattern)
+- D-145: Channel-aware version: show within channel + cross-channel if higher
+- X-074: Rejected interactive repair wizard
+- X-075: Rejected doctor as part of every command startup
+- X-076: Rejected telemetry/crash reporting integration
+- X-077: Rejected `health` and `doctor` coexisting as separate commands
+- X-078: Rejected `check`/`diagnose` as command names
+
+### Research
+
+- Doctor Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md`

--- a/docs/stories/42.1.story.md
+++ b/docs/stories/42.1.story.md
@@ -1,0 +1,89 @@
+# Story 42.1: Doctor Command Skeleton & Health Alias
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md`
+- Decisions: D-141 (doctor supersedes health), D-142 (flutter-style icon output), D-143 (conservative auto-fix)
+
+## Story
+
+As a user,
+I want to run `threedoors doctor` and see a category-based diagnostic summary with icons,
+So that I can quickly assess the health of my ThreeDoors installation.
+
+## Background
+
+ThreeDoors has an existing `health` command (`internal/cli/health.go` + `internal/core/health_checker.go`) with 4 checks (task file, database, sync, Apple Notes). This story creates the `doctor` command skeleton that will supersede `health`, establishing the category-based output format and registering `health` as an alias.
+
+The output uses flutter doctor-style icons: `[✓]` pass (green), `[!]` warning (yellow), `[✗]` error (red), `[i]` info (cyan), `[ ]` skipped (gray).
+
+## Acceptance Criteria
+
+**Given** the CLI is available
+**When** the user runs `threedoors doctor`
+**Then** the command executes and displays a header line with version and channel info
+**And** the Environment category runs and shows results with icons
+**And** a summary line appears at the bottom ("No issues found" or "N issues in M categories")
+
+**Given** the user runs `threedoors health`
+**When** the command executes
+**Then** it behaves identically to `threedoors doctor` (alias)
+
+**Given** the user runs `threedoors doctor --json`
+**When** the command executes
+**Then** output is valid JSON matching the existing CLI envelope pattern
+**And** includes `schema_version`, `command: "doctor"`, and `data.categories` array
+
+**Given** the `DoctorChecker` struct is created
+**When** check categories are registered
+**Then** each category has a name, a check function, and a severity result
+**And** categories run in defined order
+
+## Technical Notes
+
+- Create `internal/cli/doctor.go` with cobra command registration
+- Create `internal/core/doctor.go` with `DoctorChecker` struct and `CheckResult`/`CategoryResult` types
+- Reuse and extend `HealthCheckItem`/`HealthStatus` types from `internal/core/health_checker.go`
+- Register `doctor` as primary command, `health` as alias in cobra
+- Implement only the Environment category in this story (others added in subsequent stories)
+- Environment checks: config directory exists + permissions, config file valid YAML + schema version
+- JSON output follows existing `OutputEnvelope` pattern from `internal/cli/output.go`
+- Use `lipgloss` for colored icon output (respects `--no-color` flag)
+
+## Tasks
+
+### Task 1: Define DoctorChecker types in internal/core/doctor.go
+- `CheckStatus` enum: OK, WARN, FAIL, INFO, SKIP
+- `CheckResult` struct: Name, Status, Message, Suggestion
+- `CategoryResult` struct: Name, Status, Checks []CheckResult
+- `DoctorChecker` struct with configPaths and registered categories
+- `NewDoctorChecker()` factory
+
+### Task 2: Implement Environment category checks
+- Config directory existence and permissions (readdir, writability test)
+- Config file YAML parse and schema_version validation
+- Terminal size detection (width × height)
+- Color profile detection (Ascii/256/TrueColor)
+
+### Task 3: Create doctor cobra command in internal/cli/doctor.go
+- Register `doctor` command with `health` as alias
+- Wire `--json` flag to existing output formatter
+- Render category results with icons and colors
+- Summary line with issue counts
+
+### Task 4: Tests
+- Table-driven tests for DoctorChecker with mock config paths
+- Test CheckStatus ordering (FAIL > WARN > INFO > OK)
+- Test JSON output schema
+- Test `health` alias resolves to doctor
+- Run `go test -race ./internal/cli/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.10.story.md
+++ b/docs/stories/42.10.story.md
@@ -1,0 +1,103 @@
+# Story 42.10: Verbose Mode, Category Filter & Polish
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Sections 5, 7)
+
+## Story
+
+As a user,
+I want verbose output for detailed diagnostics and the ability to run only specific check categories,
+So that I can debug specific issues efficiently without running all checks.
+
+## Background
+
+With all check categories implemented (Stories 42.1-42.9), this story adds polish: `--verbose` for detailed sub-check output, `--category` for selective checking, `--skip-version` for offline runs, colored output, and a comprehensive summary line. Output should match the UX mockups from the research document.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor -v`
+**When** the command executes
+**Then** each category shows expanded detail (file paths, permissions, sizes, timestamps, individual check items)
+**And** format matches the verbose mockup from research doc
+
+**Given** the user runs `threedoors doctor --category tasks`
+**When** the command executes
+**Then** only the Task Data category runs
+**And** other categories are not checked or displayed
+
+**Given** the user runs `threedoors doctor --category env,sync`
+**When** the command executes
+**Then** only Environment and Sync categories run
+
+**Given** the user runs `threedoors doctor --skip-version`
+**When** the command executes
+**Then** the Version category is skipped entirely
+
+**Given** the user runs `threedoors doctor` in a terminal with color support
+**When** results render
+**Then** `[✓]` is green, `[!]` is yellow, `[✗]` is red, `[i]` is cyan, `[ ]` is gray
+**And** colors respect `--no-color` and `NO_COLOR` env var
+
+**Given** doctor found issues
+**When** the command completes
+**Then** a summary line shows "Doctor found issues in N categories."
+**And** if fixable issues exist: "Run 'threedoors doctor --fix' to auto-repair fixable issues."
+
+**Given** doctor found no issues
+**When** the command completes
+**Then** summary shows "No issues found. Your system is ready to use."
+
+## Technical Notes
+
+- `--verbose` / `-v` flag: each check function returns detailed info in addition to summary
+- `--category` flag: comma-separated list of category names (env, tasks, providers, sessions, sync, db, version)
+- `--skip-version` flag: shorthand for `--category` excluding version
+- Color rendering: Lipgloss styles for each icon type, respecting color profile
+- Summary line: count categories with WARN or FAIL status
+- Exit code: 0 = no issues, 1 = warnings only, 2 = errors found (for scripting)
+
+## Tasks
+
+### Task 1: Add CLI flags
+- `--verbose` / `-v` boolean flag
+- `--category` string flag (comma-separated)
+- `--skip-version` boolean flag
+- Flag validation (unknown category names)
+
+### Task 2: Verbose output rendering
+- Expand each category's View() with detailed sub-items
+- Include file paths, sizes, timestamps, permissions
+- Indent sub-items under category header
+
+### Task 3: Category filtering
+- Parse `--category` flag into set of enabled categories
+- Skip disabled categories with `[ ]` SKIP
+- `--skip-version` sets version category to skip
+
+### Task 4: Color and icon rendering
+- Lipgloss styles per CheckStatus
+- Green/yellow/red/cyan/gray icons
+- Respect `--no-color`, `NO_COLOR`, color profile
+
+### Task 5: Summary line and exit code
+- Count categories by worst status
+- Render appropriate summary
+- Set exit code for scripting
+
+### Task 6: Tests
+- Test verbose output includes expected detail
+- Test category filtering
+- Test exit codes
+- Test color rendering with mock color profiles
+- Run `go test -race ./internal/cli/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.2.story.md
+++ b/docs/stories/42.2.story.md
@@ -1,0 +1,80 @@
+# Story 42.2: Environment Checks
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 2, Category 1)
+
+## Story
+
+As a user,
+I want the doctor command to thoroughly check my environment setup,
+So that I can identify configuration problems before they cause issues.
+
+## Background
+
+Story 42.1 creates the doctor skeleton with a basic environment category. This story expands the environment checks to be comprehensive: config directory permissions, config file validation with schema version checking, terminal capability detection, and Go runtime version reporting.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor`
+**When** the Environment category executes
+**Then** config directory `~/.threedoors/` is checked for existence, readability, and writability
+**And** config file `config.yaml` is checked for valid YAML, valid schema_version (≤ current), and required fields
+
+**Given** the config directory does not exist
+**When** doctor runs
+**Then** Environment shows `[✗]` FAIL with message "Config directory not found"
+**And** suggestion: "Run threedoors to create it during onboarding"
+
+**Given** the config file has an unsupported schema_version
+**When** doctor runs
+**Then** Environment shows `[✗]` FAIL with message about unsupported schema version
+**And** suggestion to update ThreeDoors
+
+**Given** a very narrow terminal (< 40 columns)
+**When** doctor runs
+**Then** Environment shows `[!]` WARN about narrow terminal affecting theme display
+
+**Given** the terminal supports only ASCII color profile
+**When** doctor runs
+**Then** Environment shows `[i]` INFO about degraded color experience
+
+## Technical Notes
+
+- Extend `DoctorChecker` environment category from Story 42.1
+- Use `internal/core/config_paths.go` for directory path resolution
+- Use `internal/core/provider_config.go` for config validation
+- Terminal detection: `lipgloss.ColorProfile()` for color, `tea.WindowSizeMsg` pattern for size
+- Go version: `runtime.Version()` — INFO only, never fails for compiled binary
+
+## Tasks
+
+### Task 1: Config directory checks
+- Existence via `os.Stat()`
+- Readability via `os.ReadDir()`
+- Writability via temp file create+delete test
+
+### Task 2: Config file validation
+- YAML parse check
+- Schema version range check
+- Required field presence (provider at minimum)
+
+### Task 3: Terminal capability detection
+- Width × height detection
+- Color profile detection (ASCII/ANSI256/TrueColor)
+- Report as INFO items
+
+### Task 4: Tests
+- Table-driven tests with temp directories (missing, read-only, valid)
+- Config validation tests (corrupt YAML, old schema, valid)
+- Run `go test -race ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.3.story.md
+++ b/docs/stories/42.3.story.md
@@ -1,0 +1,89 @@
+# Story 42.3: Task Data Integrity Checks
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 2, Category 2)
+
+## Story
+
+As a user,
+I want the doctor command to validate my task data for consistency and integrity,
+So that I can identify corrupt or inconsistent task entries before they cause problems.
+
+## Background
+
+Task data is stored in `tasks.yaml` and can accumulate inconsistencies: duplicate IDs, dangling dependency references, blocker fields on non-blocked tasks, CompletedAt timestamps on incomplete tasks, and legacy fields needing migration. This story adds comprehensive task data validation to the doctor command.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor`
+**When** the Task Data category executes
+**Then** `tasks.yaml` is checked for existence and YAML validity
+**And** each task is validated using the existing `Validate()` method
+**And** results show task count by status (e.g., "12 tasks loaded (3 active, 2 blocked, 7 todo)")
+
+**Given** two tasks share the same ID
+**When** doctor runs
+**Then** Task Data shows `[✗]` FAIL with "Duplicate task ID: {id}"
+
+**Given** a task's `depends_on` references a non-existent task ID
+**When** doctor runs
+**Then** Task Data shows `[!]` WARN with "Task {id} depends on non-existent task {dep_id}"
+**And** suggestion: "Remove the dependency or recreate the missing task"
+
+**Given** a task has `blocker` set but status is not `blocked`
+**When** doctor runs
+**Then** Task Data shows `[!]` WARN about blocker/status inconsistency
+
+**Given** a task has `completed_at` set but status is not `complete` or `archived`
+**When** doctor runs
+**Then** Task Data shows `[!]` WARN about timestamp inconsistency
+
+**Given** `tasks.txt` exists but `tasks.yaml` does not
+**When** doctor runs
+**Then** Task Data shows `[!]` WARN about legacy migration needed
+
+## Technical Notes
+
+- Use existing `core.Task.Validate()` for per-task checks
+- Build ID set for duplicate detection: `map[string]int` counting occurrences
+- Use `core.DependencyResolver` or build dependency map for orphan detection
+- Check blocker field: non-empty `Blocker` with `Status != StatusBlocked`
+- Check CompletedAt: non-nil with `Status` not in {complete, archived}
+- Legacy detection: check for `tasks.txt` via `os.Stat()`
+- Legacy field detection: check for `source_provider` field (should be `source_refs`)
+
+## Tasks
+
+### Task 1: Task file existence and parse check
+- File exists, readable, valid YAML
+- Count tasks by status for summary
+
+### Task 2: Per-task validation
+- Run `Validate()` on each task, collect errors
+- Each validation failure becomes a WARN check result
+
+### Task 3: Cross-task consistency checks
+- Duplicate ID detection
+- Dependency reference validation
+- Blocker/status consistency
+- CompletedAt/status consistency
+
+### Task 4: Legacy detection
+- `tasks.txt` presence without `tasks.yaml`
+- `source_provider` field presence
+
+### Task 5: Tests
+- Table-driven tests with various task data scenarios
+- Fixture files in `testdata/` for corrupt/inconsistent data
+- Run `go test -race ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.4.story.md
+++ b/docs/stories/42.4.story.md
@@ -1,0 +1,80 @@
+# Story 42.4: Provider Health Checks
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 2, Category 4)
+
+## Story
+
+As a user,
+I want the doctor command to verify that my configured task providers are healthy and accessible,
+So that I can diagnose connectivity or configuration issues with my task sources.
+
+## Background
+
+ThreeDoors supports multiple task providers (textfile, Obsidian, Jira, GitHub, Todoist, Apple Notes, Apple Reminders). The existing `health` command checks basic provider connectivity. This story integrates and extends those checks into the doctor framework, supporting multi-provider configurations.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor`
+**When** the Providers category executes
+**Then** each configured provider is checked for health
+**And** results show provider name, type, and status
+
+**Given** no provider is configured
+**When** doctor runs
+**Then** Providers shows `[✗]` FAIL with "No provider configured"
+
+**Given** a provider's `LoadTasks()` fails
+**When** doctor runs
+**Then** Providers shows `[✗]` FAIL with the error message
+
+**Given** multiple providers are configured and one fails
+**When** doctor runs
+**Then** Providers shows `[!]` WARN for the category
+**And** individual check results show which provider failed and which succeeded
+
+**Given** the Obsidian provider is configured with a non-existent vault path
+**When** doctor runs
+**Then** Providers shows `[✗]` FAIL with "Obsidian vault path not found: {path}"
+
+## Technical Notes
+
+- Integrate existing `HealthChecker.CheckDatabaseReadWrite()` from `internal/core/health_checker.go`
+- Use `HealthChecker.CheckSyncStatus()` and provider-specific health checks
+- For each configured provider in `config.yaml`, attempt `LoadTasks()` with a short timeout
+- Provider-specific checks: Obsidian vault path, Jira URL reachable, GitHub token valid, etc.
+- Use `context.WithTimeout()` to prevent slow providers from blocking doctor
+
+## Tasks
+
+### Task 1: Integrate existing health checks
+- Wrap `HealthChecker` methods as doctor check functions
+- Map `HealthStatus` to `CheckStatus`
+
+### Task 2: Multi-provider iteration
+- Read configured providers from config
+- Run health check on each, collect results
+- Aggregate category status (worst individual = category status)
+
+### Task 3: Provider-specific checks
+- Textfile: file exists and writable
+- Obsidian: vault path exists
+- Network providers (Jira, GitHub, Todoist): timeout-protected connectivity test
+- Apple Notes/Reminders: macOS availability check
+
+### Task 4: Tests
+- Mock provider that fails/succeeds for unit tests
+- Test multi-provider aggregation logic
+- Test timeout behavior
+- Run `go test -race ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.5.story.md
+++ b/docs/stories/42.5.story.md
@@ -1,0 +1,78 @@
+# Story 42.5: Session & Analytics Checks
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 2, Category 3)
+
+## Story
+
+As a user,
+I want the doctor command to validate my session history and analytics cache,
+So that I can identify corrupt data files that might affect my insights dashboard.
+
+## Background
+
+ThreeDoors stores session metrics in `sessions.jsonl` (append-only JSONL) and caches pattern analysis in `patterns.json`. These files can become corrupt from interrupted writes, disk issues, or bugs. This story adds validation for session data integrity.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor`
+**When** the Session Data category executes
+**Then** `sessions.jsonl` is checked line-by-line for valid JSON
+**And** results show total session count and any corrupt lines
+
+**Given** `sessions.jsonl` has 3 corrupt lines
+**When** doctor runs
+**Then** Session Data shows `[!]` WARN with "3 corrupt lines (lines 42, 87, 103)"
+**And** suggestion: "Run threedoors doctor --fix to remove corrupt lines"
+
+**Given** `patterns.json` is corrupt (invalid JSON)
+**When** doctor runs
+**Then** Session Data shows `[!]` WARN with "Pattern cache corrupt"
+**And** suggestion: "Run threedoors doctor --fix to delete (will regenerate)"
+
+**Given** no sessions have been recorded
+**When** doctor runs
+**Then** Session Data shows `[i]` INFO with "No sessions recorded yet"
+
+**Given** sessions have required fields missing (session_id, timestamps)
+**When** doctor runs
+**Then** Session Data shows `[!]` WARN about incomplete entries
+
+## Technical Notes
+
+- Read `sessions.jsonl` line by line, `json.Unmarshal()` each line
+- Check required fields per `SessionEvent` struct in `internal/core/session_tracker.go`
+- Validate `patterns.json` with `json.Unmarshal()` into expected struct
+- Report line numbers of corrupt entries for `--fix` targeting
+- File paths from `internal/core/config_paths.go`
+
+## Tasks
+
+### Task 1: JSONL line-by-line validation
+- Open `sessions.jsonl`, read line by line
+- Attempt JSON parse, track corrupt line numbers
+- Check required fields on valid entries
+
+### Task 2: Pattern cache validation
+- Check `patterns.json` exists and is valid JSON
+- Validate expected structure fields
+
+### Task 3: Session statistics
+- Count total sessions, report as INFO
+- Report first/last session dates if available
+
+### Task 4: Tests
+- Fixture files with corrupt lines, valid data, empty file
+- Table-driven tests for each scenario
+- Run `go test -race ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.6.story.md
+++ b/docs/stories/42.6.story.md
@@ -1,0 +1,85 @@
+# Story 42.6: Sync & Offline Queue Checks
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 2, Category 5)
+
+## Story
+
+As a user,
+I want the doctor command to validate my sync state and offline queue,
+So that I can identify stuck operations or stale sync data.
+
+## Background
+
+ThreeDoors uses a write-ahead log (WAL) for offline-first sync (`sync-queue.jsonl`), maintains sync state in `sync_state.yaml`, and logs sync operations in `sync.log`. This story adds validation for all sync-related files and detects common issues like stuck entries, excessive backlog, and orphaned temp files from failed atomic writes.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor`
+**When** the Sync category executes
+**Then** `sync_state.yaml` is checked for validity and staleness (>24h)
+**And** `sync-queue.jsonl` is checked for valid entries and stuck operations
+**And** orphaned `.tmp` files in `~/.threedoors/` are detected
+
+**Given** sync state is older than 24 hours
+**When** doctor runs
+**Then** Sync shows `[!]` WARN with "Last sync: 3 days ago"
+**And** suggestion: "Press S in doors view to trigger sync"
+
+**Given** WAL queue has entries with retries ≥ 10
+**When** doctor runs
+**Then** Sync shows `[!]` WARN with "N stuck operations (retries ≥ 10)"
+
+**Given** WAL queue has > 10,000 entries
+**When** doctor runs
+**Then** Sync shows `[!]` WARN with "Excessive backlog: N entries"
+
+**Given** orphaned `.tmp` files exist in `~/.threedoors/`
+**When** doctor runs
+**Then** Sync shows `[!]` WARN with "N orphaned temp files found"
+**And** suggestion: "Run threedoors doctor --fix"
+
+**Given** sync has never run (no sync state file)
+**When** doctor runs
+**Then** Sync shows `[i]` INFO with "No sync history"
+
+## Technical Notes
+
+- Use `internal/core/sync_state.go` for state file reading
+- Use `internal/core/wal_provider.go` for queue validation
+- Temp file detection: glob `~/.threedoors/*.tmp` and check age (>1 hour = orphaned)
+- Sync log: validate `sync.log` JSONL format if present
+- Staleness threshold: 24 hours (configurable in future)
+
+## Tasks
+
+### Task 1: Sync state validation
+- Parse `sync_state.yaml`
+- Check last sync timestamp vs current time
+- Report staleness as WARN
+
+### Task 2: WAL queue validation
+- Read `sync-queue.jsonl` entries
+- Count total, identify stuck (retries ≥ 10)
+- Check queue size threshold
+
+### Task 3: Orphaned temp file detection
+- Glob `~/.threedoors/*.tmp`
+- Filter by age (>1 hour)
+- Report count and file names
+
+### Task 4: Tests
+- Fixture files for various sync states
+- Mock file system for temp file detection
+- Run `go test -race ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.7.story.md
+++ b/docs/stories/42.7.story.md
@@ -1,0 +1,82 @@
+# Story 42.7: Enrichment Database Checks
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 2, Category 6)
+
+## Story
+
+As a user,
+I want the doctor command to verify my enrichment database integrity,
+So that I can detect corruption before it causes data loss or crashes.
+
+## Background
+
+ThreeDoors uses a SQLite enrichment database (`enrichment.db`) for cross-reference tracking and metadata storage. SQLite databases can become corrupt from crashes, disk issues, or concurrent access problems. This story adds integrity validation using SQLite's built-in `PRAGMA integrity_check`.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor`
+**When** the Database category executes
+**Then** `enrichment.db` is checked for existence and accessibility
+**And** schema version is verified as current (version 1)
+**And** `PRAGMA integrity_check` is run
+
+**Given** `enrichment.db` does not exist
+**When** doctor runs
+**Then** Database shows `[!]` WARN with "Enrichment database not found"
+**And** suggestion: "Will be created on first use"
+
+**Given** `enrichment.db` fails integrity check
+**When** doctor runs
+**Then** Database shows `[✗]` FAIL with integrity check error details
+**And** suggestion: "Run: sqlite3 ~/.threedoors/enrichment.db 'PRAGMA integrity_check'"
+
+**Given** schema version is not the expected version
+**When** doctor runs
+**Then** Database shows `[!]` WARN with schema version mismatch
+
+**Given** enrichment database is healthy
+**When** doctor runs
+**Then** Database shows `[✓]` OK with "Enrichment DB: healthy, Schema version: 1"
+
+## Technical Notes
+
+- Use `internal/enrichment/enrichment.go` for DB access patterns
+- Open DB read-only for checks: `sql.Open("sqlite3", path+"?mode=ro")`
+- Run `PRAGMA integrity_check` — returns "ok" on success
+- Check schema version via `PRAGMA user_version` or app-level version table
+- Check for WAL files (`enrichment.db-wal`, `enrichment.db-shm`) — INFO only
+- Short timeout on DB operations to prevent blocking
+
+## Tasks
+
+### Task 1: Database existence and open check
+- Check file exists via `os.Stat()`
+- Attempt read-only open
+- Handle locked database gracefully
+
+### Task 2: Schema version check
+- Query schema version
+- Compare against expected version constant
+
+### Task 3: Integrity check
+- Run `PRAGMA integrity_check`
+- Parse results (multi-line on corruption)
+- Map to FAIL/OK status
+
+### Task 4: Tests
+- Test with missing DB file
+- Test with corrupt DB (create fixture)
+- Test with valid DB
+- Run `go test -race ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.8.story.md
+++ b/docs/stories/42.8.story.md
@@ -1,0 +1,102 @@
+# Story 42.8: Auto-Repair (`--fix` flag)
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 4)
+- Decisions: D-143 (conservative auto-fix)
+
+## Story
+
+As a user,
+I want to run `threedoors doctor --fix` to automatically repair safe, reversible issues,
+So that I can resolve common problems without manual intervention.
+
+## Background
+
+The doctor command identifies issues but by default only reports them. This story adds `--fix` to auto-repair safe, reversible operations. User data (tasks, sessions) is never auto-modified — only derived/transient files are touched. Each fix is reported inline with the check that triggered it.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor --fix`
+**When** orphaned `.tmp` files exist (>1 hour old)
+**Then** they are deleted and the check shows "FIXED: removed N stale .tmp files"
+
+**Given** the user runs `threedoors doctor --fix`
+**When** `patterns.json` is corrupt
+**Then** it is deleted and the check shows "FIXED: deleted patterns.json (will regenerate)"
+
+**Given** the user runs `threedoors doctor --fix`
+**When** `config.yaml` is missing but `~/.threedoors/` exists
+**Then** a sample config is generated and the check shows "FIXED: created sample config.yaml"
+
+**Given** the user runs `threedoors doctor --fix`
+**When** `tasks.txt` exists but `tasks.yaml` does not
+**Then** migration runs and creates `tasks.yaml` + `tasks.txt.bak`
+**And** check shows "FIXED: migrated tasks.txt → tasks.yaml (backup at tasks.txt.bak)"
+
+**Given** the user runs `threedoors doctor --fix`
+**When** `version-check.json` is stale or corrupt
+**Then** it is deleted and the check shows "FIXED: cleared stale version cache"
+
+**Given** the user runs `threedoors doctor --fix`
+**When** `~/.threedoors/` has incorrect permissions
+**Then** permissions are set to 700 and the check shows "FIXED: set directory permissions to 700"
+
+**Given** the user runs `threedoors doctor --fix`
+**When** corrupt task data or enrichment DB issues exist
+**Then** those issues are NOT auto-fixed (report-only with manual instructions)
+
+**Given** `--fix` repairs some issues
+**When** the command completes
+**Then** a summary line shows "Fixed N issues. M issues require manual intervention."
+
+## Technical Notes
+
+- Add `--fix` boolean flag to doctor cobra command
+- Pass fix flag through to `DoctorChecker` — each check function receives `fix bool`
+- Fix functions return a `FixResult` indicating what was done
+- Orphaned temp cleanup: glob `*.tmp`, filter age, `os.Remove()`
+- patterns.json fix: `os.Remove()` — regenerated from sessions.jsonl automatically
+- Config generation: write minimal valid config.yaml
+- Legacy migration: reuse existing migration logic if available
+- NEVER auto-fix: corrupt tasks.yaml, corrupt sessions.jsonl, corrupt enrichment.db, stuck WAL entries, provider auth, duplicate IDs, dangling deps
+
+## Tasks
+
+### Task 1: Add --fix flag to doctor command
+- Register `--fix` boolean flag
+- Pass through to `DoctorChecker.Run(ctx, fix bool)`
+- Check functions receive fix flag
+
+### Task 2: Implement safe fixes
+- Orphaned temp file cleanup (age > 1 hour)
+- Corrupt patterns.json deletion
+- Missing config.yaml generation
+- Stale version cache deletion
+- Directory permission repair
+
+### Task 3: Legacy migration fix
+- Detect `tasks.txt` without `tasks.yaml`
+- Run migration with `.bak` backup
+- Report what was migrated
+
+### Task 4: Fix result reporting
+- "FIXED:" prefix on auto-repaired items
+- Summary line with fix count vs manual count
+- Changed check icon to show fix was applied
+
+### Task 5: Tests
+- Test each fix operation in isolation
+- Verify report-only items are NOT modified when --fix is set
+- Verify files are actually repaired
+- Run `go test -race ./internal/cli/... ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/42.9.story.md
+++ b/docs/stories/42.9.story.md
@@ -1,0 +1,106 @@
+# Story 42.9: Channel-Aware Version Checking
+
+## Status: Not Started
+
+## Epic
+
+Epic 42: ThreeDoors Doctor — Self-Diagnosis Command
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md` (Section 3)
+- Decisions: D-144 (24h cached version check), D-145 (channel-aware: show within channel + cross-channel if higher)
+
+## Story
+
+As a user,
+I want the doctor command to check for updates within my distribution channel,
+So that I know when a newer version is available without switching channels.
+
+## Background
+
+ThreeDoors embeds version and channel via ldflags (`cmd/threedoors/main.go`). This story implements channel-aware version checking using the GitHub Releases API, with 24-hour caching (gh CLI pattern) and opt-out controls. Stable users see only stable updates; alpha users see alpha updates plus newer stable releases if the stable base semver exceeds their alpha base.
+
+## Acceptance Criteria
+
+**Given** the user runs `threedoors doctor`
+**When** the Version category executes
+**Then** current version and channel are displayed
+**And** if a cached check is fresh (<24h), cached results are used
+**And** if cache is stale, a new check is performed
+
+**Given** the user is on stable v1.1.0 and stable v1.3.0 exists
+**When** doctor runs
+**Then** Version shows `[i]` INFO with "Update available: v1.3.0"
+**And** suggestion: "brew upgrade threedoors"
+
+**Given** the user is on alpha v1.2.0-alpha and stable v1.3.0 exists
+**When** doctor runs
+**Then** Version shows `[i]` INFO about both the latest alpha AND the newer stable release
+
+**Given** the user is on alpha v1.2.0-alpha and stable is v1.1.0
+**When** doctor runs
+**Then** Version does NOT suggest the older stable release
+
+**Given** version is "dev"
+**When** doctor runs
+**Then** Version shows `[i]` INFO with "Running dev build" and skips update check
+
+**Given** `THREEDOORS_NO_UPDATE_CHECK=1` is set
+**When** doctor runs
+**Then** Version category is skipped with `[ ]` SKIP
+
+**Given** `CI=true` or `GITHUB_ACTIONS=true` is set
+**When** doctor runs
+**Then** Version check is auto-disabled
+
+**Given** no network is available
+**When** doctor runs
+**Then** cached result is used if fresh; otherwise Version shows `[ ]` SKIP
+
+## Technical Notes
+
+- HTTP GET `https://api.github.com/repos/arcaven/ThreeDoors/releases` — no go-github dependency
+- Filter releases by tag: no pre-release suffix = stable, `-beta` = beta, `-alpha` = alpha
+- Use `Masterminds/semver` or stdlib semver comparison for version ordering
+- Cache file: `~/.threedoors/version-check.json` with `checked_at`, versions per channel
+- Background goroutine NOT needed for doctor (doctor is explicit; blocking is fine)
+- Rate limit: 60 req/hour unauthenticated; 1 req/24h is safe
+- Privacy: only GET to public API, no user data sent
+- Opt-out: `THREEDOORS_NO_UPDATE_CHECK` env var, `update_check: false` in config.yaml
+- CI detection: `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, `BUILDKITE` env vars
+
+## Tasks
+
+### Task 1: Version check cache
+- Define cache struct and JSON file path
+- Read/write cache with 24h TTL
+- `IsFresh()` method
+
+### Task 2: GitHub Releases API client
+- HTTP GET with timeout (5s)
+- Parse release list JSON (minimal struct: tag_name, prerelease)
+- Filter by channel
+- Handle errors gracefully (network, rate limit, API down)
+
+### Task 3: Channel-aware comparison logic
+- Parse current version and channel from embedded ldflags
+- Compare against latest per-channel version
+- Cross-channel logic: alpha sees newer stable if base semver is higher
+
+### Task 4: Opt-out and CI detection
+- Check env vars for opt-out
+- Check config.yaml for `update_check` setting
+- Auto-disable in CI environments
+
+### Task 5: Tests
+- Mock HTTP server for API responses
+- Test cache freshness logic
+- Test channel comparison (stable→stable, alpha→stable, alpha→alpha)
+- Test opt-out and CI detection
+- Test dev build skip
+- Run `go test -race ./internal/core/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

- Formalizes the doctor command research (PR #413) into **Epic 42: ThreeDoors Doctor — Self-Diagnosis Command** with 10 stories
- Creates story files `docs/stories/42.1.story.md` through `42.10.story.md` covering: command skeleton, 6 check categories (environment, task data, providers, sessions, sync, database), auto-repair (`--fix`), channel-aware version checking, and verbose/filter polish
- Updates all three planning docs: `ROADMAP.md`, `docs/prd/epic-list.md`, `docs/prd/epics-and-stories.md`
- Records 5 adopted decisions (D-141 through D-145) and 5 rejected options (X-074 through X-078) on `docs/decisions/BOARD.md`
- Reserves Epic 42 in the Epic Number Registry

## Story Dependency Graph

```
42.1 (skeleton) → 42.2-42.7 (check categories, parallelizable)
42.2-42.7 → 42.8 (--fix needs checks)
42.1 → 42.9 (version check, independent)
42.2-42.9 → 42.10 (polish)
```

## Key Decisions from Research

| ID | Decision |
|----|----------|
| D-141 | `doctor` supersedes `health` (alias kept) |
| D-142 | Flutter-style icon output (`[✓]`/`[!]`/`[✗]`/`[i]`) |
| D-143 | Conservative auto-fix: only safe, reversible ops |
| D-144 | 24h cached version check (gh CLI pattern) |
| D-145 | Channel-aware: show within channel + cross-channel if higher |

## Opportunities (not implemented)

- Background version check on every CLI invocation (not just `doctor`) — deferred per X-075
- Interactive repair wizard — deferred per X-074
- TUI status bar indicator when doctor found issues — noted in research open questions

## Test plan

- [ ] All story files exist and have correct format
- [ ] ROADMAP.md includes Epic 42 in Active Epics section
- [ ] epic-list.md includes Epic 42 with story count
- [ ] epics-and-stories.md includes Epic 42 with all 10 story summaries
- [ ] BOARD.md has decisions D-141-D-145 and rejected X-074-X-078
- [ ] Epic Number Registry updated (42 allocated, 43 next available)
- [ ] No implementation code — planning artifacts only