### PR TITLE
docs: Epic 50 — In-App Bug Reporting epic and stories (P-006)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -203,6 +203,18 @@ Remediate findings from the application security audit. Fix permissive file perm
 | 42.4 | Credential Protection in Config Files | Not Started | P2 | 42.1 |
 | 42.5 | CI Supply Chain Hardening | Not Started | P1 | None |
 
+### Epic 50: In-App Bug Reporting (P2) — 0/3 stories done
+
+In-app `:bug` command for frictionless bug reporting without leaving the TUI. Breadcrumb navigation trail, environment data collection with strict privacy allowlist, mandatory preview, and tiered submission (browser URL, GitHub API, local file).
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 50.1 | Breadcrumb Tracking System | Not Started | P2 | None |
+| 50.2 | Bug Report View & Environment Collection | Not Started | P2 | 50.1 |
+| 50.3 | Submission Methods (Browser, API, File) | Not Started | P2 | 50.2 |
+
+**Dependency graph:** Linear chain: 50.1 → 50.2 → 50.3.
+
 ## Completed Epics
 
 | Epic | Title | Stories |

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -23,7 +23,7 @@
 
 | ID | Recommendation | Date | Source | Link | Awaiting |
 |----|----------------|------|--------|------|----------|
-| P-006 | In-app bug reporting via `:bug` command — browser URL primary, PAT upgrade, file fallback | 2026-03-09 | Party mode (4 rounds: PM, Architect, UX, Dev) | [Party Mode](../../_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md), [Research](../../_bmad-output/planning-artifacts/in-app-bug-reporting-research.md) | Epic/story creation |
+| P-006 | In-app bug reporting via `:bug` command — browser URL primary, PAT upgrade, file fallback | 2026-03-09 | Party mode (4 rounds: PM, Architect, UX, Dev) | [Party Mode](../../_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md), [Research](../../_bmad-output/planning-artifacts/in-app-bug-reporting-research.md) | **Done** — Epic 50 created (3 stories) |
 | P-001 | Migrate from Makefile to Justfile | 2026-03-04 | Research spike | [Analysis](../../_bmad-output/planning-artifacts/makefile-vs-justfile-analysis.md) | Owner sign-off |
 | P-002 | Envoy three-layer firewall implementation | 2026-03-08 | Party mode (8 sessions) | [Artifact](../../_bmad-output/planning-artifacts/envoy-scope-and-firewall-design.md) | Story creation |
 | P-003 | GitHub issue labeling taxonomy and triage flow | 2026-03-08 | Party mode (5 sessions) | [Artifact](../../_bmad-output/planning-artifacts/issue-labeling-and-triage-strategy.md) | Story creation |
@@ -326,7 +326,8 @@
 | 46 | OAuth Device Code Flow | 2026-03-09 | Allocated (4 stories) |
 | 47 | Sync Lifecycle & Advanced Features | 2026-03-09 | Allocated (4 stories) |
 | 49 | ThreeDoors Doctor — Self-Diagnosis Command | 2026-03-10 | Allocated (10 stories) |
-| 50 | *(next available)* | — | — |
+| 50 | In-App Bug Reporting | 2026-03-10 | Allocated (3 stories) |
+| 51 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -624,7 +624,20 @@
 - **Research:** See `_bmad-output/planning-artifacts/data-source-setup-ux-research.md`
 - **Decisions:** D-151 (conflict resolution strategy)
 
-**Epic 50+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 50: In-App Bug Reporting** (P2)
+- **Goal:** Add a `:bug` command for frictionless in-app bug reporting with navigation breadcrumb trail, automatic environment context, mandatory preview, and tiered submission (browser URL, GitHub API, local file)
+- **Prerequisites:** None (standalone feature)
+- **Status:** Not Started
+- **Deliverables:**
+  - Ring buffer breadcrumb tracking (50 entries, view transitions + non-text keys, privacy-safe)
+  - Bug report view with text description input, environment summary, and mandatory preview
+  - Three submission paths: browser URL (zero-auth), GitHub API (PAT upgrade), local file (offline)
+  - Strict privacy allowlist at capture level — task content, search queries, and personal data never collected
+- **Stories:** 50.1-50.3 (3 stories)
+- **Research:** See `../../_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`, `../../_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`
+- **Decisions:** D-112 (browser URL primary), D-113 (ring buffer), D-114 (allowlist privacy), D-115 (mandatory preview), D-116 (hardcoded target repo)
+
+**Epic 51+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -685,5 +698,6 @@
 | Epic 47: Sync Lifecycle & Advanced Features | 4 | Not Started |
 | Epic 48: Door-Like Doors | 4 | Not Started |
 | Epic 49: ThreeDoors Doctor | 10 | Not Started |
