### PR TITLE
docs: data source setup UX — Epics 43-47 planning (26 stories)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -229,6 +229,69 @@ Transform rectangular card/panel doors into visually convincing doors using side
 
 **Dependency graph:** Stories 42.1 & 42.2 can parallelize. Stories 42.3 & 42.4 can parallelize after 42.1 completes.
 
+### Epic 43: Connection Manager Infrastructure (P1) — 0/6 stories done
+
+Connection lifecycle layer for data source integrations. State machine, credential storage (system keychain), config schema v3 (named connections), CRUD operations, sync event logging, and migration of existing adapters to the new pattern.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 43.1 | Connection State Machine and ConnectionManager Type | Not Started | P1 | None |
+| 43.2 | Keyring Integration with Environment Variable Fallback | Not Started | P1 | None |
+| 43.3 | Config Schema v3 Migration with Connections Support | Not Started | P1 | None |
+| 43.4 | Connection CRUD Operations | Not Started | P1 | 43.1, 43.2, 43.3 |
+| 43.5 | Sync Event Logging Infrastructure | Not Started | P1 | None |
+| 43.6 | Migrate Existing Adapters to ConnectionManager Pattern | Not Started | P1 | 43.1-43.5 |
+
+### Epic 44: Sources TUI (P1) — 0/7 stories done
+
+TUI interfaces for data source management: setup wizard (`:connect`), sources dashboard (`:sources`), source detail view, sync log view, status bar health alerts, disconnection flow, and re-authentication flow. Uses `charmbracelet/huh` for wizard forms.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 44.1 | Setup Wizard with huh Forms | Not Started | P1 | Epic 43 |
+| 44.2 | Sources Dashboard View | Not Started | P1 | Epic 43 |
+| 44.3 | Source Detail View | Not Started | P1 | 44.2 |
+| 44.4 | Sync Log View | Not Started | P1 | 43.5 |
+| 44.5 | Status Bar Integration for Connection Health Alerts | Not Started | P1 | Epic 43 |
+| 44.6 | Disconnection Flow with Task Preservation Options | Not Started | P1 | 44.2 |
+| 44.7 | Re-Authentication Flow | Not Started | P1 | 44.3, Epic 46 |
+
+### Epic 45: Sources CLI (P1) — 0/5 stories done
+
+Non-interactive CLI commands for data source management: `threedoors connect`, `threedoors sources` (list/status/test/manage/log), and JSON output support for scripting and CI/automation.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 45.1 | `threedoors connect` Command (Non-Interactive) | Not Started | P1 | Epic 43 |
+| 45.2 | `threedoors sources` List/Status/Test Commands | Not Started | P1 | Epic 43 |
+| 45.3 | `threedoors sources` Management Commands | Not Started | P1 | Epic 43 |
+| 45.4 | `threedoors sources log` Command | Not Started | P1 | 43.5 |
+| 45.5 | JSON Output Support for All Sources Commands | Not Started | P1 | 45.1-45.4 |
+
+### Epic 46: OAuth Device Code Flow (P2) — 0/4 stories done
+
+Generic OAuth device code flow client for browser-based authentication. Provider-specific integrations for GitHub and Linear. Silent token refresh with explicit re-auth on expiry.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 46.1 | Generic Device Code Flow Client | Not Started | P2 | None |
+| 46.2 | GitHub OAuth Integration | Not Started | P2 | 46.1 |
+| 46.3 | Linear OAuth Integration | Not Started | P2 | 46.1 |
+| 46.4 | Token Refresh Lifecycle | Not Started | P2 | 46.1 |
+
+### Epic 47: Sync Lifecycle & Advanced Features (P2) — 0/4 stories done
+
+Conflict resolution (last-writer-wins with field-level strategy), orphaned task handling, auto-detection of installed tools in setup wizard, and proactive connection health notifications.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 47.1 | Conflict Resolution Strategy with Logging | Not Started | P2 | Epic 43 |
+| 47.2 | Orphaned Task Handling | Not Started | P2 | 47.1 |
+| 47.3 | Auto-Detection of Existing Tools in Setup Wizard | Not Started | P2 | 44.1 |
+| 47.4 | Proactive Connection Health Notifications | Not Started | P2 | 44.5 |
+
+**Epic 43-47 dependency graph:** Epic 43 is the critical path — all other epics depend on it. Epics 44 (TUI) and 45 (CLI) can parallelize after Epic 43. Epic 46 (OAuth) is independent. Epic 47 (Advanced) depends on 43+44.
+
 ### Epic 36: Door Selection Interaction Feedback (P1) — 4/4 stories done — COMPLETE
 
 Make door selection feel responsive and satisfying. Reopened for Story 36.4 (space/enter toggle).

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -166,6 +166,12 @@
 | D-138 | Keep bar for non-door views; door hints replace bar in doors view | 2026-03-09 | Non-door views lack spatial anchors for inline hints; bar remains useful there; doors have natural hint placement (doorknob metaphor) | [Course Correction](../../_bmad-output/planning-artifacts/door-key-indicators-course-correction.md) |
 | D-139 | Rename config to `show_key_hints` with migration from `show_keybinding_bar` | 2026-03-09 | New name better describes unified behavior; auto-migration reads old field as fallback; backward compatible | [Course Correction](../../_bmad-output/planning-artifacts/door-key-indicators-course-correction.md) |
 | D-140 | Remove auto-fade; `h` is purely manual toggle (overrides D-126) | 2026-03-09 | Auto-fade was designed for onboarding scaffolding; `h` toggle is a power-user feature; users control their own experience | [Course Correction](../../_bmad-output/planning-artifacts/door-key-indicators-course-correction.md) |
+| D-147 | Use `99designs/keyring` for credential storage | 2026-03-09 | More backends than `zalando/go-keyring`, encrypted file fallback for headless Linux, built for aws-vault | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| D-148 | OAuth device code flow (not callback server) for OAuth providers | 2026-03-09 | No port conflicts, no firewall issues, works in SSH/containers, proven pattern (gh, gcloud, railway) | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| D-149 | Compiled-in providers (not pluggable) for data sources | 2026-03-09 | Go `plugin` package is Linux-only and fragile; Registry+Factory pattern is clean, simple, testable | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| D-150 | Use `charmbracelet/huh` for setup wizard forms | 2026-03-09 | Native Bubbletea integration, Group-as-page wizard model, dynamic forms via WithHideFunc | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| D-151 | Last-writer-wins with remote-wins for metadata, local-wins for ThreeDoors fields | 2026-03-09 | Simple and predictable; source system authoritative for metadata; ThreeDoors owns its enrichments | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| D-152 | Named connections with ULID IDs for multi-instance provider support | 2026-03-09 | Supports multiple instances of same provider type; user-friendly labels; globally unique IDs | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
 
 ## Rejected
 
@@ -287,6 +293,13 @@
 | X-081 | Wall Context with shade characters (Proposal E, Epic 42) | 2026-03-09 | 4 chars per side too expensive; threshold line achieves grounding at zero width cost; conflicts with some themes | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
 | X-082 | Door Swing perspective animation (Proposal H, Epic 42) | 2026-03-09 | Highest complexity (~200+ LOC), text reflow risk, adds animation latency = friction; SOUL.md prioritizes reducing friction | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
 | X-083 | Light Spill per-cell background colors (Proposal I, Epic 42) | 2026-03-09 | Per-cell background colors require theme-specific tuning; Crack of Light achieves similar effect more simply | [Research](../../_bmad-output/planning-artifacts/doors-more-doorlike-research.md) |
+| X-087 | OAuth callback server for data source auth | 2026-03-09 | Port conflicts, firewall issues, doesn't work in SSH/containers; device code flow is superior | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| X-088 | `zalando/go-keyring` for credential storage | 2026-03-09 | Fewer backends, no encrypted file fallback for headless Linux | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| X-089 | Go plugin architecture for data source providers | 2026-03-09 | Linux-only, fragile, poor debugging, no real ecosystem | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| X-090 | Store credentials in config.yaml | 2026-03-09 | Security risk; credentials should never be in plain text config files | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| X-091 | Apple Notes as task integration target | 2026-03-09 | No task model, fragile AppleScript, macOS-only, extremely poor ROI | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| X-092 | In-app settings editor (like lazygit) for source config | 2026-03-09 | Setup wizard is better UX for initial config; config file editing fine for power users | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
+| X-093 | Webhook receiver for change detection | 2026-03-09 | Adds HTTP server complexity; polling is simpler, works universally; revisit as future optimization | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
 
 ## Epic Number Registry
 
@@ -296,7 +309,12 @@
 |------|---------|-----------|--------|
 | 41 | Charm Ecosystem Adoption & TUI Polish | 2026-03-09 | Proposed (pending PM approval) |
 | 42 | Door-Like Doors — Visual Door Metaphor Enhancement | 2026-03-09 | Stories created |
-| 43 | *(next available)* | — | — |
+| 43 | Connection Manager Infrastructure | 2026-03-09 | Allocated (6 stories) |
+| 44 | Sources TUI | 2026-03-09 | Allocated (7 stories) |
+| 45 | Sources CLI | 2026-03-09 | Allocated (5 stories) |
+| 46 | OAuth Device Code Flow | 2026-03-09 | Allocated (4 stories) |
+| 47 | Sync Lifecycle & Advanced Features | 2026-03-09 | Allocated (4 stories) |
+| 48 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -526,7 +526,75 @@
 - **Research:** See `_bmad-output/planning-artifacts/doors-more-doorlike-research.md` (5-round party mode, 7 agents)
 - **Decisions:** D-141 (adopt 5 proposals), X-080 through X-083 (4 rejected alternatives)
 
