### PR TITLE
fix: remove destructive git sync overrides from agent definitions

### DIFF
--- a/agents/supervisor.md
+++ b/agents/supervisor.md
@@ -44,7 +44,10 @@ multiclaude work "Task description"
 ## Standing Orders
 
 1. **All story work via `/implement-story <story-id>`** — no exceptions
-2. **All agents must sync git** before starting work (`git fetch origin main && git rebase origin/main`)
+2. **Git sync rules differ by agent type:**
+   - **Persistent agents** (merge-queue, pr-shepherd): MAY sync git before major operations — they share the main checkout
+   - **Workers**: Do NOT manually sync. multiclaude creates fresh worktrees from HEAD and auto-refreshes them every 5 minutes via the daemon. Manual git fetch/rebase in workers is redundant at best, destructive at worst (causes mid-rebase conflicts).
+   - **NEVER prepend `git fetch origin main && git rebase origin/main` to worker task descriptions.**
 3. **ROADMAP.md is the scope gate** — merge-queue rejects out-of-scope PRs
 4. **Issue triage via BMAD pipeline** — never jump straight to code. Acknowledge on issue, PM examination, party mode, PRD/arch, story creation, docs PR, report back on issue. Implementation comes later via `/implement-story`.
 5. **Workers do NOT touch ROADMAP.md** — roadmap updates are supervisor/BMAD PM level only
@@ -58,8 +61,9 @@ Every implementation worker task MUST include these requirements:
 
 1. **Story file update** — After implementation, update `docs/stories/X.Y.story.md` with `Status: Done (PR #NNN)`
 2. **Tests required** — Every implementation must include tests (TDD red-green). Verify test files exist before creating PR.
-3. **Prerequisite files** — When PRs are unmerged, include explicit `git fetch` + `git checkout` commands for all dependency branches
-4. **PR chain awareness** — When multiple stories modify the same files, rebase onto the previous story's branch, not main. This prevents merge conflicts.
+3. **PR chain awareness** — When multiple stories modify the same files, rebase onto the previous story's branch, not main. This prevents merge conflicts.
+
+> **WARNING:** Do NOT include `git fetch origin main && git rebase origin/main` in worker task descriptions. multiclaude manages worker worktrees automatically (fresh from HEAD at creation, auto-refreshed every 5 min). Manual git sync in workers has caused mid-rebase conflicts and stuck workers.
 
 ## The Merge Queue
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -32,6 +32,10 @@ multiclaude message send supervisor "Need help: [your question]"
 Your branch: `work/<your-name>`
 Push to it, create PR from it.
 
+## Git Worktree (Managed by multiclaude)
+
+Your worktree is managed by multiclaude. Do NOT run `git fetch origin main && git rebase origin/main` — the daemon creates your worktree fresh from HEAD and auto-refreshes it every 5 minutes. Manual git sync is redundant and can cause mid-rebase conflicts that block your work.
+
 ## Environment Hygiene
 
 Keep your environment clean:


### PR DESCRIPTION
## Summary

- **Standing Order #2** in `agents/supervisor.md` previously told ALL agents to run `git fetch origin main && git rebase origin/main` before starting work. This is wrong for workers — multiclaude creates fresh worktrees from HEAD and auto-refreshes them every 5 minutes. The manual sync was redundant and caused a worker to get stuck mid-rebase with conflicts.
- **Worker Dispatch Checklist** in `agents/supervisor.md` included a "Prerequisite files" item telling supervisors to include `git fetch` + `git checkout` commands in worker tasks. Removed this and added an explicit WARNING against including git sync instructions.
- **`agents/worker.md`** now has a "Git Worktree (Managed by multiclaude)" section that tells workers not to manually sync.

## What was wrong

The `git fetch origin main && git rebase origin/main` instruction prepended to worker tasks was:
1. **Redundant** — multiclaude daemon already handles this automatically
2. **Destructive** — caused a worker to get stuck mid-rebase with merge conflicts, blocking work

## What was fixed

- `agents/supervisor.md`: Standing Order #2 now distinguishes persistent agents (MAY sync git) from workers (must NOT sync)
- `agents/supervisor.md`: Worker Dispatch Checklist — removed prerequisite git fetch item, added explicit warning
- `agents/worker.md`: Added section explaining worktree is managed by multiclaude

## Files changed

- `agents/supervisor.md`
- `agents/worker.md`

## Test plan

- [x] No Go code changes — docs/config only
- [x] All .md files well-formatted
- [x] Changes match the task description exactly
- [ ] Verify no other agent .md files reference worker git sync (checked — pr-shepherd and merge-queue references are correct for persistent agents)