-| **Total** | **261** | **146 complete, 4 epics in progress, 115 not started** |
+| Epic 50: In-App Bug Reporting | 3 | Not Started |
+| **Total** | **264** | **146 complete, 4 epics in progress, 118 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -4909,3 +4909,72 @@ GitHub Releases API with 24h cache. Channel-aware comparison. Opt-out controls. 
 ### Research
 
 - Doctor Research: `_bmad-output/planning-artifacts/threedoors-doctor-research.md`
+
+---
+
+## Epic 50: In-App Bug Reporting
+
+**Epic Goal:** Add a `:bug` command for frictionless in-app bug reporting with navigation breadcrumb trail, automatic environment context, mandatory preview, and tiered submission methods.
+
+**Prerequisites:** None (standalone feature)
+**Status:** Not Started
+**Priority:** P2
+
+### Overview
+
+When ThreeDoors users encounter a bug, reporting friction is high: leave the TUI, open browser, navigate to GitHub Issues, manually describe environment, reconstruct steps from memory. By step 3, most users give up. The `:bug` command makes bug reporting a natural part of the TUI conversation, aligned with SOUL.md's "friend helping you" philosophy.
+
+The implementation follows strict privacy principles: a ring buffer captures navigation breadcrumbs (view transitions, non-text keys, command names) in memory only. Text input (`tea.KeyRunes`) is never captured — the privacy firewall is at the capture level, not the report level. Users see a mandatory preview of exactly what will be sent before any data leaves their machine.
+
+### Stories
+
+#### Story 50.1: Breadcrumb Tracking System
+
+**Status:** Not Started
+**Priority:** P2
+**Depends On:** None
+**Effort:** Small
+
+Ring buffer breadcrumb system tracking the last 50 user navigation actions in memory. Captures view transitions, non-text key events, and command names (arguments stripped). Text input (`tea.KeyRunes`) is never recorded — this is the privacy firewall. Integrated at top of `MainModel.Update()`.
+
+**AC:** Ring buffer records view transitions with timestamps. Non-text keys recorded (`key:Enter`). Text input never captured. Commands recorded without args (`cmd:stats`). Buffer wraps at 50 entries. `Format()` returns chronological human-readable output.
+
+#### Story 50.2: Bug Report View & Environment Collection
+
+**Status:** Not Started
+**Priority:** P2
+**Depends On:** 50.1
+**Effort:** Medium
+
+New `ViewBugReport` mode with text description input, automatic environment data collection (version, OS, terminal, theme, task count — strict allowlist), breadcrumb trail integration, and mandatory preview screen. Wired via `:bug` command in `search_view.executeCommand()`.
+
+**AC:** `:bug` opens bug report view. Environment shows only allowlisted data. Blocklist disclaimer displayed. Enter shows full markdown preview. Esc cancels and returns to previous view. No task content, file paths, or personal data in output.
+
+#### Story 50.3: Submission Methods (Browser, API, File)
+
+**Status:** Not Started
+**Priority:** P2
+**Depends On:** 50.2
+**Effort:** Medium
+
+Three tiered submission methods from the preview screen: (1) Browser URL — opens GitHub issue creation with pre-filled title/body via URL query params, zero auth needed; (2) GitHub API — direct submission if `GITHUB_TOKEN` configured; (3) Local file — saves to `~/.threedoors/bug-reports/` as GitHub-flavored markdown. Error cascading between methods.
+
+**AC:** `[b]` opens browser with pre-filled issue URL. `[s]` (if token) creates issue via API, shows URL. `[f]` saves to `~/.threedoors/bug-reports/bug-<timestamp>.md`. Browser failure offers clipboard fallback. API failure offers browser/file alternatives. Success returns to previous view.
+
+### Design Decisions
+
+- D-112: Browser URL as primary bug report submission (zero-auth)
+- D-113: Ring buffer breadcrumbs (50 entries, count-bounded)
+- D-114: Allowlist-only privacy for bug reports (capture-level filtering)
+- D-115: Mandatory preview before bug report submission
+- D-116: Bug report target repo hardcoded to arcaven/ThreeDoors
+- X-059: Rejected OAuth device flow for bug report auth
+- X-060: Rejected gh CLI for bug report submission
+- X-061: Rejected time-bounded breadcrumb buffer
+- X-062: Rejected blocklist approach for bug report privacy
+- X-063: Rejected configurable target repo for bug reports
+
+### Research
+
+- Research: `_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`
+- Party Mode: `_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`

