### PR TITLE
docs: governance sync — Story 43.1 Done, remove duplicate Epic 48

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,13 +111,13 @@ Transform rectangular card/panel doors into visually convincing doors using side
 
 **Dependency graph:** Stories 48.1 & 48.2 can parallelize. Stories 48.3 & 48.4 can parallelize after 48.1 completes.
 
-### Epic 43: Connection Manager Infrastructure (P1) — 0/6 stories done
+### Epic 43: Connection Manager Infrastructure (P1) — 1/6 stories done
 
 Connection lifecycle layer for data source integrations. State machine, credential storage (system keychain), config schema v3 (named connections), CRUD operations, sync event logging, and migration of existing adapters to the new pattern.
 
 | Story | Title | Status | Priority | Depends On |
 |-------|-------|--------|----------|------------|
-| 43.1 | Connection State Machine and ConnectionManager Type | Not Started | P1 | None |
+| 43.1 | Connection State Machine and ConnectionManager Type | Done (PR #428) | P1 | None |
 | 43.2 | Keyring Integration with Environment Variable Fallback | Not Started | P1 | None |
 | 43.3 | Config Schema v3 Migration with Connections Support | Not Started | P1 | None |
 | 43.4 | Connection CRUD Operations | Not Started | P1 | 43.1, 43.2, 43.3 |

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -4798,46 +4798,6 @@ Pin third-party GitHub Actions (golangci-lint-action, paths-filter, goreleaser-a
 
 ---
 
-## Epic 48: Door-Like Doors — Visual Door Metaphor Enhancement
-
-**Priority:** P2
-**Status:** Not Started
-**Dependencies:** Epic 35 (Door Visual Appearance — complete), Epic 17 (Door Theme System — complete), Story 41.5 (Harmonica spike — complete, D-136 GO decision)
-
-### Epic Goal
-
-Transform rectangular card/panel doors into visually convincing doors by implementing 5 adopted proposals from the "doors more door-like" party mode research (5 rounds, 7 agents).
-
-The 5 adopted proposals collectively raise "doorness" from ~3.5/7 (Classic) to ~6.5/7 across all themes, at a total cost of ~200-250 LOC and 0-1 character of width.
-
-### Stories
-
-| Story | Title | Status | Priority | Depends On |
-|-------|-------|--------|----------|------------|
-| 48.1 | Side-Mounted Handle + Hinge Marks | Not Started | P2 | Epic 35 (done), Epic 17 (done) |
-| 48.2 | Continuous Threshold / Floor Line | Not Started | P2 | None |
-| 48.3 | Crack of Light Effect on Selection | Not Started | P2 | 48.1 |
-| 48.4 | Handle Turn Micro-Animation | Not Started | P2 | 48.1 |
-
-### Design Decisions
-
-- D-141: Adopt 5 proposals (B, C, D, F, G) for door-like doors; reject 4 (A, E, H, I)
-- X-080 through X-083: Rejected alternatives
-
-### Noted Opportunities (Out of Scope)
-
-1. Door-Opening Transition Animation
-2. Light Spill Enhancement
-3. Nested Frame for Wide Terminals
-4. Wall Context for Wide Terminals
-
-### Research
-
-- Party Mode (5 rounds, 7 agents): `_bmad-output/planning-artifacts/doors-more-doorlike-research.md`
-- Prior: `_bmad-output/planning-artifacts/door-appearance-party-mode.md` (Epic 35)
-
----
-
 ## Epic 49: ThreeDoors Doctor — Self-Diagnosis Command
 
 **Priority:** P1

--- a/docs/stories/43.1.story.md
+++ b/docs/stories/43.1.story.md
@@ -1,6 +1,6 @@
 # Story 43.1: Connection State Machine and ConnectionManager Type
 
-## Status: In Review
+## Status: Done (PR #428)
 
 ## Epic
 


### PR DESCRIPTION
## Summary

- **Story 43.1**: `In Review` → `Done (PR #428)` — PR merged 2026-03-10
- **ROADMAP.md**: Epic 43 progress updated to 1/6, Story 43.1 row updated
- **epics-and-stories.md**: Removed duplicate Epic 48 section (lines ~4801-4838, artifact from renumbering PR #421)

## Test plan

- [ ] Story 43.1 file shows `Done (PR #428)`
- [ ] ROADMAP Epic 43 header shows 1/6
- [ ] ROADMAP Epic 43 table shows 43.1 as Done
- [ ] epics-and-stories.md has exactly ONE Epic 48 section (grep count = 1)