-**Epic 43+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 43: Connection Manager Infrastructure** (P1)
+- **Goal:** Build the connection lifecycle layer for data source integrations: state machine, credential storage (system keychain via 99designs/keyring), config schema v3 (named connections with ULID IDs), CRUD operations, sync event logging, and migration of existing 8 adapters to the new pattern
+- **Prerequisites:** Epic 7 (Adapter SDK — complete), Epic 11 (Sync Observability — complete)
+- **Status:** Not Started
+- **Deliverables:**
+  - ConnectionManager type with 7-state machine (Disconnected, Connecting, Connected, Syncing, Error, AuthExpired, Paused)
+  - CredentialStore with keychain + env var + encrypted file fallback chain
+  - Config schema v3 with `connections:` array, auto-migration from v2
+  - Connection CRUD: add, remove, pause, resume, test, force-sync
+  - JSONL sync event logging per connection with rolling retention
+  - All existing adapters wrapped in ConnectionManager pattern
+- **Stories:** 43.1-43.6 (6 stories)
+- **Research:** See `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
+- **Decisions:** D-147 (keyring), D-149 (compiled-in providers), D-152 (named connections with ULIDs)
+
+**Epic 44: Sources TUI** (P1)
+- **Goal:** TUI interfaces for data source management: setup wizard (`:connect` command using charmbracelet/huh), sources dashboard (`:sources`), source detail view with health checks, sync log view, status bar health alerts, disconnection flow with task preservation, and re-authentication flow
+- **Prerequisites:** Epic 43 (Connection Manager Infrastructure)
+- **Status:** Not Started
+- **Deliverables:**
+  - 4-step setup wizard with provider-adaptive forms (API token, OAuth device code, local path)
+  - Sources dashboard with status indicators (connected/paused/error/auth expired)
+  - Source detail view with health checks and sync statistics
+  - Sync log view with scrollable event history
+  - Status bar alerts for connections needing attention
+  - Disconnect and re-auth flows
+- **Stories:** 44.1-44.7 (7 stories)
+- **Research:** See `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
+- **Decisions:** D-150 (charmbracelet/huh for wizard)
+
+**Epic 45: Sources CLI** (P1)
+- **Goal:** Non-interactive CLI commands for data source management: `threedoors connect <provider>` with flags, `threedoors sources` (list/status/test/manage/log), and consistent `--json` output for scripting and CI/automation
+- **Prerequisites:** Epic 43 (Connection Manager Infrastructure), Epic 23 (CLI Interface — complete)
+- **Status:** Not Started
+- **Deliverables:**
+  - `threedoors connect <provider>` with per-provider flag sets
+  - `threedoors sources` list, status, test, pause/resume/sync/disconnect commands
+  - `threedoors sources log` with filtering
+  - JSON output for all commands
+- **Stories:** 45.1-45.5 (5 stories)
+- **Research:** See `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
+
+**Epic 46: OAuth Device Code Flow** (P2)
+- **Goal:** Generic OAuth device code flow client (RFC 8628) for browser-based authentication, with provider-specific integrations for GitHub and Linear, and silent token refresh lifecycle
+- **Prerequisites:** None (consumed by Epics 44/45)
+- **Status:** Not Started
+- **Deliverables:**
+  - Reusable device code flow client (request code, display URL, poll for token)
+  - GitHub OAuth integration (device code + PAT fallback)
+  - Linear OAuth/API key integration
+  - Silent token refresh with explicit re-auth on expiry
+- **Stories:** 46.1-46.4 (4 stories)
+- **Research:** See `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
+- **Decisions:** D-148 (device code flow over callback server)
+
+**Epic 47: Sync Lifecycle & Advanced Features** (P2)
+- **Goal:** Advanced sync features: conflict resolution (last-writer-wins with field-level strategy), orphaned task handling (mark not delete), auto-detection of installed tools in setup wizard, and proactive connection health notifications
+- **Prerequisites:** Epic 43, Epic 44
+- **Status:** Not Started
+- **Deliverables:**
+  - ConflictResolver with remote-wins for metadata, local-wins for ThreeDoors fields
+  - Orphaned task marking and management UI
+  - Installed tool detection (gh CLI, Todoist config, Obsidian vaults)
+  - Predictive warnings (token expiry, rate limits, error streaks)
+- **Stories:** 47.1-47.4 (4 stories)
+- **Research:** See `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
+- **Decisions:** D-151 (conflict resolution strategy)
+
+**Epic 48+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -580,5 +648,10 @@
 | Epic 40: Beautiful Stats Display | 10 | Complete |
 | Epic 41: Charm Ecosystem Adoption | 6 | Not Started |
 | Epic 42: Door-Like Doors | 4 | Not Started |
-| **Total** | **220** | **146 complete, 4 epics in progress, 74 not started** |
+| Epic 43: Connection Manager Infrastructure | 6 | Not Started |
+| Epic 44: Sources TUI | 7 | Not Started |
+| Epic 45: Sources CLI | 5 | Not Started |
+| Epic 46: OAuth Device Code Flow | 4 | Not Started |
+| Epic 47: Sync Lifecycle & Advanced Features | 4 | Not Started |
+| **Total** | **246** | **146 complete, 4 epics in progress, 100 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -4416,6 +4416,331 @@ Highest-scoring proposal (15/15). On selection, replace right border chars with 
 
 1. Door-Opening Transition Animation (perspective shrink on Enter → detail view; ~200+ LOC, separate spike)
 2. Light Spill Enhancement (warm gradient layered on Crack of Light; future polish story)
+
+---
+
+## Epic 43: Connection Manager Infrastructure
+
+**Priority:** P1
+**Status:** Not Started
+**Dependencies:** Epic 7 (Adapter SDK — complete), Epic 11 (Sync Observability — complete)
+
+### Epic Goal
+
+Build the connection lifecycle layer for data source integrations. ThreeDoors has 8 working adapters but no infrastructure for users to set up, monitor, manage, and troubleshoot their data source connections. The ConnectionManager provides state machine lifecycle, secure credential storage, config schema for named multi-instance connections, CRUD operations, sync event logging, and migration of all existing adapters to the new pattern.
+
+### Stories
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 43.1 | Connection State Machine and ConnectionManager Type | Not Started | P1 | None |
+| 43.2 | Keyring Integration with Environment Variable Fallback | Not Started | P1 | None |
+| 43.3 | Config Schema v3 Migration with Connections Support | Not Started | P1 | None |
+| 43.4 | Connection CRUD Operations | Not Started | P1 | 43.1, 43.2, 43.3 |
+| 43.5 | Sync Event Logging Infrastructure | Not Started | P1 | None |
+| 43.6 | Migrate Existing Adapters to ConnectionManager Pattern | Not Started | P1 | 43.1-43.5 |
+
+**Dependency graph:**
+```
+43.1 (State Machine) ──┐
+43.2 (Keyring)      ───┼──→ 43.4 (CRUD) ──┐
+43.3 (Config v3)    ───┘                    ├──→ 43.6 (Adapter Migration)
+43.5 (Sync Log)     ───────────────────────┘
+```
+
+Stories 43.1, 43.2, 43.3, and 43.5 can parallelize. Story 43.4 depends on 43.1-43.3. Story 43.6 depends on all.
+
+### Story Details
+
+#### Story 43.1: Connection State Machine and ConnectionManager Type
+
+ConnectionState enum with 7 states (Disconnected, Connecting, Connected, Syncing, Error, AuthExpired, Paused) and validated transition table. Connection struct with ULID ID, provider name, label, state, sync metadata. ConnectionManager with thread-safe CRUD.
+
+**AC:** State transitions validated, invalid transitions return error, concurrent access safe with RWMutex, List() returns all connections with current state.
+
+#### Story 43.2: Keyring Integration with Environment Variable Fallback
+
+CredentialStore interface with priority chain: env vars → system keychain → encrypted file fallback. Uses `99designs/keyring`. Credentials never in config.yaml. Env var patterns: `THREEDOORS_<PROVIDER>_TOKEN`, `THREEDOORS_CONN_<LABEL_SLUG>_TOKEN`. Respects `GH_TOKEN`/`GITHUB_TOKEN`.
+
+**AC:** Credentials stored in keychain, env vars override keychain, connection-specific env vars override provider-level, headless fallback works, credentials masked in display.
+
+#### Story 43.3: Config Schema v3 Migration with Connections Support
+
+Config schema v3 adds `connections:` array. Auto-migration from v2 single-provider format. Credentials excluded from config.yaml. Atomic save pattern.
+
+**AC:** v2 configs auto-migrate to v3, multiple connections with same provider supported, no credentials in saved YAML, backward compatible.
+
+#### Story 43.4: Connection CRUD Operations
+
+Complete lifecycle operations: Add (with credential storage + config persistence), Remove (with keepTasks option + credential cleanup), Pause/Resume, TestConnection (health check), ForceSync.
+
+**AC:** All CRUD operations validated, credentials cleaned up on remove, health check returns API/token/rate-limit status.
+
+#### Story 43.5: Sync Event Logging Infrastructure
+
+JSONL sync log per connection. SyncEvent types: sync_complete, sync_error, conflict. Rolling retention of last 1000 events. Queryable by connection, time, severity.
+
+**AC:** Events logged per sync cycle, errors and conflicts captured, reader supports filtering and limit, rolling retention works.
+
+#### Story 43.6: Migrate Existing Adapters to ConnectionManager Pattern
+
+Bridge all 8 existing adapters to ConnectionManager. Wrap sync cycles to emit SyncEvents. Integrate pause/resume with sync scheduler. Preserve backward compatibility for legacy single-provider configs.
+
+**AC:** All adapters work through ConnectionManager, legacy configs work, health checks mapped, pause/resume stops/starts sync.
+
+### Design Decisions
+
+- D-147: Use `99designs/keyring` for credential storage (over `zalando/go-keyring`)
+- D-149: Compiled-in providers (not pluggable) — Registry+Factory pattern
+- D-152: Named connections with ULID IDs for multi-instance support
+
+### Research
+
+- Full lifecycle research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
+
+---
+
+## Epic 44: Sources TUI
+
+**Priority:** P1
+**Status:** Not Started
+**Dependencies:** Epic 43 (Connection Manager Infrastructure)
+
+### Epic Goal
+
+TUI interfaces for data source management: a 4-step setup wizard (`:connect`), sources dashboard (`:sources`), source detail view with health checks, sync log view, status bar health alerts, disconnection flow with task preservation, and re-authentication flow.
+
+### Stories
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 44.1 | Setup Wizard with huh Forms | Not Started | P1 | Epic 43 |
+| 44.2 | Sources Dashboard View | Not Started | P1 | Epic 43 |
+| 44.3 | Source Detail View | Not Started | P1 | 44.2 |
+| 44.4 | Sync Log View | Not Started | P1 | 43.5 |
+| 44.5 | Status Bar Integration for Connection Health Alerts | Not Started | P1 | Epic 43 |
+| 44.6 | Disconnection Flow with Task Preservation Options | Not Started | P1 | 44.2 |
+| 44.7 | Re-Authentication Flow | Not Started | P1 | 44.3, Epic 46 |
+
+### Story Details
+
+#### Story 44.1: Setup Wizard with huh Forms
+
+4-step wizard using `charmbracelet/huh`: (1) Provider selection, (2) Provider-specific config (API token, OAuth, or local path), (3) Sync configuration (mode, filters, poll interval), (4) Test connection and confirm. `:connect` command triggers wizard.
+
+**AC:** All 4 steps render, provider-adaptive forms work, Esc cancels without changes, connection test runs before confirmation.
+
+#### Story 44.2: Sources Dashboard View
+
+`:sources` command opens list view with status indicators (●/○/⚠/✗), labels, sync times, task counts. Keybindings: a (add), d (disconnect), p (pause/resume), r (re-sync), t (test), Enter (detail), Esc (back).
+
+**AC:** All connections listed with status indicators, keybindings dispatch correct actions, empty state handled.
+
+#### Story 44.3: Source Detail View
+
+Full metadata display: status, sync time, task counts, provider settings, health checks (✓/✗ for API, token, rate limit, cache). Actions: edit, re-auth, pause, disconnect, view log.
+
+**AC:** All metadata displayed, health checks shown, keybindings work.
+
+#### Story 44.4: Sync Log View
+
+Scrollable sync event history per connection using bubbles/viewport. Events show timestamp, status indicator (✓/⚠/✗), description.
+
+**AC:** Events displayed in reverse chronological order, viewport scrolls, empty state shows message.
+
+#### Story 44.5: Status Bar Integration for Connection Health Alerts
+
+Non-intrusive alert in doors view when connections need attention (auth expired, persistent errors). Only most critical alert shown with `:sources` hint.
+
+**AC:** No alert when healthy, yellow warning for auth expired, error count for multiple issues.
+
+#### Story 44.6: Disconnection Flow with Task Preservation Options
+
+Confirmation dialog: "Keep tasks locally" vs "Remove synced tasks". Uses huh forms. Cleans up credentials.
+
+**AC:** Confirmation required, keep/remove options work, Esc cancels, credentials deleted.
+
+#### Story 44.7: Re-Authentication Flow
+
+Re-auth for expired tokens without disconnect/reconnect. API token: masked input for new token. OAuth: triggers device code flow (Epic 46). On success, connection transitions back to Connected.
+
+**AC:** API token re-entry works, connection test verifies new token, failure keeps AuthExpired state.
+
+### Design Decisions
+
+- D-150: Use `charmbracelet/huh` for setup wizard forms
+
+### Research
+
+- Full UX research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
+
+---
+
+## Epic 45: Sources CLI
+
+**Priority:** P1
+**Status:** Not Started
+**Dependencies:** Epic 43 (Connection Manager Infrastructure), Epic 23 (CLI Interface — complete)
+
+### Epic Goal
+
+Non-interactive CLI commands for data source management. Supports both human power users (table output) and automation (JSON output via `--json` flag). Consistent with existing CLI patterns from Epic 23.
+
+### Stories
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 45.1 | `threedoors connect` Command (Non-Interactive) | Not Started | P1 | Epic 43 |
+| 45.2 | `threedoors sources` List/Status/Test Commands | Not Started | P1 | Epic 43 |
+| 45.3 | `threedoors sources` Management Commands | Not Started | P1 | Epic 43 |
+| 45.4 | `threedoors sources log` Command | Not Started | P1 | 43.5 |
+| 45.5 | JSON Output Support for All Sources Commands | Not Started | P1 | 45.1-45.4 |
+
+### Story Details
+
+#### Story 45.1: `threedoors connect` Command (Non-Interactive)
+
+`threedoors connect <provider>` with flags: `--label`, `--token`, provider-specific flags (`--repos`, `--server`, `--lists`, `--path`). No flags → launches interactive wizard.
+
+**AC:** Each provider connectable via flags, connection test runs, error for missing flags, no-flag mode launches wizard.
+
+#### Story 45.2: `threedoors sources` List/Status/Test Commands
+
+`sources` (table list), `sources status <name>` (detailed), `sources test <name>` (health check with ✓/✗). All support `--json`.
+
+**AC:** Table output formatted, detailed status includes health checks, test exit code reflects health, JSON output valid.
+
+#### Story 45.3: `threedoors sources` Management Commands
+
+`sources pause/resume/sync/reauth/edit/disconnect <name>`. Disconnect has `--keep-tasks` flag (interactive prompt without it).
+
+**AC:** Each command validates state, disconnect prompts interactively without flag.
+
+#### Story 45.4: `threedoors sources log` Command
+
+`sources log <name>` with `--last N` and `--errors` flags. Shows recent sync events.
+
+**AC:** Events displayed with timestamps, `--last` limits count, `--errors` filters, JSON output works.
+
+#### Story 45.5: JSON Output Support for All Sources Commands
+
+Consistent JSON serialization across all sources subcommands. Error envelope: `{"error":"message"}`.
+
+**AC:** All commands produce valid JSON with `--json`, warnings to stderr, error envelope consistent.
+
+### Research
+
+- CLI design: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 4)
+
+---
+
+## Epic 46: OAuth Device Code Flow
+
+**Priority:** P2
+**Status:** Not Started
+**Dependencies:** None (consumed by Epics 44/45 for OAuth-supporting providers)
+
+### Epic Goal
+
+Generic, reusable OAuth device code flow client (RFC 8628) for browser-based authentication. Provider-specific integrations for GitHub and Linear. Silent token refresh with explicit re-auth on expiry.
+
+### Stories
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 46.1 | Generic Device Code Flow Client | Not Started | P2 | None |
+| 46.2 | GitHub OAuth Integration | Not Started | P2 | 46.1 |
+| 46.3 | Linear OAuth Integration | Not Started | P2 | 46.1 |
+| 46.4 | Token Refresh Lifecycle | Not Started | P2 | 46.1 |
+
+### Story Details
+
+#### Story 46.1: Generic Device Code Flow Client
+
+Provider-agnostic device code flow: request device code, display user code + URL, open browser, poll for token with backoff, exchange for access/refresh tokens. Uses `context.Context` for cancellation.
+
+**AC:** Successful flow returns tokens, timeout handled, slow_down backoff works, cancellation stops polling.
+
+#### Story 46.2: GitHub OAuth Integration
+
+Wire device code client to GitHub endpoints. Scope: `repo`. Fallback: `GH_TOKEN`/`GITHUB_TOKEN` env vars, PAT entry.
+
+**AC:** Device code flow works with GitHub, env var fallback offered, PAT fallback for Enterprise.
+
+#### Story 46.3: Linear OAuth Integration
+
+API key as primary auth (simpler). OAuth 2.0 authorization code as secondary if available. Validates via Linear viewer endpoint.
+
+**AC:** API key auth works, connection test verifies via viewer endpoint.
+
+#### Story 46.4: Token Refresh Lifecycle
+
+Pre-emptive refresh when token within 5 min of expiry. Refresh failure → AuthExpired state. 401 detection for API key connections.
+
+**AC:** Silent refresh before expiry, AuthExpired on refresh failure, 401 triggers AuthExpired, events logged.
+
+### Design Decisions
+
+- D-148: OAuth device code flow (not callback server) — no port conflicts, works in SSH/containers
+
+### Research
+
+- OAuth patterns: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.5)
+
+---
+
+## Epic 47: Sync Lifecycle & Advanced Features
+
+**Priority:** P2
+**Status:** Not Started
+**Dependencies:** Epic 43 (Connection Manager Infrastructure), Epic 44 (Sources TUI)
+
+### Epic Goal
+
+Advanced sync features: field-level conflict resolution with logging, orphaned task handling (mark not auto-delete), auto-detection of installed tools in setup wizard, and proactive connection health notifications.
+
+### Stories
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 47.1 | Conflict Resolution Strategy with Logging | Not Started | P2 | Epic 43 |
+| 47.2 | Orphaned Task Handling | Not Started | P2 | 47.1 |
+| 47.3 | Auto-Detection of Existing Tools in Setup Wizard | Not Started | P2 | 44.1 |
+| 47.4 | Proactive Connection Health Notifications | Not Started | P2 | 44.5 |
+
+### Story Details
+
+#### Story 47.1: Conflict Resolution Strategy with Logging
+
+Last-writer-wins with field-level strategy: remote-wins for metadata (status, priority), local-wins for ThreeDoors fields (effort category, door assignment). All conflicts logged. Never auto-delete.
+
+**AC:** Metadata conflicts resolved with remote-wins, ThreeDoors fields local-wins, conflicts logged with both values, remote deletions mark tasks as orphaned.
+
+#### Story 47.2: Orphaned Task Handling
+
+Tasks deleted remotely are flagged as orphaned (not auto-deleted). Excluded from door selection. `:orphaned` command lets users keep (convert to local) or delete.
+
+**AC:** Orphaned tasks flagged, excluded from doors, keep/delete actions work.
+
+#### Story 47.3: Auto-Detection of Existing Tools in Setup Wizard
+
+Detect `gh` CLI, `TODOIST_API_TOKEN`, `.obsidian/` directories, Jira configs. Detected tools appear at top of provider list with badges and pre-filled settings.
+
+**AC:** Detected tools shown at top with badges, pre-fill works, no detections shows default order.
+
+#### Story 47.4: Proactive Connection Health Notifications
+
+Predictive warnings: token expiring within 7 days, rate limit >80%, 3+ consecutive sync errors. Non-intrusive status bar alerts.
+
+**AC:** Token expiry warning, rate limit warning, error streak warning, no warnings when healthy.
+
+### Design Decisions
+
+- D-151: Last-writer-wins conflict resolution with field-level strategy
+
+### Research
+
+- Sync patterns: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.3)
 3. Nested Frame for Wide Terminals (frame-within-frame when width > 30; width-adaptive)
 4. Wall Context for Wide Terminals (shade characters flanking doors)
 

--- a/docs/stories/43.1.story.md
+++ b/docs/stories/43.1.story.md
@@ -1,0 +1,76 @@
+# Story 43.1: Connection State Machine and ConnectionManager Type
+
+## Status: Not Started
+
+## Epic
+
+Epic 43: Connection Manager Infrastructure
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.1)
+- Decision: D-152 (Named connections with ULID IDs)
+
+## Story
+
+As a developer,
+I want a ConnectionManager type with a well-defined state machine for data source connections,
+So that each provider instance has predictable lifecycle states (disconnected, connecting, connected, syncing, error, auth expired, paused) with validated transitions.
+
+## Background
+
+ThreeDoors has 8 working adapters but no connection lifecycle layer. The existing Registry/Factory pattern creates providers but doesn't track their runtime state. The ConnectionManager will own the state machine, enforce valid transitions, and emit state change events. Connection IDs use ULIDs for uniqueness.
+
+States: Disconnected → Connecting → Connected ⇄ Syncing, Connected → Error, Connected → AuthExpired, Connected ⇄ Paused. Error/AuthExpired can transition back to Connecting on retry/reauth.
+
+## Acceptance Criteria
+
+**Given** a new Connection is created
+**When** ConnectionManager.Add() is called with provider name, label, and settings
+**Then** a Connection struct is created with a ULID ID, state Disconnected, and the provided metadata
+**And** the connection is stored in the manager's map
+
+**Given** a connection in state Disconnected
+**When** a Connect action is triggered
+**Then** the state transitions to Connecting
+**And** a state change event is emitted
+
+**Given** a connection in state Connected
+**When** a sync cycle begins
+**Then** the state transitions to Syncing
+**And** transitions back to Connected when sync completes
+**And** transitions to Error if sync fails
+
+**Given** a connection in any state
+**When** an invalid transition is attempted (e.g., Disconnected → Syncing)
+**Then** an error is returned describing the invalid transition
+**And** the state remains unchanged
+
+**Given** a connection in state Error or AuthExpired
+**When** the error/auth issue is resolved
+**Then** the connection can transition back to Connecting
+
+**Given** multiple connections exist
+**When** ConnectionManager.List() is called
+**Then** all connections are returned with current state, last sync time, and task count
+
+## Technical Notes
+
+- New package: `internal/tasks/connection/`
+- `ConnectionState` as `int` enum with String() method
+- `Connection` struct: ID, ProviderName, Label, State, LastSync, LastError, SyncMode, PollInterval, Settings map, TaskCount
+- `ConnectionManager` struct with `sync.RWMutex` for concurrent access
+- State transition table as map[ConnectionState][]ConnectionState for validation
+- Use `oklog/ulid` or similar for ULID generation
+- Emit events via callback or channel for UI reactivity
+
+## Tasks
+
+### Task 1: Define ConnectionState enum and transition table
+### Task 2: Define Connection struct with NewConnection() factory
+### Task 3: Implement ConnectionManager (Add, Remove, Get, List, state transitions)
+### Task 4: Tests — valid/invalid transitions, CRUD, concurrent access with -race
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/43.2.story.md
+++ b/docs/stories/43.2.story.md
@@ -1,0 +1,62 @@
+# Story 43.2: Keyring Integration with Environment Variable Fallback
+
+## Status: Not Started
+
+## Epic
+
+Epic 43: Connection Manager Infrastructure
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.2, Section 1.8)
+- Decision: D-147 (Use 99designs/keyring for credential storage)
+
+## Story
+
+As a user,
+I want my data source credentials stored securely in the system keychain with environment variable overrides for CI/automation,
+So that my API tokens and OAuth secrets are never stored in plain text config files.
+
+## Background
+
+Credentials follow a priority chain: env var → system keychain → encrypted file fallback. Credentials are stored under service `threedoors`, key `connection:<id>:token`. Environment variables follow the pattern `THREEDOORS_<PROVIDER>_TOKEN` and `THREEDOORS_CONN_<LABEL_SLUG>_TOKEN`. GitHub connections also respect `GH_TOKEN`/`GITHUB_TOKEN`.
+
+## Acceptance Criteria
+
+**Given** a connection is configured
+**When** credentials are stored
+**Then** they are saved to the system keychain and never written to config.yaml
+
+**Given** an environment variable `THREEDOORS_TODOIST_TOKEN` is set
+**When** the Todoist connection retrieves credentials
+**Then** the environment variable value is used instead of the keychain value
+
+**Given** a connection-specific env var `THREEDOORS_CONN_WORK_JIRA_TOKEN` is set
+**When** the "Work Jira" connection retrieves credentials
+**Then** the connection-specific env var takes priority over the provider-level env var
+
+**Given** the system has no keychain available (headless Linux)
+**When** credentials are stored
+**Then** the encrypted file fallback is used with a warning about reduced security
+
+**Given** credentials are displayed in any UI or log
+**When** rendering credential values
+**Then** they are masked with `••••` and never shown in plain text
+
+## Technical Notes
+
+- Dependency: `99designs/keyring`
+- CredentialStore interface: Get, Set, Delete
+- ChainCredentialStore: env → keyring → encrypted file fallback
+- Label slugification: "Work Jira" → "WORK_JIRA"
+
+## Tasks
+
+### Task 1: Define CredentialStore interface and EnvCredentialStore
+### Task 2: Implement KeyringCredentialStore wrapping 99designs/keyring
+### Task 3: Implement ChainCredentialStore with priority chain
+### Task 4: Tests — env var priority, label slugification, masking
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/43.3.story.md
+++ b/docs/stories/43.3.story.md
@@ -1,0 +1,57 @@
+# Story 43.3: Config Schema v3 Migration with Connections Support
+
+## Status: Not Started
+
+## Epic
+
+Epic 43: Connection Manager Infrastructure
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 4.4)
+- Decision: D-014 (Auto-migrate schema on load)
+
+## Story
+
+As a user,
+I want my config.yaml to support named connections (multiple instances of the same provider type) while preserving backward compatibility,
+So that I can connect to multiple Jira instances, multiple Todoist accounts, etc.
+
+## Background
+
+Schema v3 introduces a `connections:` array. Legacy single-provider configs are auto-migrated. Credentials are NOT stored in config.yaml (see Story 43.2).
+
+## Acceptance Criteria
+
+**Given** a config.yaml with schema_version 2
+**When** loaded
+**Then** it is auto-migrated to schema_version 3 with a connection entry from the legacy provider field
+
+**Given** a config.yaml with schema_version 3
+**When** loaded
+**Then** all connections in connections[] are parsed into Connection structs
+
+**Given** two connections with the same provider type
+**When** config is loaded
+**Then** both are available with distinct IDs and labels
+
+**Given** no credential fields
+**When** config is saved
+**Then** no credential data appears in the saved YAML
+
+## Technical Notes
+
+- ConnectionConfig: ID, Provider, Label, Settings map[string]string
+- Atomic write pattern for config saves
+- Preserve all existing config fields
+
+## Tasks
+
+### Task 1: Define ConnectionConfig type, add Connections field to config
+### Task 2: Implement v2→v3 migration logic
+### Task 3: Connection CRUD methods on config
+### Task 4: Tests — migration, round-trip, multi-connection, backward compat
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/43.4.story.md
+++ b/docs/stories/43.4.story.md
@@ -1,0 +1,58 @@
+# Story 43.4: Connection CRUD Operations
+
+## Status: Not Started
+
+## Epic
+
+Epic 43: Connection Manager Infrastructure
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.1)
+
+## Story
+
+As a user,
+I want to add, remove, pause, resume, test, and force-sync my data source connections,
+So that I can manage my integrations throughout their lifecycle.
+
+## Background
+
+Wires up ConnectionManager (43.1), CredentialStore (43.2), and Config persistence (43.3) into complete CRUD operations. TestConnection performs lightweight health checks (API reachable, token valid, rate limit OK).
+
+## Acceptance Criteria
+
+**Given** valid provider name, label, and settings
+**When** Add() is called
+**Then** connection is created, credentials stored, config persisted
+
+**Given** Remove() with keepTasks=true
+**Then** connection removed, credentials deleted, tasks retained locally
+
+**Given** Pause() on a connected source
+**Then** state transitions to Paused, sync polling stops
+
+**Given** Resume() on a paused source
+**Then** state transitions to Connected, sync resumes
+
+**Given** TestConnection()
+**Then** HealthCheckResult returned with API/token/rate-limit status
+
+**Given** ForceSync()
+**Then** immediate sync cycle triggered outside normal interval
+
+## Technical Notes
+
+- HealthCheckResult struct: APIReachable, TokenValid, RateLimitOK, TaskCount, Details
+- Extends Stories 43.1, 43.2, 43.3
+
+## Tasks
+
+### Task 1: Implement Add with credential storage and config persistence
+### Task 2: Implement Remove with keepTasks and credential cleanup
+### Task 3: Implement Pause/Resume, TestConnection, ForceSync
+### Task 4: Tests for all CRUD operations
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/43.5.story.md
+++ b/docs/stories/43.5.story.md
@@ -1,0 +1,53 @@
+# Story 43.5: Sync Event Logging Infrastructure
+
+## Status: Not Started
+
+## Epic
+
+Epic 43: Connection Manager Infrastructure
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.4)
+
+## Story
+
+As a user,
+I want sync events logged per connection (successes, errors, conflicts, state changes),
+So that I can review what happened during sync and diagnose issues.
+
+## Background
+
+JSONL-formatted sync log per connection. Rolling retention of last 1000 events. Supports filtering by connection ID, time range, and severity.
+
+## Acceptance Criteria
+
+**Given** a successful sync
+**Then** SyncEvent with type "sync_complete" logged with task counts
+
+**Given** a sync failure
+**Then** SyncEvent with type "sync_error" logged with error message
+
+**Given** a conflict
+**Then** SyncEvent with type "conflict" logged with resolution details
+
+**Given** SyncLog() called with limit
+**Then** most recent N events returned in reverse chronological order
+
+## Technical Notes
+
+- JSONL file per connection: `~/.threedoors/sync-logs/<connection-id>.jsonl`
+- SyncEvent: Timestamp, ConnectionID, Type, task counts, error, conflict details
+- Rolling retention: truncate to last 1000 on write
+
+## Tasks
+
+### Task 1: Define SyncEvent struct and event types
+### Task 2: Implement JSONL writer with atomic appends
+### Task 3: Implement reader with filtering and limit
+### Task 4: Implement rolling retention
+### Task 5: Tests
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/43.6.story.md
+++ b/docs/stories/43.6.story.md
@@ -1,0 +1,57 @@
+# Story 43.6: Migrate Existing Adapters to ConnectionManager Pattern
+
+## Status: Not Started
+
+## Epic
+
+Epic 43: Connection Manager Infrastructure
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.4)
+- Decision: D-149 (Compiled-in providers)
+
+## Story
+
+As a developer,
+I want existing adapters (textfile, applenotes, jira, github, obsidian, reminders, todoist) to work through the ConnectionManager,
+So that all providers benefit from lifecycle management, health monitoring, and sync logging.
+
+## Background
+
+Each adapter factory is wrapped to produce connections that ConnectionManager tracks. The existing Registry/Factory pattern remains. Connections are created from config.yaml's connections[] array. Legacy single-provider configs work via auto-migration (Story 43.3).
+
+## Acceptance Criteria
+
+**Given** config.yaml with connections[] entries
+**When** application starts
+**Then** each connection creates a provider via existing Factory and wraps it in a Connection
+
+**Given** legacy single-provider config after migration
+**Then** provider works exactly as before and appears in `:sources` view
+
+**Given** any adapter
+**When** TestConnection() called
+**Then** adapter's HealthCheck is mapped to HealthCheckResult format
+
+**Given** a paused connection
+**Then** sync scheduler skips that provider's sync cycle
+
+## Technical Notes
+
+- This is the largest story in Epic 43
+- Bridge existing providers to ConnectionManager
+- Wrap sync cycles to emit SyncEvents (Story 43.5)
+- Preserve backward compatibility
+
+## Tasks
+
+### Task 1: Create provider-to-connection bridge wrapper
+### Task 2: Update application startup to use ConnectionManager
+### Task 3: Integrate with sync scheduler (pause/resume)
+### Task 4: Map existing health checks to HealthCheckResult
+### Task 5: Integration tests with textfile provider, backward compat test
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/44.1.story.md
+++ b/docs/stories/44.1.story.md
@@ -1,0 +1,83 @@
+# Story 44.1: Setup Wizard with huh Forms
+
+## Status: Not Started
+
+## Epic
+
+Epic 44: Sources TUI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.1, Section 1.7)
+- Decision: Use `charmbracelet/huh` for setup wizard (Groups-as-pages pattern)
+
+## Story
+
+As a user,
+I want an interactive setup wizard (`:connect` command) that guides me through connecting a new data source step by step,
+So that I can configure integrations without editing config files or reading documentation.
+
+## Background
+
+The wizard uses `charmbracelet/huh` with its Groups-as-pages pattern for a 4-step flow: (1) Provider selection from registry, (2) Provider-specific configuration (API token entry, OAuth device code, or local path selection), (3) Sync configuration (mode, projects/filters, poll interval), (4) Test connection and confirm. Each provider declares its own form fields via a FormSpec interface. The wizard adapts dynamically based on provider type (API token flow vs OAuth vs local).
+
+## Acceptance Criteria
+
+**Given** the user types `:connect` in the TUI
+**When** the wizard opens
+**Then** Step 1 shows a Select list of all registered providers from the Registry
+**And** each provider shows its name and a brief description
+
+**Given** the user selects a provider requiring an API token (e.g., Todoist)
+**When** Step 2 renders
+**Then** it shows a label input field and a masked password input for the API token
+**And** a help text shows where to find the token (provider-specific)
+
+**Given** the user selects a provider requiring OAuth (e.g., GitHub)
+**When** Step 2 renders
+**Then** it shows the device code flow UI (Story 46.1 dependency, or placeholder)
+**And** a label input field
+
+**Given** the user selects a local provider (e.g., textfile)
+**When** Step 2 renders
+**Then** it shows a label input and a file path input
+**And** validates the path exists
+
+**Given** Step 2 is complete
+**When** Step 3 renders
+**Then** it shows sync mode selection (read-only vs bidirectional)
+**And** provider-specific filter options (projects, lists, repos, JQL)
+**And** poll interval selection
+
+**Given** Step 3 is complete
+**When** Step 4 renders
+**Then** a connection test runs automatically
+**And** results show API reachability, token validity, and task count
+**And** a "Connect" button finalizes the setup
+
+**Given** the user presses Esc at any step
+**When** the wizard is cancelled
+**Then** no connection is created and no credentials are stored
+
+## Technical Notes
+
+- New file: `internal/tui/connect_wizard.go`
+- Dependency: `charmbracelet/huh` (go module)
+- FormSpec interface: each provider exports form field definitions
+- huh Form with 4 Groups (one per step)
+- Use `WithHideFunc()` for conditional step content based on provider type
+- Embed huh form in Bubbletea via `tea.Model` interface
+- Wire `:connect` command to open wizard (extends existing command mode from Epic 39)
+
+## Tasks
+
+### Task 1: Add `charmbracelet/huh` dependency
+### Task 2: Define FormSpec interface for provider-specific form fields
+### Task 3: Implement Step 1 (provider select) and Step 2 (provider config)
+### Task 4: Implement Step 3 (sync config) and Step 4 (test + confirm)
+### Task 5: Wire `:connect` command to wizard
+### Task 6: Tests — wizard navigation, cancel behavior, form validation
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/44.2.story.md
+++ b/docs/stories/44.2.story.md
@@ -1,0 +1,72 @@
+# Story 44.2: Sources Dashboard View
+
+## Status: Not Started
+
+## Epic
+
+Epic 44: Sources TUI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.2)
+
+## Story
+
+As a user,
+I want a `:sources` dashboard showing all connected data sources with their sync status, task counts, and health indicators,
+So that I can monitor my integrations at a glance and take action on any that need attention.
+
+## Background
+
+The Sources dashboard is a new TUI view accessible via `:sources` command. It shows a list of all connections with status indicators (green=connected, gray=paused, yellow=needs attention, red=disconnected), last sync time, and task count. Keybindings allow adding, disconnecting, pausing/resuming, re-syncing, testing, and viewing details. The view follows existing patterns from the insights dashboard (Lipgloss panels, responsive layout).
+
+## Acceptance Criteria
+
+**Given** the user types `:sources`
+**When** the dashboard renders
+**Then** all connections are listed with: status indicator, label, sync status text, and task count
+**And** the currently selected connection is highlighted
+
+**Given** a connection is syncing normally
+**When** the dashboard renders
+**Then** it shows `●` (green) with "Synced Xm ago" and task count
+
+**Given** a connection is paused
+**When** the dashboard renders
+**Then** it shows `○` (gray) with "Paused" and cached task count
+
+**Given** a connection has an expired auth token
+**When** the dashboard renders
+**Then** it shows `⚠` (yellow) with "Auth expired" and 0 tasks
+
+**Given** the dashboard is visible
+**When** the user presses keybindings
+**Then** `a` opens the connect wizard (Story 44.1)
+**And** `d` triggers disconnect flow (Story 44.6)
+**And** `p` toggles pause/resume for selected connection
+**And** `r` triggers re-sync for selected connection
+**And** `t` triggers test for selected connection
+**And** `Enter` opens detail view (Story 44.3)
+**And** `Esc` returns to previous view
+
+## Technical Notes
+
+- New file: `internal/tui/sources_view.go`
+- New ViewMode: `ViewSources` in main model
+- Register keybindings in keybinding registry (Epic 39)
+- Status indicators via Lipgloss colored text
+- Use `lipgloss.Table()` or manual column alignment for the list
+- Receives ConnectionManager updates via tea.Msg for live status changes
+
+## Tasks
+
+### Task 1: Define ViewSources mode and sources_view.go scaffold
+### Task 2: Implement list rendering with status indicators and Lipgloss styling
+### Task 3: Implement keybinding handlers (a, d, p, r, t, Enter, Esc)
+### Task 4: Wire `:sources` command to open dashboard
+### Task 5: Register keybindings in keybinding registry
+### Task 6: Tests — rendering at various widths, keybinding dispatch, empty state
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/44.3.story.md
+++ b/docs/stories/44.3.story.md
@@ -1,0 +1,60 @@
+# Story 44.3: Source Detail View
+
+## Status: Not Started
+
+## Epic
+
+Epic 44: Sources TUI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.2, Detail View)
+
+## Story
+
+As a user,
+I want to view detailed information about a specific data source connection including health checks, settings, and sync statistics,
+So that I can understand the state of each integration and diagnose issues.
+
+## Background
+
+Pressing Enter on a connection in the Sources dashboard (Story 44.2) opens a detail view showing: status, last sync time, task counts (active + completed), provider-specific settings (projects, JQL, repos), sync mode, poll rate, and a health checks panel (API reachable, token valid, rate limit, cache freshness). Actions: edit settings, re-authenticate, pause sync, disconnect, view sync log.
+
+## Acceptance Criteria
+
+**Given** a connection is selected in the sources dashboard
+**When** Enter is pressed
+**Then** the detail view shows the connection's full metadata in a Lipgloss panel layout
+
+**Given** the detail view is open
+**When** health checks are displayed
+**Then** each check shows ✓ or ✗ with a description (API reachable, Token valid, Rate limit OK, Cache fresh)
+
+**Given** the detail view is open
+**When** keybindings are pressed
+**Then** `e` opens edit settings wizard
+**And** `r` triggers re-authentication flow (Story 44.7)
+**And** `p` toggles pause/resume
+**And** `d` triggers disconnect flow (Story 44.6)
+**And** `l` opens sync log view (Story 44.4)
+**And** `Esc` returns to sources list
+
+## Technical Notes
+
+- New file: `internal/tui/source_detail_view.go`
+- Reuse Lipgloss panel patterns from insights dashboard (Epic 40)
+- Health checks call ConnectionManager.TestConnection() (Story 43.4)
+- Provider-specific settings displayed from Connection.Settings map
+- Two-column layout: left = metadata, right = health checks
+
+## Tasks
+
+### Task 1: Implement source_detail_view.go with panel layout
+### Task 2: Render connection metadata (status, sync, tasks, settings)
+### Task 3: Render health check results panel
+### Task 4: Implement keybinding handlers
+### Task 5: Tests — rendering with various connection states, health check display
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/44.4.story.md
+++ b/docs/stories/44.4.story.md
@@ -1,0 +1,57 @@
+# Story 44.4: Sync Log View
+
+## Status: Not Started
+
+## Epic
+
+Epic 44: Sources TUI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.2, Sync Log View)
+
+## Story
+
+As a user,
+I want to view a scrollable sync log for a specific data source showing recent sync events, errors, and conflicts,
+So that I can diagnose sync issues and understand what changes were synced.
+
+## Background
+
+The sync log view displays SyncEvents (from Story 43.5) for a specific connection in reverse chronological order. Each entry shows timestamp, status indicator (✓/⚠/✗), and a description. Uses bubbles/viewport for scrolling (consistent with existing viewport adoption from Epic 41).
+
+## Acceptance Criteria
+
+**Given** the sync log view is opened for a connection
+**When** the view renders
+**Then** events are shown in reverse chronological order with timestamps
+**And** successful syncs show ✓ with task change counts
+**And** errors show ✗ with error message
+**And** conflicts show ⚠ with resolution details
+
+**Given** more events than fit on screen
+**When** the user scrolls
+**Then** the viewport scrolls through the full event history
+
+**Given** a connection with no sync events
+**When** the sync log view is opened
+**Then** a message "No sync events yet" is displayed
+
+## Technical Notes
+
+- New file: `internal/tui/synclog_detail_view.go`
+- Use bubbles/viewport (already adopted in Epic 41, Story 41.4)
+- Read events from SyncLogger (Story 43.5)
+- Lipgloss styling for event types
+- `Esc` returns to source detail view
+
+## Tasks
+
+### Task 1: Implement synclog_detail_view.go with viewport
+### Task 2: Render sync events with styled indicators
+### Task 3: Handle empty state
+### Task 4: Tests — rendering with various event types, scrolling, empty state
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/44.5.story.md
+++ b/docs/stories/44.5.story.md
@@ -1,0 +1,59 @@
+# Story 44.5: Status Bar Integration for Connection Health Alerts
+
+## Status: Not Started
+
+## Epic
+
+Epic 44: Sources TUI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.3)
+
+## Story
+
+As a user,
+I want to see a non-intrusive alert in the doors view status bar when any data source needs attention (auth expired, persistent errors, disconnected),
+So that I'm aware of connection issues without having to check the sources dashboard.
+
+## Background
+
+The doors view already has a status bar area (keybinding bar, flash messages). This story adds a connection health alert that appears only when a source needs attention. The alert follows the existing auto-fade pattern and shows the source name and issue type with a hint to use `:sources` to fix it. Only shown when a source is in Error or AuthExpired state.
+
+## Acceptance Criteria
+
+**Given** all connections are healthy
+**When** the doors view renders
+**Then** no connection health alert is shown
+
+**Given** a connection enters AuthExpired state
+**When** the doors view renders
+**Then** a yellow warning line appears: "⚠ Linear auth expired — :sources to fix"
+
+**Given** a connection has persistent sync errors
+**When** the doors view renders
+**Then** a warning line appears with the source name and error hint
+
+**Given** multiple sources need attention
+**When** the doors view renders
+**Then** only the most critical alert is shown (to avoid cluttering the view)
+**And** a count indicator shows "2 sources need attention"
+
+## Technical Notes
+
+- Modify `internal/tui/doors_view.go` View() method
+- ConnectionManager provides a NeedsAttention() method returning connections with issues
+- Use Lipgloss adaptive color for the warning text
+- Position below doors, above keybinding bar
+- Follow existing flash message dismiss pattern
+
+## Tasks
+
+### Task 1: Add NeedsAttention() to ConnectionManager
+### Task 2: Render alert in doors view when sources need attention
+### Task 3: Priority logic for multiple alerts
+### Task 4: Tests — alert rendering with various connection states
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/44.6.story.md
+++ b/docs/stories/44.6.story.md
@@ -1,0 +1,60 @@
+# Story 44.6: Disconnection Flow with Task Preservation Options
+
+## Status: Not Started
+
+## Epic
+
+Epic 44: Sources TUI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.4)
+
+## Story
+
+As a user,
+I want a confirmation dialog when disconnecting a data source that asks whether to keep or remove synced tasks,
+So that I don't accidentally lose tasks when removing an integration.
+
+## Background
+
+Disconnecting a source is a destructive action that should have a confirmation step. The dialog uses huh forms with a Select for task handling (keep locally vs remove) and a Confirm. The "keep tasks locally" option marks tasks as local-only (removes source attribution). Credentials are always cleaned up from the keychain.
+
+## Acceptance Criteria
+
+**Given** the user presses `d` on a connection in the sources dashboard
+**When** the disconnect dialog opens
+**Then** it shows the connection name and asks what to do with synced tasks
+**And** offers "Keep tasks locally" and "Remove synced tasks" options
+
+**Given** the user selects "Keep tasks locally" and confirms
+**When** disconnect completes
+**Then** the connection is removed from ConnectionManager and config
+**And** credentials are deleted from keychain
+**And** previously synced tasks remain with source attribution removed
+
+**Given** the user selects "Remove synced tasks" and confirms
+**When** disconnect completes
+**Then** the connection and all its synced tasks are removed
+
+**Given** the user presses Esc in the disconnect dialog
+**When** the dialog closes
+**Then** no changes are made
+
+## Technical Notes
+
+- New file or extend: `internal/tui/disconnect_dialog.go`
+- Use huh Confirm + Select components
+- Call ConnectionManager.Remove(id, keepTasks) (Story 43.4)
+- Flash message confirms successful disconnect
+
+## Tasks
+
+### Task 1: Implement disconnect dialog with huh forms
+### Task 2: Wire dialog to sources dashboard `d` keybinding
+### Task 3: Handle task preservation/removal via ConnectionManager
+### Task 4: Tests — confirm/cancel flows, task preservation behavior
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/44.7.story.md
+++ b/docs/stories/44.7.story.md
@@ -1,0 +1,59 @@
+# Story 44.7: Re-Authentication Flow
+
+## Status: Not Started
+
+## Epic
+
+Epic 44: Sources TUI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 3.5)
+
+## Story
+
+As a user,
+I want to re-authenticate a data source when its token expires without having to disconnect and reconnect,
+So that I can fix auth issues quickly and resume syncing.
+
+## Background
+
+When a connection enters AuthExpired state, the user presses `r` in the source detail view to trigger re-auth. For OAuth providers, this opens the device code flow (Story 46.2-46.3). For API token providers, this opens a masked input field for a new token. On success, credentials are updated in the keychain and the connection transitions back to Connecting → Connected.
+
+## Acceptance Criteria
+
+**Given** a connection in AuthExpired state with API token auth
+**When** `r` is pressed
+**Then** a masked input field appears for the new API token
+**And** on submission, the token is updated in the keychain
+**And** a connection test runs to verify the new token
+**And** on success, the connection transitions to Connected
+
+**Given** a connection in AuthExpired state with OAuth auth
+**When** `r` is pressed
+**Then** the OAuth device code flow is triggered (reuses Story 45 infrastructure)
+**And** on success, tokens are updated in the keychain
+
+**Given** re-authentication fails (invalid token, OAuth denied)
+**When** the failure occurs
+**Then** an error message is shown
+**And** the connection remains in AuthExpired state
+
+## Technical Notes
+
+- Extend source detail view with re-auth flow
+- Detect auth type from provider configuration
+- Reuse huh masked input for API token re-entry
+- OAuth flow depends on Epic 46 (can be implemented with placeholder/token-only first)
+- ConnectionManager.ReAuthenticate() updates credentials and transitions state
+
+## Tasks
+
+### Task 1: Implement API token re-entry UI with huh masked input
+### Task 2: Implement credential update and connection test on re-auth
+### Task 3: Wire to source detail view `r` keybinding
+### Task 4: Tests — successful re-auth, failed re-auth, cancel
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/45.1.story.md
+++ b/docs/stories/45.1.story.md
@@ -1,0 +1,70 @@
+# Story 45.1: `threedoors connect` Command (Non-Interactive)
+
+## Status: Not Started
+
+## Epic
+
+Epic 45: Sources CLI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 4.1)
+
+## Story
+
+As a power user or CI system,
+I want to configure data source connections via CLI flags without interactive prompts,
+So that I can script and automate connection setup.
+
+## Background
+
+The `threedoors connect <provider>` command supports both interactive (launches wizard from Story 44.1) and non-interactive modes. Non-interactive mode uses flags for all required fields: `--label`, `--token` (or env var), and provider-specific flags like `--repos`, `--server`, `--lists`, `--path`. The command validates inputs, stores credentials, creates the connection, and runs a connection test.
+
+## Acceptance Criteria
+
+**Given** `threedoors connect todoist --label "Personal" --token $TOKEN`
+**When** the command runs
+**Then** a Todoist connection is created with the specified label
+**And** the token is stored in the keychain
+**And** a connection test runs and results are printed
+**And** the command exits 0 on success
+
+**Given** `threedoors connect github --label "OSS" --repos owner/repo1,owner/repo2`
+**When** the command runs (with GH_TOKEN set)
+**Then** a GitHub connection is created for the specified repos
+**And** the GH_TOKEN env var is used for authentication
+
+**Given** `threedoors connect jira --label "Work" --server https://jira.company.com --token $TOKEN`
+**When** the command runs
+**Then** a Jira connection is created with the specified server URL
+
+**Given** `threedoors connect textfile --label "Notes" --path ~/tasks.yaml`
+**When** the command runs
+**Then** a textfile connection is created pointing to the specified path
+
+**Given** `threedoors connect todoist` with no flags
+**When** the command runs in a terminal
+**Then** the interactive wizard launches (defers to Story 44.1)
+
+**Given** required flags are missing in non-interactive mode
+**When** the command runs
+**Then** a clear error message lists the missing required flags
+
+## Technical Notes
+
+- New Cobra subcommand under existing CLI (Epic 23)
+- Provider-specific flag sets defined via provider FormSpec
+- Reuses ConnectionManager.Add() (Story 43.4) and CredentialStore (Story 43.2)
+- `--json` flag for machine-readable output (consistent with Epic 23 patterns)
+
+## Tasks
+
+### Task 1: Define `connect` Cobra command with provider subcommands
+### Task 2: Implement provider-specific flag parsing
+### Task 3: Wire to ConnectionManager.Add() and CredentialStore
+### Task 4: Run connection test and format output (table + JSON)
+### Task 5: Tests — each provider's flag combinations, missing flags, JSON output
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/45.2.story.md
+++ b/docs/stories/45.2.story.md
@@ -1,0 +1,63 @@
+# Story 45.2: `threedoors sources` List/Status/Test Commands
+
+## Status: Not Started
+
+## Epic
+
+Epic 45: Sources CLI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 4.1, 4.2)
+
+## Story
+
+As a power user,
+I want CLI commands to list all connections, view detailed status of a specific connection, and test connection health,
+So that I can monitor and diagnose integrations from the command line or scripts.
+
+## Background
+
+Three related subcommands: `threedoors sources` (summary list), `threedoors sources status [name]` (detailed status), and `threedoors sources test <name>` (health check). All support `--json` for machine-readable output. The list format matches the table layout from the research (name, provider, status, last sync, tasks).
+
+## Acceptance Criteria
+
+**Given** `threedoors sources` is run
+**When** connections exist
+**Then** a table is printed with columns: NAME, PROVIDER, STATUS, LAST SYNC, TASKS
+
+**Given** `threedoors sources status "Work Jira"` is run
+**When** the connection exists
+**Then** detailed output shows: name, provider, status, server, last sync, tasks (active + completed), filter/JQL, sync mode, poll rate, and health checks
+
+**Given** `threedoors sources test "Work Jira"` is run
+**When** the health check completes
+**Then** each check is printed with ✓/✗: DNS resolution, TLS, authentication, authorization, rate limit
+**And** exit code 0 for healthy, 1 for unhealthy
+
+**Given** `threedoors sources --json` is run
+**When** connections exist
+**Then** JSON array of connection objects is printed
+
+**Given** a connection name that doesn't exist
+**When** any sources subcommand is run with that name
+**Then** a clear error message is printed and exit code is 1
+
+## Technical Notes
+
+- New Cobra subcommands under `sources`
+- Reuses ConnectionManager.List(), .Get(), .TestConnection() (Story 43.4)
+- Table formatting via `text/tabwriter` or Lipgloss table (consistent with Epic 23)
+- JSON output via `encoding/json` with `--json` flag
+
+## Tasks
+
+### Task 1: Implement `sources` list command with table output
+### Task 2: Implement `sources status` with detailed output
+### Task 3: Implement `sources test` with health checks
+### Task 4: Add `--json` support to all three commands
+### Task 5: Tests — table formatting, JSON output, error cases
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/45.3.story.md
+++ b/docs/stories/45.3.story.md
@@ -1,0 +1,66 @@
+# Story 45.3: `threedoors sources` Management Commands
+
+## Status: Not Started
+
+## Epic
+
+Epic 45: Sources CLI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 4.1)
+
+## Story
+
+As a power user,
+I want CLI commands to pause, resume, force-sync, re-authenticate, edit, and disconnect data source connections,
+So that I can manage integrations programmatically without the TUI.
+
+## Background
+
+Management subcommands: `sources pause <name>`, `sources resume <name>`, `sources sync <name>`, `sources reauth <name>`, `sources edit <name>` (re-opens wizard), `sources disconnect <name>` (with `--keep-tasks` flag). Each command validates the connection exists and the operation is valid for the current state.
+
+## Acceptance Criteria
+
+**Given** `threedoors sources pause "Home Reminders"` is run
+**When** the connection is currently syncing
+**Then** sync is paused and confirmation is printed
+
+**Given** `threedoors sources resume "Home Reminders"` is run
+**When** the connection is paused
+**Then** sync resumes and confirmation is printed
+
+**Given** `threedoors sources sync "Work Jira"` is run
+**When** the connection is connected
+**Then** an immediate sync cycle is triggered and results are printed
+
+**Given** `threedoors sources disconnect "Linear" --keep-tasks` is run
+**When** the connection exists
+**Then** the connection is removed, credentials deleted, tasks preserved
+
+**Given** `threedoors sources disconnect "Linear"` is run without `--keep-tasks`
+**When** the command runs interactively
+**Then** it prompts for task handling choice before disconnecting
+
+**Given** an invalid operation for the current state (e.g., resume when not paused)
+**When** the command runs
+**Then** a clear error message explains the invalid state transition
+
+## Technical Notes
+
+- Cobra subcommands under `sources`
+- Reuses ConnectionManager methods (Story 43.4)
+- `disconnect` without `--keep-tasks` prompts interactively (uses `bufio.Scanner`)
+- All commands support `--json` for machine-readable confirmation
+
+## Tasks
+
+### Task 1: Implement pause/resume commands
+### Task 2: Implement sync command
+### Task 3: Implement disconnect command with interactive/non-interactive modes
+### Task 4: Implement reauth and edit commands
+### Task 5: Tests — each command with valid/invalid states, JSON output
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/45.4.story.md
+++ b/docs/stories/45.4.story.md
@@ -1,0 +1,55 @@
+# Story 45.4: `threedoors sources log` Command
+
+## Status: Not Started
+
+## Epic
+
+Epic 45: Sources CLI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 4.1)
+
+## Story
+
+As a power user,
+I want a CLI command to view sync logs for a specific connection or filter across all connections,
+So that I can diagnose sync issues from the command line.
+
+## Background
+
+`threedoors sources log <name>` shows recent sync events for a connection. `--last N` controls how many events. `--errors` filters to errors and conflicts only. Supports `--json` for machine-readable output.
+
+## Acceptance Criteria
+
+**Given** `threedoors sources log "Personal Todoist"` is run
+**When** events exist
+**Then** the most recent 20 events are printed with timestamps and status indicators
+
+**Given** `threedoors sources log "Personal Todoist" --last 50` is run
+**Then** the most recent 50 events are printed
+
+**Given** `threedoors sources log --errors` is run
+**When** errors exist across any connection
+**Then** only error and conflict events are shown from all connections
+
+**Given** `threedoors sources log "Personal Todoist" --json` is run
+**Then** events are output as a JSON array
+
+## Technical Notes
+
+- Cobra subcommand under `sources`
+- Reads from SyncLogger (Story 43.5)
+- Table format: TIMESTAMP, STATUS, DESCRIPTION
+- Reuses existing CLI output patterns
+
+## Tasks
+
+### Task 1: Implement `sources log` command
+### Task 2: Add `--last` and `--errors` flags
+### Task 3: Add `--json` output
+### Task 4: Tests — output formatting, filtering, empty state
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/45.5.story.md
+++ b/docs/stories/45.5.story.md
@@ -1,0 +1,59 @@
+# Story 45.5: JSON Output Support for All Sources Commands
+
+## Status: Not Started
+
+## Epic
+
+Epic 45: Sources CLI
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 4.1)
+
+## Story
+
+As a script or automation author,
+I want all `threedoors sources` commands to support `--json` output,
+So that I can parse connection status and sync data programmatically.
+
+## Background
+
+This story ensures consistent JSON output across all sources subcommands. The `--json` flag is already a persistent flag in the CLI (Epic 23). This story adds JSON serialization for Connection, HealthCheckResult, SyncEvent, and command results. JSON schemas should be documented for consumers.
+
+## Acceptance Criteria
+
+**Given** any sources subcommand with `--json`
+**When** the command produces output
+**Then** valid JSON is printed to stdout
+**And** no non-JSON text is mixed in (warnings go to stderr)
+
+**Given** `threedoors sources --json`
+**Then** output is `[{"id":"...","provider":"todoist","label":"Personal Todoist","status":"connected",...}]`
+
+**Given** `threedoors sources status "Work Jira" --json`
+**Then** output is a single connection object with health checks included
+
+**Given** `threedoors sources test "Work Jira" --json`
+**Then** output includes `{"healthy":true,"checks":[{"name":"api_reachable","passed":true},...]}`
+
+**Given** a command that fails
+**When** `--json` is set
+**Then** output is `{"error":"connection not found: Work Jira"}` and exit code is 1
+
+## Technical Notes
+
+- Extend existing JSON output formatter from Epic 23
+- Define JSON struct tags on Connection, HealthCheckResult, SyncEvent
+- Consistent error envelope: `{"error": "message"}`
+- Warnings to stderr, data to stdout
+
+## Tasks
+
+### Task 1: Add JSON struct tags to Connection, HealthCheckResult, SyncEvent
+### Task 2: Implement JSON formatting for each sources subcommand
+### Task 3: Error envelope for JSON mode
+### Task 4: Tests — JSON schema validation for each command
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/46.1.story.md
+++ b/docs/stories/46.1.story.md
@@ -1,0 +1,69 @@
+# Story 46.1: Generic Device Code Flow Client
+
+## Status: Not Started
+
+## Epic
+
+Epic 46: OAuth Device Code Flow
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.5)
+- Decision: Device code flow over callback server (no port conflicts, works in SSH/containers)
+
+## Story
+
+As a developer,
+I want a generic, reusable OAuth device code flow client that any provider can use for browser-based authentication,
+So that OAuth-supporting providers (GitHub, Linear, etc.) share one implementation instead of duplicating the flow.
+
+## Background
+
+Device code flow (RFC 8628): (1) Request device code + user code from authorization server, (2) Display user code and verification URL, (3) Open browser automatically (fallback: display URL), (4) Poll token endpoint until user authorizes or timeout, (5) Exchange for access + refresh tokens, (6) Store in keychain. The client is provider-agnostic — each provider supplies endpoint URLs and client ID.
+
+## Acceptance Criteria
+
+**Given** a DeviceCodeConfig with authorization endpoint, token endpoint, client ID, and scopes
+**When** StartDeviceCodeFlow() is called
+**Then** a DeviceCodeResponse is returned with user_code, verification_uri, and device_code
+
+**Given** a device code has been obtained
+**When** PollForToken() is called
+**Then** it polls the token endpoint at the specified interval
+**And** returns TokenResponse on success (access_token, refresh_token, expires_in)
+**And** returns a timeout error after the specified expiry period
+**And** handles "authorization_pending" and "slow_down" responses correctly
+
+**Given** the polling detects a "slow_down" response
+**When** the next poll occurs
+**Then** the interval is increased by 5 seconds per RFC 8628
+
+**Given** a successful token response
+**When** tokens are obtained
+**Then** they can be stored via CredentialStore (Story 43.2)
+
+**Given** the flow is cancelled by the user
+**When** context is cancelled
+**Then** polling stops immediately and a cancellation error is returned
+
+## Technical Notes
+
+- New file: `internal/tasks/connection/oauth/devicecode.go`
+- DeviceCodeConfig: AuthEndpoint, TokenEndpoint, ClientID, Scopes []string
+- DeviceCodeResponse: DeviceCode, UserCode, VerificationURI, ExpiresIn, Interval
+- TokenResponse: AccessToken, RefreshToken, ExpiresIn, TokenType
+- Use `context.Context` for cancellation
+- HTTP client with configurable timeout
+- No external OAuth library — thin HTTP client is simpler and more auditable
+
+## Tasks
+
+### Task 1: Define types (DeviceCodeConfig, DeviceCodeResponse, TokenResponse)
+### Task 2: Implement StartDeviceCodeFlow (POST to auth endpoint)
+### Task 3: Implement PollForToken with interval backoff and timeout
+### Task 4: Browser open helper (exec `open` on macOS, `xdg-open` on Linux)
+### Task 5: Tests — successful flow, timeout, slow_down backoff, cancellation (mock HTTP server)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/46.2.story.md
+++ b/docs/stories/46.2.story.md
@@ -1,0 +1,62 @@
+# Story 46.2: GitHub OAuth Integration
+
+## Status: Not Started
+
+## Epic
+
+Epic 46: OAuth Device Code Flow
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 2, GitHub Issues)
+- Prior art: `gh auth login` device code flow
+
+## Story
+
+As a user,
+I want to authenticate with GitHub using OAuth device code flow when connecting GitHub Issues,
+So that I don't need to manually create and paste a Personal Access Token.
+
+## Background
+
+GitHub supports OAuth device code flow via `https://github.com/login/device`. This story wires the generic device code client (Story 46.1) to GitHub's specific endpoints and required scopes. Falls back to PAT entry if OAuth is unavailable (e.g., GitHub Enterprise without OAuth app). Also respects existing `GH_TOKEN`/`GITHUB_TOKEN` env vars.
+
+## Acceptance Criteria
+
+**Given** the user selects GitHub Issues in the connect wizard
+**When** OAuth is chosen as the auth method
+**Then** the device code flow starts with GitHub's endpoints
+**And** the user code and verification URL are displayed
+**And** the browser opens to `github.com/login/device`
+
+**Given** the user authorizes in the browser
+**When** the token is obtained
+**Then** access token is stored in the keychain
+**And** a connection test verifies the token works
+
+**Given** `GH_TOKEN` or `GITHUB_TOKEN` is already set
+**When** the user selects GitHub Issues
+**Then** the wizard offers to use the existing token instead of OAuth
+
+**Given** GitHub Enterprise is configured
+**When** OAuth is not available
+**Then** the wizard falls back to PAT entry
+
+## Technical Notes
+
+- GitHub device code endpoint: `https://github.com/login/device/code`
+- GitHub token endpoint: `https://github.com/login/oauth/access_token`
+- Required scopes: `repo` (for issue access)
+- Requires registering a GitHub OAuth App (client_id needed)
+- Detect `GH_TOKEN`/`GITHUB_TOKEN` env vars as fallback
+
+## Tasks
+
+### Task 1: Configure GitHub-specific DeviceCodeConfig
+### Task 2: Wire GitHub OAuth flow into connect wizard GitHub step
+### Task 3: Implement env var detection fallback
+### Task 4: Tests — mock GitHub OAuth endpoints, env var fallback
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/46.3.story.md
+++ b/docs/stories/46.3.story.md
@@ -1,0 +1,53 @@
+# Story 46.3: Linear OAuth Integration
+
+## Status: Not Started
+
+## Epic
+
+Epic 46: OAuth Device Code Flow
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 2, Linear)
+
+## Story
+
+As a user,
+I want to authenticate with Linear using OAuth when connecting Linear as a task source,
+So that I get a seamless browser-based auth experience.
+
+## Background
+
+Linear supports OAuth 2.0 with authorization code flow. If Linear adds device code flow support, use that. Otherwise, implement authorization code flow with a local callback server (minimal port usage) or fall back to API key entry. Linear API keys are available at Settings → API → Personal API keys.
+
+## Acceptance Criteria
+
+**Given** the user selects Linear in the connect wizard
+**When** OAuth is available
+**Then** the OAuth flow authenticates the user via browser
+
+**Given** the user selects Linear in the connect wizard
+**When** API key entry is chosen (or OAuth unavailable)
+**Then** a masked input field accepts the Linear API key
+**And** the key is stored in the keychain
+
+**Given** authentication succeeds
+**When** the connection test runs
+**Then** it verifies the token by querying the Linear viewer endpoint
+
+## Technical Notes
+
+- Linear OAuth docs: OAuth 2.0 authorization code flow
+- Linear API key: simpler alternative, available at Settings → API
+- If device code not supported, API key is the primary flow for now
+- Depends on Linear adapter from Epic 30 for the actual provider
+
+## Tasks
+
+### Task 1: Configure Linear-specific auth flow (API key primary, OAuth secondary)
+### Task 2: Wire auth into connect wizard Linear step
+### Task 3: Tests — API key validation, mock auth flow
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/46.4.story.md
+++ b/docs/stories/46.4.story.md
@@ -1,0 +1,63 @@
+# Story 46.4: Token Refresh Lifecycle
+
+## Status: Not Started
+
+## Epic
+
+Epic 46: OAuth Device Code Flow
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 1.9, Token lifecycle)
+
+## Story
+
+As a user,
+I want my OAuth access tokens to refresh silently before they expire, and to be notified clearly when re-authentication is required,
+So that my sync connections don't break unexpectedly.
+
+## Background
+
+OAuth tokens have limited lifetimes. Access tokens should be refreshed silently using the refresh token before expiry. When the refresh token itself expires (or is revoked), the connection transitions to AuthExpired state and the user must explicitly re-authenticate (Story 44.7). Token expiry is tracked per connection. The CLI never silently re-authenticates — it only refreshes.
+
+## Acceptance Criteria
+
+**Given** an access token is within 5 minutes of expiry
+**When** a sync cycle begins
+**Then** the token is silently refreshed using the refresh token
+**And** the new tokens are stored in the keychain
+**And** sync proceeds normally
+
+**Given** the refresh token has expired or been revoked
+**When** token refresh is attempted
+**Then** the connection transitions to AuthExpired state
+**And** the user is notified via status bar alert (Story 44.5)
+**And** sync stops until the user re-authenticates
+
+**Given** an API key (non-OAuth) connection
+**When** the API returns a 401 Unauthorized
+**Then** the connection transitions to AuthExpired state
+**And** the user is notified
+
+**Given** token refresh succeeds
+**When** the event is logged
+**Then** a SyncEvent with type "token_refreshed" is recorded
+
+## Technical Notes
+
+- Token metadata stored alongside credentials: expiry time, refresh token
+- Pre-emptive refresh: check expiry before each sync, refresh if < 5 min remaining
+- Refresh endpoint call: POST with grant_type=refresh_token
+- 401 detection in existing HTTP clients for API key expiry
+
+## Tasks
+
+### Task 1: Store token expiry metadata in keychain (or alongside)
+### Task 2: Implement pre-emptive token refresh logic
+### Task 3: Implement 401 detection for API key connections
+### Task 4: Wire AuthExpired state transition on refresh failure
+### Task 5: Tests — refresh before expiry, refresh token expired, 401 detection
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/47.1.story.md
+++ b/docs/stories/47.1.story.md
@@ -1,0 +1,58 @@
+# Story 47.1: Conflict Resolution Strategy with Logging
+
+## Status: Not Started
+
+## Epic
+
+Epic 47: Sync Lifecycle & Advanced Features
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.3)
+
+## Story
+
+As a user,
+I want sync conflicts to be resolved automatically with sensible defaults and logged for transparency,
+So that I don't lose data and can review what happened when both sides changed.
+
+## Background
+
+Party mode consensus: last-writer-wins with notification as default. Remote-wins for metadata (status, priority) — the source system is authoritative. Local-wins for ThreeDoors-specific fields (effort category, door assignment). All conflicts are logged in the sync log for transparency. Never auto-delete — orphaned tasks get marked, user decides.
+
+## Acceptance Criteria
+
+**Given** a task is modified both locally and remotely
+**When** sync detects the conflict
+**Then** the conflict is resolved per the strategy (remote-wins for metadata, local-wins for ThreeDoors fields)
+**And** a conflict SyncEvent is logged with both values and the resolution
+
+**Given** a task is deleted remotely but exists locally
+**When** sync detects the deletion
+**Then** the task is NOT auto-deleted
+**And** it is marked as "orphaned" with a flag indicating remote deletion
+**And** a SyncEvent is logged
+
+**Given** the sync log contains conflict events
+**When** the user views the sync log (TUI or CLI)
+**Then** conflicts show the task ID, field, local value, remote value, and which side won
+
+## Technical Notes
+
+- Extend existing sync logic in adapter implementations
+- ConflictResolver interface with configurable strategy per field
+- Default strategy: FieldCategory map (metadata fields → remote-wins, ThreeDoors fields → local-wins)
+- Orphaned task flag on Task struct
+- All conflict events use SyncLogger (Story 43.5)
+
+## Tasks
+
+### Task 1: Define ConflictResolver interface and default strategy
+### Task 2: Implement field-level conflict resolution
+### Task 3: Implement orphaned task marking (not deletion)
+### Task 4: Wire conflict logging to SyncLogger
+### Task 5: Tests — metadata conflicts, ThreeDoors field conflicts, orphaned tasks
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/47.2.story.md
+++ b/docs/stories/47.2.story.md
@@ -1,0 +1,59 @@
+# Story 47.2: Orphaned Task Handling
+
+## Status: Not Started
+
+## Epic
+
+Epic 47: Sync Lifecycle & Advanced Features
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.3)
+
+## Story
+
+As a user,
+I want tasks that were deleted remotely to be flagged rather than auto-deleted, with a way to review and decide what to do with them,
+So that I don't lose tasks that I might still want locally.
+
+## Background
+
+When a task is deleted in the source system but still exists in ThreeDoors, it becomes "orphaned." These tasks are flagged with an orphaned marker and excluded from door selection. A `:orphaned` command or section in the sources detail view lists orphaned tasks and lets the user keep (convert to local) or delete them.
+
+## Acceptance Criteria
+
+**Given** a synced task is deleted in the remote source
+**When** the next sync cycle runs
+**Then** the task is marked as orphaned (not deleted)
+**And** it no longer appears in door selection
+
+**Given** orphaned tasks exist
+**When** the user views them via `:orphaned` or sources detail
+**Then** each orphaned task shows its name, source, and deletion time
+
+**Given** the user selects an orphaned task
+**When** they choose "keep locally"
+**Then** the task is converted to a local-only task (source attribution removed)
+
+**Given** the user selects an orphaned task
+**When** they choose "delete"
+**Then** the task is permanently removed
+
+## Technical Notes
+
+- Add `Orphaned bool` and `OrphanedAt time.Time` fields to Task struct
+- Exclude orphaned tasks from door selection pool
+- New TUI view or section for orphaned task management
+- `:orphaned` command registration
+
+## Tasks
+
+### Task 1: Add orphaned fields to Task struct
+### Task 2: Mark tasks as orphaned during sync (not delete)
+### Task 3: Exclude orphaned tasks from door selection
+### Task 4: Implement orphaned task management UI
+### Task 5: Tests — orphan detection, exclusion from doors, keep/delete actions
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/47.3.story.md
+++ b/docs/stories/47.3.story.md
@@ -1,0 +1,63 @@
+# Story 47.3: Auto-Detection of Existing Tools in Setup Wizard
+
+## Status: Not Started
+
+## Epic
+
+Epic 47: Sync Lifecycle & Advanced Features
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.6)
+
+## Story
+
+As a user,
+I want the setup wizard to detect tools I already have installed (gh CLI, Todoist config, Obsidian vaults) and offer to connect them,
+So that setup is "we found these — connect them?" instead of "configure everything from scratch."
+
+## Background
+
+Innovation insight from party mode: the `:connect` wizard should detect installed tools before showing the provider list. Detections: `gh` CLI installed and authenticated, `TODOIST_API_TOKEN` env var set, `~/.config/todoist/` exists, Jira config files present, `.obsidian/` directories found. Detected tools appear at the top of the provider list with a "detected" badge.
+
+## Acceptance Criteria
+
+**Given** `gh` CLI is installed and authenticated
+**When** the connect wizard opens
+**Then** "GitHub Issues (detected — gh CLI)" appears at the top of the provider list
+
+**Given** `TODOIST_API_TOKEN` is set in the environment
+**When** the connect wizard opens
+**Then** "Todoist (detected — API token found)" appears at the top of the provider list
+
+**Given** `.obsidian/` directories exist in common locations
+**When** the connect wizard opens
+**Then** "Obsidian (detected — vault found at ~/Documents/vault)" appears at the top
+
+**Given** no tools are detected
+**When** the connect wizard opens
+**Then** the provider list appears in its default order with no "detected" badges
+
+**Given** a detected tool is selected
+**When** the wizard proceeds
+**Then** pre-fills configuration from the detected source (e.g., token from env var, vault path)
+
+## Technical Notes
+
+- New file: `internal/tasks/connection/detect.go`
+- Detector interface: each provider can implement a Detect() method
+- Check: exec.LookPath for CLIs, os.Getenv for env vars, glob for config dirs
+- Detection results fed into wizard Step 1 to reorder and annotate the list
+- Pre-fill settings from detected sources
+
+## Tasks
+
+### Task 1: Define Detector interface
+### Task 2: Implement detectors for gh, Todoist, Obsidian, Jira
+### Task 3: Integrate detection results into connect wizard provider list
+### Task 4: Pre-fill settings from detected sources
+### Task 5: Tests — each detector with present/absent tools, wizard integration
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/47.4.story.md
+++ b/docs/stories/47.4.story.md
@@ -1,0 +1,58 @@
+# Story 47.4: Proactive Connection Health Notifications
+
+## Status: Not Started
+
+## Epic
+
+Epic 47: Sync Lifecycle & Advanced Features
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/data-source-setup-ux-research.md` (Section 5.2, 3.3)
+
+## Story
+
+As a user,
+I want to be proactively notified when a connection's token is about to expire, rate limits are close to exhaustion, or consecutive sync errors indicate a problem,
+So that I can fix issues before they cause sync failures.
+
+## Background
+
+Proactive notifications extend the status bar alert (Story 44.5) with predictive warnings: token expiring within 7 days, rate limit usage above 80%, 3+ consecutive sync errors. Notifications are non-intrusive (status bar) and include actionable hints (`:sources` to investigate).
+
+## Acceptance Criteria
+
+**Given** an OAuth token expires within 7 days
+**When** the doors view renders
+**Then** a warning shows "⚠ Todoist token expires in 5 days — :sources to renew"
+
+**Given** rate limit usage exceeds 80%
+**When** the doors view renders
+**Then** a warning shows "⚠ GitHub rate limit 82% — sync may slow down"
+
+**Given** 3+ consecutive sync errors for a connection
+**When** the doors view renders
+**Then** a warning shows "⚠ Jira sync failing — :sources to investigate"
+
+**Given** no connections have issues
+**When** the doors view renders
+**Then** no connection warnings are shown
+
+## Technical Notes
+
+- Extend ConnectionManager.NeedsAttention() (from Story 44.5)
+- Add predictive checks: token expiry window, rate limit threshold, error streak count
+- Rate limit tracking: store remaining/total from API response headers per connection
+- Error streak: counter in Connection struct, reset on successful sync
+
+## Tasks
+
+### Task 1: Add predictive health check methods to ConnectionManager
+### Task 2: Track rate limits from API response headers
+### Task 3: Track consecutive error count per connection
+### Task 4: Wire predictive warnings into status bar
+### Task 5: Tests — expiry prediction, rate limit threshold, error streak detection
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

Formalizes the data source setup UX research (`_bmad-output/planning-artifacts/data-source-setup-ux-research.md`, PR #415) into 5 epics with 26 stories covering the full connection lifecycle for data source integrations.

### Epics Created

- **Epic 43: Connection Manager Infrastructure** (6 stories) — State machine, keyring credential storage, config schema v3 (named connections), CRUD operations, sync event logging, adapter migration
- **Epic 44: Sources TUI** (7 stories) — `:connect` setup wizard (charmbracelet/huh), `:sources` dashboard, detail view, sync log, status bar alerts, disconnect/re-auth flows
- **Epic 45: Sources CLI** (5 stories) — `threedoors connect`, `threedoors sources` (list/status/test/manage/log), `--json` output
- **Epic 46: OAuth Device Code Flow** (4 stories) — Generic RFC 8628 client, GitHub/Linear integrations, token refresh lifecycle
- **Epic 47: Sync Lifecycle & Advanced Features** (4 stories) — Conflict resolution (field-level), orphaned task handling, tool auto-detection, proactive health notifications

### Decisions Recorded

**Adopted (D-147 through D-152):**
- D-147: `99designs/keyring` for credential storage
- D-148: OAuth device code flow (not callback server)
- D-149: Compiled-in providers (not pluggable)
- D-150: `charmbracelet/huh` for setup wizard
- D-151: Last-writer-wins with field-level conflict strategy
- D-152: Named connections with ULID IDs

**Rejected (X-087 through X-093):** OAuth callback server, `zalando/go-keyring`, Go plugin arch, credentials in config.yaml, Apple Notes integration, in-app settings editor, webhook receiver

### Dependency Graph

Epic 43 is the critical path — all other epics depend on it. Epics 44 (TUI) and 45 (CLI) can parallelize after Epic 43. Epic 46 (OAuth) is independent. Epic 47 (Advanced) depends on 43+44.

### Docs Updated

- `ROADMAP.md` — 5 new epic sections with story tables
- `docs/prd/epic-list.md` — 5 new epic entries + story count summary
- `docs/prd/epics-and-stories.md` — Full epic details with story descriptions and design decisions
- `docs/decisions/BOARD.md` — 6 adopted decisions, 7 rejected alternatives, epic number registry updated
- 26 story files created in `docs/stories/`

### Notes

- Epic 42 was claimed by another agent for "Door-Like Doors" — renumbered from 42-46 to 43-47 to avoid collision
- No implementation code — planning artifacts and story files only
- Research source: PR #415

## Test plan

- [ ] All story files exist and have correct epic references
- [ ] Cross-references between stories are consistent (no stale 42.x references)
- [ ] BOARD.md has no merge conflict markers
- [ ] Decision IDs don't collide with existing decisions
- [ ] Epic number registry shows 43-47 as allocated
- [ ] Story count summary in epic-list.md is accurate (246 total)