--- a/docs/stories/50.1.story.md
+++ b/docs/stories/50.1.story.md
@@ -1,0 +1,99 @@
+# Story 50.1: Breadcrumb Tracking System
+
+## Status: Not Started
+
+## Epic
+
+Epic 50: In-App Bug Reporting
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`
+- Party Mode: `_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`
+- Decisions: D-113 (ring buffer 50 entries), D-114 (allowlist at capture level)
+
+## Story
+
+As a user,
+I want ThreeDoors to track my recent navigation actions in memory,
+So that when I report a bug, the report includes context about what I was doing.
+
+## Background
+
+The breadcrumb system is a prerequisite for the `:bug` command (Story 50.2). It captures view transitions, non-text key events, and command names (without arguments) in a fixed-size ring buffer. The system runs in memory only — nothing is persisted, logged, or transmitted. The privacy firewall is at the capture level: `tea.KeyRunes` (text input) is never recorded, so even a bug in report generation cannot leak user text.
+
+Party mode confirmed (ARCH-4, DEV-1, DEV-2):
+- Ring buffer over time-bounded (fixed memory, simpler implementation)
+- Capture at top of `MainModel.Update()` (single integration point)
+- Never record `tea.KeyRunes` (allowlist, not blocklist)
+
+## Acceptance Criteria
+
+**Given** the TUI is running
+**When** the user navigates between views
+**Then** the `BreadcrumbTrail` records each view transition with timestamp
+
+**Given** the user presses non-text keys (Enter, Esc, arrows, Tab)
+**When** the key event is processed
+**Then** the breadcrumb trail records the key name (e.g., `"key:Enter"`)
+
+**Given** the user types text (task names, search queries)
+**When** `tea.KeyRunes` events are processed
+**Then** the breadcrumb trail does NOT record these events
+
+**Given** the user executes a command (e.g., `:stats`, `:add buy milk`)
+**When** the command is parsed
+**Then** the breadcrumb trail records only the command name (e.g., `"cmd:stats"`, `"cmd:add"`) — arguments are stripped
+
+**Given** the breadcrumb trail has 50 entries
+**When** a new event is recorded
+**Then** the oldest entry is overwritten (ring buffer behavior)
+**And** total memory usage remains constant
+
+**Given** the breadcrumb trail has entries
+**When** `Format()` is called
+**Then** entries are returned in chronological order as human-readable lines
+**And** each line includes UTC timestamp, view mode name, and action
+
+## Technical Notes
+
+- Create `internal/tui/breadcrumb.go` with `BreadcrumbTrail` type
+- `BreadcrumbEntry` struct: `ViewMode string`, `Action string`, `Timestamp time.Time`
+- Fixed array `[50]BreadcrumbEntry`, not slice — zero allocations after init
+- `Record(viewMode string, action string)` and `Format() string` methods
+- Integration point: top of `MainModel.Update()`, before the main switch
+- Capture points:
+  1. View transitions: when `m.viewMode` changes → `"view:<NewViewName>"`
+  2. Non-text keys: `tea.KeyMsg` where `msg.Type != tea.KeyRunes` → `"key:<keyname>"`
+  3. Command execution: in `executeCommand()` → `"cmd:<command>"` (name only)
+  4. Window resize: `tea.WindowSizeMsg` → `"resize:<w>x<h>"`
+- All timestamps in UTC per project convention
+
+## Tasks
+
+### Task 1: Define BreadcrumbTrail type in internal/tui/breadcrumb.go
+- `BreadcrumbCapacity` const = 50
+- `BreadcrumbEntry` struct with ViewMode, Action, Timestamp
+- `BreadcrumbTrail` struct with fixed array, head, count
+- `NewBreadcrumbTrail()` factory (returns value, not pointer — zero value useful)
+- `Record(viewMode, action string)` with ring buffer wrapping
+- `Format() string` producing human-readable chronological output
+
+### Task 2: Integrate into MainModel
+- Add `breadcrumbs BreadcrumbTrail` field to `MainModel`
+- Add `recordBreadcrumb(action string)` helper method
+- Call at top of `Update()` for key events (skip `tea.KeyRunes`)
+- Record view transitions when `m.viewMode` changes
+- Record command names (no args) in `executeCommand()`
+
+### Task 3: Tests
+- Table-driven tests for ring buffer: empty, partial fill, overflow, wrap-around
+- Privacy test: verify `tea.KeyRunes` events are not recorded
+- Format test: verify chronological ordering after wrap-around
+- Command stripping test: verify args are removed
+- Test `BreadcrumbCapacity` boundary (49th, 50th, 51st entry)
+- Run `go test -race ./internal/tui/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/50.2.story.md
+++ b/docs/stories/50.2.story.md
@@ -1,0 +1,109 @@
+# Story 50.2: Bug Report View & Environment Collection
+
+## Status: Not Started
+
+## Epic
+
+Epic 50: In-App Bug Reporting
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`
+- Party Mode: `_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`
+- Decisions: D-115 (mandatory preview), D-114 (allowlist privacy)
+
+## Story
+
+As a user who encounters a bug,
+I want to type `:bug` and describe what went wrong in a text input,
+So that I can report the issue with automatic environment context without leaving the TUI.
+
+## Background
+
+This story creates the `:bug` command and bug report view. The view collects a user-written description, gathers environment data (version, OS, terminal, theme, task count), includes breadcrumb trail from Story 50.1, and shows a mandatory preview of the full report before any submission. The preview screen shows exactly what will be sent — nothing hidden.
+
+Party mode confirmed (UX-1, UX-2):
+- Mandatory preview before any submission (SOUL.md trust alignment)
+- Explicit allowlist shown in view + blocklist disclaimer
+- Warm, friendly language (not corporate)
+
+## Acceptance Criteria
+
+**Given** the user is in any view
+**When** they type `:bug`
+**Then** the TUI switches to `ViewBugReport` mode showing a description input area
+
+**Given** the bug report view is shown
+**When** the user sees the environment summary
+**Then** it shows only allowlisted data: version, commit, build date, Go version, OS/arch, terminal size, current view, theme name, task count, provider count, session duration
+**And** a disclaimer states "No task names, content, or personal data will be included"
+
+**Given** the user has typed a description
+**When** they press Enter
+**Then** a preview screen shows the full markdown report (description + environment + breadcrumbs)
+**And** the user can review every line before proceeding
+
+**Given** the preview screen is shown
+**When** the user presses Esc
+**Then** they return to the description input (can edit further)
+
+**Given** the user is in the bug report view (description or preview)
+**When** they press Esc from the description input
+**Then** the bug report is cancelled and they return to their previous view
+
+**Given** the environment collection runs
+**When** it gathers data
+**Then** it NEVER includes: task names/content, file paths, provider names/config, search queries, text input, tag names, username/home directory, credentials, mood entries, values/goals
+
+## Technical Notes
+
+- Add `ViewBugReport` to ViewMode enum in `main_model.go`
+- Create `internal/tui/bug_report_view.go` with the view implementation
+- Create `internal/tui/bug_report.go` with `BugReport` struct and `CollectEnvironment()` function
+- Wire `:bug` command in `search_view.go:executeCommand()` switch
+- Use `textarea` from `charmbracelet/bubbles` for description input
+- Environment collection uses:
+  - `cli/version.go` build vars (Version, Commit, BuildDate)
+  - `runtime.GOOS`, `runtime.GOARCH`, `runtime.Version()`
+  - Terminal dimensions from `tea.WindowSizeMsg` (stored on model)
+  - Theme name from config
+  - Task count: `len(m.taskPool.Tasks())` (count only)
+  - Provider count from registry (count only)
+  - Session duration: `time.Since(m.sessionStart)`
+- Report format: GitHub-flavored markdown (renders on GitHub, works for all submission paths)
+- Scrub `os.UserHomeDir()` from any paths that might leak
+
+## Tasks
+
+### Task 1: Create BugReport type in internal/tui/bug_report.go
+- `BugReport` struct: Description, Environment, Breadcrumbs, Timestamp
+- `EnvironmentInfo` struct with all allowlisted fields
+- `CollectEnvironment()` function gathering safe data
+- `FormatMarkdown() string` producing the full GFM report
+- Path scrubbing helper to replace home directory with `~`
+
+### Task 2: Create bug report view in internal/tui/bug_report_view.go
+- Two sub-states: `bugReportInput` and `bugReportPreview`
+- Description input using `bubbles/textarea`
+- Environment summary displayed alongside input
+- Preview shows full formatted markdown (scrollable if long)
+- Privacy disclaimer text
+- Keybinding hints: `[Enter] Preview`, `[Esc] Cancel` / `[Esc] Back to edit`
+
+### Task 3: Wire into MainModel
+- Add `ViewBugReport` to ViewMode enum
+- Add `:bug` case to `executeCommand()` in `search_view.go`
+- Handle `ViewBugReport` in `MainModel.Update()` and `MainModel.View()`
+- Track `previousView` for returning after cancel
+
+### Task 4: Tests
+- `CollectEnvironment()` returns all expected fields
+- `FormatMarkdown()` produces valid markdown with all sections
+- Privacy verification: test that no blocklisted data appears in output
+- View state transitions: input → preview → back to input → cancel
+- `:bug` command wiring test
+- Run `go test -race ./internal/tui/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/50.3.story.md
+++ b/docs/stories/50.3.story.md
@@ -1,0 +1,127 @@
+# Story 50.3: Submission Methods (Browser, API, File)
+
+## Status: Not Started
+
+## Epic
+
+Epic 50: In-App Bug Reporting
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`
+- Party Mode: `_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`
+- Decisions: D-112 (browser URL primary), D-116 (hardcoded target repo)
+
+## Story
+
+As a user who has previewed their bug report,
+I want to choose how to submit it — browser, API, or local file,
+So that I can report bugs regardless of my GitHub setup or network connectivity.
+
+## Background
+
+This story adds three submission methods to the bug report preview screen (Story 50.2). The tiered approach ensures zero-config bug reporting for all users:
+
+1. **Browser URL (primary, zero-config):** Opens GitHub issue creation page with pre-filled title and body via URL query parameters. Uses whatever GitHub session the browser has. No auth needed.
+2. **GitHub API (automatic upgrade):** If `GITHUB_TOKEN` is configured (from Epic 26 or environment), offers direct API submission via `go-github` `Issues.Create()`. Seamless for power users.
+3. **Local file (offline fallback):** Saves the report as a timestamped markdown file in `~/.threedoors/bug-reports/`. Always available.
+
+Party mode confirmed (PM-1):
+- Browser URL as primary — zero-config, uses existing browser session
+- PAT as automatic upgrade when available
+- File save as offline fallback
+- Error cascading: API fail → offer browser, browser fail → offer clipboard/file
+
+## Acceptance Criteria
+
+**Given** the preview screen is showing the formatted report
+**When** the user presses `b`
+**Then** the default browser opens with a pre-filled GitHub issue creation URL
+**And** the URL targets `arcaven/ThreeDoors` with title and body as query parameters
+**And** the TUI shows "Opening GitHub in your browser..." confirmation
+
+**Given** the user has `GITHUB_TOKEN` configured
+**When** the preview screen is shown
+**Then** an additional option `[s] Submit via GitHub` is displayed
+**And** pressing `s` creates a GitHub issue via the API
+**And** the TUI shows the issue URL on success
+
+**Given** the user presses `f` on the preview screen
+**When** the save executes
+**Then** the report is saved to `~/.threedoors/bug-reports/bug-<RFC3339-timestamp>.md`
+**And** the directory is auto-created if it doesn't exist
+**And** the TUI shows "Report saved to ~/.threedoors/bug-reports/..." confirmation
+
+**Given** browser launch fails
+**When** the error is caught
+**Then** the TUI offers to copy the URL to clipboard as fallback
+**And** the user can still choose file save
+
+**Given** API submission fails
+**When** the error is caught
+**Then** the TUI shows the error and offers browser or file save as alternatives
+
+**Given** the submission succeeds (any method)
+**When** the user presses any key
+**Then** they return to their previous view before `:bug`
+
+## Technical Notes
+
+- Add submission handling to `bug_report_view.go` preview state
+- Browser URL construction in `internal/tui/bug_report.go`:
+  - Format: `https://github.com/arcaven/ThreeDoors/issues/new?title=...&body=...&labels=type.bug`
+  - URL-encode body using `net/url.QueryEscape()`
+  - Truncate breadcrumbs if total URL > 7500 chars (conservative browser limit)
+- Platform-specific browser launch:
+  - macOS: `exec.Command("open", url)`
+  - Linux: `exec.Command("xdg-open", url)`
+  - Use `runtime.GOOS` to select
+- GitHub API submission:
+  - Check for existing `GitHubClient` or `GITHUB_TOKEN` env var
+  - Add `CreateIssue(ctx, title, body string) (*Issue, error)` to `GitHubClient`
+  - Use `go-github` `Issues.Create()` method
+- Local file save:
+  - Directory: `~/.threedoors/bug-reports/` (create with `0o700` per security standards)
+  - File: `bug-<RFC3339>.md` with `0o600` permissions
+  - Use atomic write pattern (write-to-tmp, sync, rename)
+- All operations via `tea.Cmd` (no blocking I/O in Update loop)
+- Warm language: "Report saved to..." not "Error report archived to..."
+
+## Tasks
+
+### Task 1: Browser URL submission
+- `BuildIssueURL(report BugReport) string` function
+- URL encoding with `net/url`
+- Truncation strategy for long reports (drop oldest breadcrumbs first)
+- Platform-specific `openBrowser(url string) tea.Cmd`
+- Clipboard fallback using `exec.Command("pbcopy")` on macOS
+
+### Task 2: GitHub API submission
+- Add `CreateIssue(ctx context.Context, title, body string) (*github.Issue, error)` to `GitHubClient`
+- Check token availability before showing option
+- Submit as `tea.Cmd` (async, non-blocking)
+- Display created issue URL on success
+
+### Task 3: Local file save
+- `SaveBugReport(report BugReport) tea.Cmd`
+- Auto-create `~/.threedoors/bug-reports/` directory (`0o700`)
+- Atomic write with `0o600` permissions
+- RFC3339 timestamp in filename (colons replaced with hyphens for filesystem safety)
+
+### Task 4: Wire submission into preview view
+- Add `[b] Open in browser`, `[s] Submit via GitHub` (conditional), `[f] Save to file` keys
+- Success/error feedback messages with warm language
+- Error cascading: API fail → offer browser → offer file
+- Return to previous view after any successful submission
+
+### Task 5: Tests
+- URL construction: verify encoding, label inclusion, truncation
+- File save: verify path, permissions, content matches report
+- API submission: mock `GitHubClient`, verify issue creation
+- Error cascading: mock failures, verify fallback flow
+- Browser launch: verify platform-specific command selection
+- Run `go test -race ./internal/tui/...`
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

- Creates **Epic 50: In-App Bug Reporting** with 3 stories based on completed party mode research (P-006)
- Story 50.1: Breadcrumb Tracking System — ring buffer (50 entries), view transitions + non-text keys, privacy-safe capture
- Story 50.2: Bug Report View & Environment Collection — `:bug` command, strict allowlist, mandatory preview
- Story 50.3: Submission Methods — browser URL (zero-auth primary), GitHub API (PAT upgrade), local file (offline fallback)
- Updates all planning docs: ROADMAP.md, epic-list.md, epics-and-stories.md, BOARD.md

## Context

Based on 4-round party mode (PM, Architect, UX Designer, Dev) documented in:
- `_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`
- `_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`

Decisions D-112 through D-116, rejected options X-059 through X-063 were already recorded by the research phase. This PR converts P-006 from "Awaiting epic/story creation" to "Done — Epic 50 created (3 stories)".

## Opportunities (not implemented)

- Future `:bug-submit` command to batch-submit saved local reports
- Clipboard integration for URL copy when browser launch fails (noted in Story 50.3 but scoped as part of that story)

## Test plan

- [ ] Verify story files follow project template format
- [ ] Verify ROADMAP.md epic entry matches epic-list.md and epics-and-stories.md
- [ ] Verify BOARD.md epic registry shows Epic 50 allocated
- [ ] Verify P-006 status updated to "Done"
- [ ] Verify decision references in story files match existing D-112 through D-116