### PR TITLE
docs: Epic 51 — SLAES stories and planning docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -259,6 +259,27 @@ In-app `:bug` command for frictionless bug reporting without leaving the TUI. Br
 | 40 | Beautiful Stats Display | 10/10 |
 | 41 | Charm Ecosystem Adoption & TUI Polish | 6/6 |
 
+### Epic 51: SLAES — Self-Learning Agentic Engineering System (P1) — 0/10 stories done
+
+Continuous improvement meta-system with a persistent `retrospector` agent that monitors PR merges, detects process waste, audits doc consistency, and files improvement recommendations to BOARD.md. Dual-loop architecture: spec-chain quality (did we build the right thing?) and operational efficiency (are we building efficiently?).
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 51.1 | Retrospector Agent Definition (Responsibility+WHY Format) | Not Started | P1 | None |
+| 51.2 | Rewrite Operational Agent Definitions (Responsibility+WHY Format) | Not Started | P1 | None |
+| 51.3 | JSONL Findings Log & Per-Merge Lightweight Retro | Not Started | P1 | 51.1 |
+| 51.4 | Saga Detection (Dispatch Waste Alerting) | Not Started | P1 | 51.1 |
+| 51.5 | Doc Consistency Audit (Periodic Cross-Check) | Not Started | P1 | 51.1 |
+| 51.6 | BOARD.md Recommendation Pipeline | Not Started | P1 | 51.3, 51.4, 51.5 |
+| 51.7 | Merge Conflict Rate Analysis | Not Started | P2 | 51.3, 51.6 |
+| 51.8 | CI Failure Rate Analysis & Coding Standard Proposals | Not Started | P2 | 51.3, 51.6 |
+| 51.9 | Research Lifecycle Tracking | Not Started | P2 | 51.3, 51.6 |
+| 51.10 | PR Creation Authority & Trend Reporting | Not Started | P2 | 51.1-51.9 |
+
+**Phasing:** Phase 0 (stories 51.1-51.2): Bootstrap — rewrite agent definitions. Phase 1 (stories 51.3-51.6): MVP monitoring. Phase 2 (stories 51.7-51.10): Advanced analysis after 2 weeks of MVP validation.
+
+**Dependency graph:** Stories 51.1 & 51.2 can parallelize. Stories 51.3-51.5 can parallelize after 51.1. Story 51.6 depends on 51.3-51.5. Phase 2 stories depend on Phase 1 validation.
+
 ## Icebox (Deferred Indefinitely)
 
 | Epic | Title | Stories | Decision Date | Rationale |

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -637,7 +637,20 @@
 - **Research:** See `../../_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`, `../../_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`
 - **Decisions:** D-112 (browser URL primary), D-113 (ring buffer), D-114 (allowlist privacy), D-115 (mandatory preview), D-116 (hardcoded target repo)
 
-**Epic 51+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 51: SLAES — Self-Learning Agentic Engineering System** (P1)
+- **Goal:** Build a continuous improvement meta-system with a persistent `retrospector` agent that monitors PR merges, detects process waste (saga patterns), audits doc consistency, analyzes CI/conflict patterns, and files improvement recommendations to BOARD.md. Dual-loop architecture: spec-chain quality and operational efficiency.
+- **Prerequisites:** Epic 37 (Persistent BMAD Agents — complete)
+- **Status:** Not Started
+- **Deliverables:**
+  - Phase 0: Retrospector agent definition in responsibility+WHY format; rewrite 5 operational agent definitions with incident-hardened guardrails
+  - Phase 1 (MVP): JSONL findings log with per-merge lightweight retro, saga detection (2+ workers on same fix), doc consistency audit (periodic cross-check of planning docs), BOARD.md recommendation pipeline with confidence scoring
+  - Phase 2: Merge conflict rate analysis (hot files, parallelization safety), CI failure taxonomy and spec-chain tracing, research lifecycle tracking, PR creation authority, weekly trend reporting
+  - 5 Watchmen safeguards: no self-modification, audit trail, confidence scoring, periodic human review, kill switch (3 rejections → read-only)
+- **Stories:** 51.1-51.10 (10 stories)
+- **Research:** See `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md`, `_bmad-output/planning-artifacts/subagent-abuse-investigation.md`
+- **Decisions:** D-1 (single agent), D-2 (SLAES/retrospector naming), D-3 (persistent 15-min polling), D-4 (Level 2 authority), D-5 (consumer model), D-6 (dual-loop), D-7 (per-PR + batch), D-8 (5 Watchmen safeguards), D-9 (mode rotation), D-10 (responsibility+WHY definitions)
+
+**Epic 52+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -699,5 +712,6 @@
 | Epic 48: Door-Like Doors | 4 | Not Started |
 | Epic 49: ThreeDoors Doctor | 10 | Not Started |
 | Epic 50: In-App Bug Reporting | 3 | Not Started |
-| **Total** | **264** | **146 complete, 4 epics in progress, 118 not started** |
+| Epic 51: SLAES | 10 | Not Started |
+| **Total** | **274** | **146 complete, 4 epics in progress, 128 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -4978,3 +4978,105 @@ Three tiered submission methods from the preview screen: (1) Browser URL — ope
 
 - Research: `_bmad-output/planning-artifacts/in-app-bug-reporting-research.md`
 - Party Mode: `_bmad-output/planning-artifacts/in-app-bug-reporting-party-mode.md`
+
+---
+
+## Epic 51: SLAES — Self-Learning Agentic Engineering System (P1)
+
+**Goal:** Build a continuous improvement meta-system with a persistent `retrospector` agent that monitors PR merges, detects process waste, audits doc consistency, analyzes CI/conflict patterns, and files improvement recommendations to BOARD.md.
+
+**Prerequisites:** Epic 37 (Persistent BMAD Agents — complete)
+
+**Status:** Not Started (0/10 stories)
+
+**Phasing:**
+- Phase 0 (Bootstrap): Stories 51.1-51.2 — Agent definition rewrites
+- Phase 1 (MVP): Stories 51.3-51.6 — Core monitoring and recommendations
+- Phase 2 (After 2-week validation): Stories 51.7-51.10 — Advanced analysis and PR creation
+
+### Stories
+
+#### Story 51.1: Retrospector Agent Definition (Responsibility+WHY Format)
+
+Create `agents/retrospector.md` — the SLAES primary agent — using responsibility+WHY format from day one. Persistent agent with 15-minute polling, Level 2 authority (read + BOARD.md for MVP), dual-loop architecture, 5 Watchmen safeguards, and context exhaustion mitigation.
+
+**AC:** Definition uses responsibility+WHY format (no procedural instructions). Incident-hardened guardrails reference INC-001/002/003. Includes authority table (CAN/CANNOT), operational mode rotation, self-restart trigger (20 PRs or 8 hours), consumer model for project-watchdog/arch-watchdog interaction.
+
+#### Story 51.2: Rewrite Operational Agent Definitions (Responsibility+WHY Format)
+
+Rewrite 5 operational agent definitions (merge-queue, pr-shepherd, worker, project-watchdog, supervisor) in responsibility+WHY format with incident-hardened guardrails. Phase 0 bootstrap task.
+
+**AC:** All 5 definitions rewritten with WHY rationale and incident citations. merge-queue owns merge integrity. pr-shepherd has INC-001 isolation guardrail. worker has INC-002 no-manual-sync guardrail. project-watchdog has INC-003 mutex guardrail. supervisor has subagent abuse guardrail. All agents restarted and verified operational.
+
+#### Story 51.3: JSONL Findings Log & Per-Merge Lightweight Retro
+
+Implement the data collection foundation: every merged PR generates a JSONL entry with AC match checking, CI first-pass rate, conflict data, and rebase count. Rolling retention with archival.
+
+**AC:** Per-PR JSONL entries appended on merge detection. Fields: pr, story, ac_match (full/partial/none/no-story), ci_first_pass, conflicts, rebase_count, timestamp. Rolling retention at 1000 entries with monthly archive. Idempotent processing with last_processed_pr marker.
+
+#### Story 51.4: Saga Detection (Dispatch Waste Alerting)
+
+Detect when 2+ workers are dispatched for the same fix within 4 hours. Alert supervisor with failure chain analysis and recommended action.
+
+**AC:** Same-branch dispatch detection within 4-hour window. Supervisor alert with branch name, worker names, failure chain. Escalation trap pattern detection (fix-A-break-B chain). JSONL logging with type "saga_detected". Recurrence tracking with BOARD.md recommendation after 3+ occurrences.
+
+#### Story 51.5: Doc Consistency Audit (Periodic Cross-Check)
+
+Periodically cross-check epic-list, epics-and-stories, ROADMAP, and story files for drift. Runs as a rotating deep analysis mode every 4 hours.
+
+**AC:** Detects status mismatches across all 4 planning doc layers. Detects orphaned stories and ghost entries. Messages supervisor only on inconsistencies (no noise on clean runs). JSONL logging with type "doc_inconsistency" or "doc_audit_clean". Runs in 4-hour rotation with other deep analysis modes.
+
+#### Story 51.6: BOARD.md Recommendation Pipeline
+
+Unified output layer: aggregate findings into BOARD.md recommendations with confidence scoring (High/Medium/Low), evidence trails, and kill switch safeguard.
+
+**AC:** Recommendations filed in BOARD.md "Pending Recommendations" section with auto-assigned P-NNN ID. Confidence scoring: High (5+ data points), Medium (2-4), Low (1). Kill switch: 3 consecutive rejections → read-only mode. Rate-limited to 3 recommendations per batch cycle.
+
+#### Story 51.7: Merge Conflict Rate Analysis (Phase 2)
+
+Analyze merge conflict patterns: hot file detection, epic collision zones, parallel dispatch safety scoring, rebase churn analysis.
+
+**AC:** Hot file detection (3+ concurrent PRs). Epic collision zone identification. Rebase churn flagging (3+ rebases). BOARD.md recommendations with specific file paths and sequencing suggestions. Depends on Phase 1 validation.
+
+#### Story 51.8: CI Failure Rate Analysis & Coding Standard Proposals (Phase 2)
+
+Classify CI failures by taxonomy (race condition, lint, flakiness, build, coverage) and trace to fixable spec-chain layer. Propose CLAUDE.md rule changes and coding standard updates.
+
+**AC:** Failure taxonomy classification. Spec-chain layer tracing (Code → Story → PRD → Architecture → CLAUDE.md). Pattern detection across 3+ PRs triggers BOARD.md recommendation. Unclassified failures flagged for human review. Depends on Phase 1 validation.
+
+#### Story 51.9: Research Lifecycle Tracking (Phase 2)
+
+Track research artifacts through lifecycle: active → formalized → stale → abandoned. Alert on unformalized research older than 2 weeks.
+
+**AC:** Scan `_bmad-output/planning-artifacts/`. Classify by lifecycle state. Flag stale research (>2 weeks, no stories). Report total/active/formalized/stale counts. Depends on Phase 1 validation.
+
+#### Story 51.10: PR Creation Authority & Trend Reporting (Phase 2)
+
+Expand retrospector authority to create PRs proposing improvements. Generate weekly trend reports with project health metrics.
+
+**AC:** PR creation on `slaes/` branches for high-confidence recommendations pending >48 hours. Self-modification safeguard (never touch own definition). Weekly trend report with CI first-pass rate, rebase count, saga count, recommendation acceptance rate. Metric regression detection. Depends on all Phase 1 + Phase 2 stories.
+
+### Design Decisions
+
+- D-1: Single agent (not 3 separate agents) — avoids pushing agent count to 8
+- D-2: System name SLAES, agent name `retrospector`
+- D-3: Persistent agent with 15-minute polling (not 5-minute, not cron)
+- D-4: Level 2 authority (read + propose, not read-only or auto-apply)
+- D-5: Consumer model — consumes project-watchdog/arch-watchdog outputs, never duplicates
+- D-6: Dual-loop architecture (spec-chain quality + operational efficiency)
+- D-7: Per-PR lightweight data collection + periodic batch analysis
+- D-8: 5 Watchmen safeguards (no self-mod, audit trail, confidence scoring, human review, kill switch)
+- D-9: Operational mode rotation for context management
+- D-10: Prevention over detection — responsibility+WHY definition methodology
+- X-A1: Rejected three focused agents (agent count → 8)
+- X-A2: Rejected two agents (duplicate analytical pipeline)
+- X-A3: Rejected `kaizen-agent` name (potentially pretentious)
+- X-A9: Rejected ephemeral/cron-based (loses state, saga detection needs continuity)
+- X-A10: Rejected 5-minute polling (unnecessary, budget impact)
+- X-A12: Rejected read-only recommend-only (advisory doesn't work — registry precedent)
+- X-A13: Rejected auto-apply (INC-001 precedent)
+
+### Research
+
+- SLAES Party Mode: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md`
+- Subagent Abuse Investigation: `_bmad-output/planning-artifacts/subagent-abuse-investigation.md`

--- a/docs/stories/51.1.story.md
+++ b/docs/stories/51.1.story.md
@@ -1,0 +1,90 @@
+# Story 51.1: Retrospector Agent Definition (Responsibility+WHY Format)
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md`
+- Research: `_bmad-output/planning-artifacts/subagent-abuse-investigation.md`
+- Decisions: D-1 through D-10 in party mode artifact
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector agent defined in responsibility+WHY format from day one,
+So that it self-corrects in novel situations rather than following procedural steps blindly.
+
+## Background
+
+The SLAES party mode (7 agents, 5 rounds) designed a new persistent agent called `retrospector` that monitors PR merges, detects process waste, audits doc consistency, and files improvement recommendations. Decision D-10 established that agent definitions should use a responsibility+WHY format (not procedural) to prevent incidents like INC-001/002/003.
+
+The retrospector is a persistent agent with 15-minute polling, Level 2 authority (read + BOARD.md recommendations for MVP), and dual-loop architecture (spec-chain quality + operational efficiency).
+
+## Acceptance Criteria
+
+**Given** the file `agents/retrospector.md` is created
+**When** reviewed against the responsibility+WHY methodology
+**Then** each section states WHAT the agent owns and WHY it owns it
+**And** incident-hardened guardrails reference specific INC-NNN incidents
+**And** no procedural "do X then Y" instructions exist
+
+**Given** the retrospector definition exists
+**When** the agent is spawned via `multiclaude agents spawn`
+**Then** it starts its 15-minute polling loop
+**And** it can read any file in the repo via standard tools
+**And** it can write to `docs/decisions/BOARD.md` (recommendations section only)
+**And** it can message the supervisor
+
+**Given** the Watchmen safeguards are defined
+**When** the agent attempts to modify its own definition
+**Then** the definition explicitly forbids self-modification
+**And** the confidence scoring system (High/Medium/Low) is documented
+**And** the self-restart trigger (20 PRs or 8 hours) is defined
+
+**Given** the interaction model is defined
+**When** retrospector receives events from project-watchdog or arch-watchdog
+**Then** it consumes their outputs without duplicating their work
+**And** the consumer model is clearly documented
+
+## Technical Notes
+
+- Create `agents/retrospector.md` using responsibility+WHY format
+- Define operational modes: post-merge retro, deep analysis (rotating), saga detection
+- Define authority boundaries per the party mode D-4 decision (MVP: read + BOARD.md only)
+- Define the 5 Watchmen safeguards from D-8
+- Define context exhaustion mitigation from D-9
+- Reference JSONL findings log schema from D-7
+- MVP authority subset: Read + BOARD.md recommendations + supervisor messages (no PR creation)
+
+## Tasks
+
+### Task 1: Draft retrospector.md agent definition
+- Responsibility sections with WHY rationale
+- Authority boundary table (CAN/CANNOT)
+- Incident guardrail clauses citing INC-001, INC-002, INC-003
+- Operational mode rotation schedule
+- Context exhaustion and restart protocol
+
+### Task 2: Define JSONL findings log schema
+- Per-PR entry format (pr, story, ac_match, ci_first_pass, conflicts, rebase_count, timestamp)
+- Location: `docs/operations/retrospector-findings.jsonl` (proposed)
+- Rolling retention policy
+
+### Task 3: Define interaction protocols
+- Consumer model: how retrospector reads from project-watchdog and arch-watchdog
+- Message protocol: when and how to alert supervisor
+- BOARD.md write format: recommendation entries with confidence scores
+
+### Task 4: Review and validation
+- Verify no procedural instructions leaked in
+- Verify all 5 Watchmen safeguards are present
+- Verify authority boundaries match D-4 MVP subset
+- Verify compatibility with existing persistent agent spawn workflow
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.10.story.md
+++ b/docs/stories/51.10.story.md
@@ -1,0 +1,64 @@
+# Story 51.10: PR Creation Authority & Trend Reporting
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (Phase 2, items 9-10)
+- Depends on: All Phase 1 stories (51.1-51.6) validated, Phase 2 stories (51.7-51.9)
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to create PRs proposing improvements and generate periodic trend reports,
+So that SLAES recommendations are actionable without manual intervention and project health is visible over time.
+
+## Background
+
+Phase 2 feature. After MVP validation, the retrospector's authority expands from "read + BOARD.md recommendations" to "read + BOARD.md + create PRs." This enables it to propose CLAUDE.md rule changes, story template updates, and agent definition improvements as reviewable PRs. Additionally, it generates periodic "Continuous Improvement Reports" with project health metrics and trend data.
+
+## Acceptance Criteria
+
+**Given** the retrospector has a high-confidence recommendation
+**When** the recommendation involves a specific file change (CLAUDE.md rule, story template, etc.)
+**Then** it creates a PR with the proposed change on a `slaes/` prefixed branch
+**And** the PR description includes: recommendation ID, confidence score, evidence, rationale
+**And** the PR is NOT auto-merged (merge-queue handles merge)
+
+**Given** the retrospector creates a PR
+**When** the PR modifies agent definitions
+**Then** it NEVER modifies its own definition (Watchmen safeguard #1)
+**And** the PR description notes which agents need restart after merge
+
+**Given** a reporting cycle completes (weekly)
+**When** the retrospector generates a trend report
+**Then** it includes: PRs merged this period, CI first-pass rate trend, average rebase count trend, saga count, doc consistency score, recommendation acceptance rate
+**And** the report is saved to `docs/operations/slaes-report-YYYY-WNN.md`
+
+**Given** the trend report shows declining metrics
+**When** a metric drops below its 4-week average
+**Then** the report highlights the regression with possible causes
+
+## Technical Notes
+
+- PR creation via `gh pr create` on `slaes/<recommendation-id>` branches
+- Self-modification check: if PR touches `agents/retrospector.md`, abort and alert supervisor
+- Trend report aggregates JSONL findings log data
+- Report format: markdown with inline metrics, no charts (terminal-friendly)
+- Weekly cadence via the rotation scheduler
+- PR creation is gated: only for High-confidence recommendations that have been pending >48 hours without human action
+
+## Tasks
+
+### Task 1: Implement PR creation workflow
+### Task 2: Implement self-modification safeguard
+### Task 3: Implement weekly trend report generation
+### Task 4: Implement metric regression detection
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.2.story.md
+++ b/docs/stories/51.2.story.md
@@ -1,0 +1,105 @@
+# Story 51.2: Rewrite Operational Agent Definitions (Responsibility+WHY Format)
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (D-10)
+- Research: `_bmad-output/planning-artifacts/subagent-abuse-investigation.md`
+- Incidents: INC-001 (pr-shepherd contamination), INC-002 (cargo-culted git rebase), INC-003 (Epic 42 collision)
+
+## Story
+
+As a multiclaude operator,
+I want all 5 operational agent definitions rewritten in responsibility+WHY format,
+So that agents self-correct in novel situations and prevent repeat incidents.
+
+## Background
+
+Decision D-10 from the SLAES party mode established that procedural agent definitions cause incidents. Three incidents (INC-001: pr-shepherd contamination, INC-002: cargo-culted git rebase in workers, INC-003: Epic 42 number collision) were all preventable with responsibility+WHY definitions that include incident-hardened guardrails.
+
+Priority order: merge-queue → pr-shepherd → worker → project-watchdog → supervisor.
+
+This is Phase 0 — a bootstrap task before SLAES monitoring begins.
+
+## Acceptance Criteria
+
+**Given** the 5 agent definitions are rewritten
+**When** reviewed against the responsibility+WHY methodology
+**Then** each states WHAT the agent owns and WHY
+**And** each includes incident-hardened guardrails citing specific INC-NNN incidents
+**And** no procedural "do X then Y" instructions exist
+
+**Given** the merge-queue definition is rewritten
+**When** it encounters a novel merge scenario
+**Then** it can reason from its responsibility ("you own merge integrity because...") rather than following a script
+
+**Given** the pr-shepherd definition is rewritten
+**When** it operates in the shared checkout
+**Then** it has explicit isolation requirements citing INC-001
+**And** worktree contamination risk is documented in the WHY
+
+**Given** the worker definition is rewritten
+**When** a worker starts in a fresh worktree
+**Then** it does NOT run manual git sync (citing INC-002 and multiclaude worktree model)
+**And** the WHY explains that multiclaude manages worktrees automatically
+
+**Given** the project-watchdog definition is rewritten
+**When** concurrent epic number requests arrive
+**Then** the mutex responsibility is explicit with INC-003 citation
+
+**Given** all agents are restarted after rewrite
+**When** they resume operations
+**Then** behavior is unchanged or improved (no regressions)
+
+## Technical Notes
+
+- Rewrite `agents/merge-queue.md` — owns merge integrity, scope checking, CI verification
+- Rewrite `agents/pr-shepherd.md` — owns branch health, rebase, conflict resolution (INC-001 guardrail)
+- Rewrite `agents/worker.md` — owns story implementation in isolated worktrees (INC-002 guardrail)
+- Rewrite `agents/project-watchdog.md` — owns epic/story number mutex, doc consistency (INC-003 guardrail)
+- Rewrite `agents/supervisor.md` — owns coordination, dispatch, escalation
+- Each definition must include: responsibility statement, WHY rationale, authority table, incident guardrails, interaction protocols
+- Agents must be restarted after rewrite (definitions are baked in at spawn time)
+- Run `/sync-enhancements` after merge to propagate improved templates
+
+## Tasks
+
+### Task 1: Rewrite merge-queue.md
+- Responsibility: merge integrity, scope checking, CI verification
+- WHY: unchecked merges introduce scope creep and broken builds
+- Guardrails: OAuth workflow scope limitation, scope rejection protocol
+
+### Task 2: Rewrite pr-shepherd.md
+- Responsibility: branch health, rebase, conflict resolution
+- WHY: stale branches cause merge cascades and CI churn
+- Guardrail: INC-001 — never modify git state outside assigned branch context
+
+### Task 3: Rewrite worker.md
+- Responsibility: story implementation in isolated worktrees
+- WHY: workers produce code artifacts that must be reviewable and mergeable
+- Guardrail: INC-002 — never run manual git sync (multiclaude manages worktrees)
+
+### Task 4: Rewrite project-watchdog.md
+- Responsibility: epic/story number mutex, planning doc consistency
+- WHY: concurrent number allocation causes collision cascades
+- Guardrail: INC-003 — serialize all number allocations through single chokepoint
+
+### Task 5: Rewrite supervisor.md
+- Responsibility: coordination, dispatch, escalation, never execution
+- WHY: supervisor executing fixes bypasses review and creates invisible changes
+- Guardrail: subagent abuse policy (no research via Agent tool)
+
+### Task 6: Validation and restart
+- Review all 5 definitions for procedural leaks
+- Restart all persistent agents
+- Verify operations resume normally
+- Document any behavioral changes observed
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.3.story.md
+++ b/docs/stories/51.3.story.md
@@ -1,0 +1,88 @@
+# Story 51.3: JSONL Findings Log & Per-Merge Lightweight Retro
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (D-7)
+- Depends on: Story 51.1
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to collect structured data on every PR merge,
+So that patterns can be detected in batch analysis rather than relying on manual observation.
+
+## Background
+
+Decision D-7 established a dual approach: lightweight per-PR data collection feeding periodic batch analysis. Every merged PR generates a JSONL entry with AC match checking, CI first-pass rate, mid-PR correction detection, and conflict data. This is the data foundation for all SLAES analysis.
+
+## Acceptance Criteria
+
+**Given** a PR merges to main
+**When** the retrospector detects it (via `gh pr list --state merged` polling)
+**Then** it creates a JSONL entry with: pr number, story reference, ac_match (full/partial/none/no-story), ci_first_pass (bool), conflicts count, rebase_count, timestamp
+**And** the entry is appended to the findings log
+
+**Given** the findings log exists
+**When** it grows beyond 1000 entries
+**Then** older entries are archived (not deleted) to a dated archive file
+**And** the active log is truncated to the most recent 500 entries
+
+**Given** a PR has a story reference (e.g., "Story 43.1" in commit message)
+**When** the retrospector runs AC match checking
+**Then** it compares changed files against the story's task list
+**And** records match level: full (all tasks addressed), partial (some missing), none (no overlap)
+
+**Given** a PR has no story reference
+**When** the retrospector processes it
+**Then** it records ac_match as "no-story" without failing
+**And** flags it as a potential process gap (infra/docs PRs exempt)
+
+**Given** the retrospector polls for merged PRs
+**When** it finds PRs merged since its last check
+**Then** it processes each one in chronological order
+**And** records a `last_processed_pr` marker to avoid reprocessing
+
+## Technical Notes
+
+- JSONL log location: `docs/operations/retrospector-findings.jsonl`
+- Use `gh pr list --state merged --json number,title,mergedAt,files,labels` for data
+- Use `gh pr view <N> --json commits` to extract story references from commit messages
+- AC match requires reading story files from `docs/stories/` and comparing task lists to PR file changes
+- CI first-pass: check if the first CI run on the PR passed (vs required fix commits)
+- Rebase count: count force-push events on the PR branch
+- Archive location: `docs/operations/archive/retrospector-findings-YYYY-MM.jsonl`
+
+## Tasks
+
+### Task 1: Implement PR merge detection polling
+- Poll `gh pr list --state merged` every 15 minutes
+- Track `last_processed_pr` in a state file
+- Process new merges in chronological order
+
+### Task 2: Implement JSONL entry generation
+- Extract PR metadata (files, commits, labels, CI status)
+- Parse story reference from commit messages
+- Calculate AC match level by comparing PR files to story tasks
+- Detect CI first-pass rate from check runs
+- Count rebase/force-push events
+
+### Task 3: Implement findings log management
+- Append entries to JSONL log
+- Rolling retention: archive when >1000 entries
+- Archive naming convention with monthly rotation
+
+### Task 4: Tests and validation
+- Test JSONL schema with sample entries
+- Test AC match algorithm with mock story files
+- Test archive rotation logic
+- Verify retrospector processes PRs idempotently
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.4.story.md
+++ b/docs/stories/51.4.story.md
@@ -1,0 +1,82 @@
+# Story 51.4: Saga Detection (Dispatch Waste Alerting)
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (D-9, Saga Detection section)
+- Depends on: Story 51.1
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to detect when multiple workers are dispatched for the same fix,
+So that I can intervene before an escalation trap wastes worker cycles.
+
+## Background
+
+Process waste sagas occur when Worker 1 fails, Worker 2 fixes A but breaks B, Worker 3 fixes B but breaks C, etc. The SLAES party mode identified this pattern (the "escalation trap") and designed a saga detection system. The retrospector monitors worker dispatch patterns and alerts when thresholds are breached.
+
+From PR #431 analysis: insufficient pre-flight checks, narrow fix scope, and no escalation protocol are root causes.
+
+## Acceptance Criteria
+
+**Given** 2+ workers are dispatched to fix CI on the same branch/PR within 4 hours
+**When** the retrospector detects this pattern
+**Then** it sends an alert to the supervisor with: branch name, worker names, failure chain analysis
+**And** it recommends: targeted fix, revert-and-reimplement, or escalate
+**And** it logs the saga to the findings JSONL with type "saga_detected"
+
+**Given** a saga is detected
+**When** the retrospector analyzes the failure chain
+**Then** it identifies whether failures are related or independent
+**And** it proposes a coding standard or worker instruction to prevent the pattern
+
+**Given** the escalation trap pattern is detected (fix-A-break-B-fix-B-break-C)
+**When** the retrospector reports to the supervisor
+**Then** the report includes the full chain with specific file/test references
+**And** suggests root cause analysis before further fix attempts
+
+**Given** saga tallies are tracked
+**When** the same pattern recurs 3+ times across different PRs
+**Then** the retrospector files a BOARD.md recommendation proposing a systemic fix
+**And** the recommendation includes confidence score and evidence count
+
+## Technical Notes
+
+- Monitor worker dispatch via `multiclaude worker list` polling
+- Track worker-to-branch mapping over time
+- Detect same-branch dispatch within 4-hour window
+- Analyze CI failure logs via `gh run list` and `gh run view`
+- Saga detection is threshold-based: 2 workers = alert, 3+ = escalation trap warning
+- Tally persistence: append to JSONL findings log with saga-specific fields
+
+## Tasks
+
+### Task 1: Implement worker dispatch tracking
+- Poll `multiclaude worker list` for active workers
+- Build worker-to-branch mapping with timestamps
+- Detect same-branch overlaps within 4-hour window
+
+### Task 2: Implement saga detection logic
+- Threshold: 2+ workers on same branch within 4 hours
+- Classify: related failures vs independent failures
+- Identify escalation trap pattern (sequential fix-break chain)
+
+### Task 3: Implement alerting and recommendations
+- Message supervisor with structured saga alert
+- Include failure chain analysis and recommended action
+- Log to JSONL with saga-specific fields
+
+### Task 4: Implement recurrence tracking
+- Track saga patterns across PRs
+- File BOARD.md recommendation when pattern recurs 3+ times
+- Include confidence score based on evidence count
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.5.story.md
+++ b/docs/stories/51.5.story.md
@@ -1,0 +1,83 @@
+# Story 51.5: Doc Consistency Audit (Periodic Cross-Check)
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (D-6, D-9)
+- Depends on: Story 51.1
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to periodically verify planning doc consistency,
+So that drift between story files, epic-list, epics-and-stories, and ROADMAP is caught automatically.
+
+## Background
+
+The document authority chain is: `docs/prd/epics-and-stories.md` + `docs/prd/epic-list.md` (source of truth) → `ROADMAP.md` (synced copy) → `docs/stories/*.story.md` (individual status). Drift between these layers causes merge-queue scope rejections, incorrect sprint status, and duplicate epic allocations.
+
+This is one of the retrospector's rotating deep analysis modes, running every 4 hours.
+
+## Acceptance Criteria
+
+**Given** the retrospector runs its doc consistency mode
+**When** it cross-checks all planning docs
+**Then** it detects: stories marked Done in story files but not in epics-and-stories, epics marked complete in one doc but not others, story files that exist but aren't referenced in epics-and-stories, ROADMAP.md entries that differ from epics-and-stories
+
+**Given** inconsistencies are found
+**When** the retrospector reports them
+**Then** it files a structured finding in JSONL with type "doc_inconsistency"
+**And** it messages the supervisor with a summary of inconsistencies
+**And** it includes which doc is likely authoritative and what the correct state should be
+
+**Given** no inconsistencies are found
+**When** the audit completes
+**Then** it logs a clean audit entry in JSONL with type "doc_audit_clean"
+**And** does NOT message the supervisor (no noise on clean runs)
+
+**Given** the doc consistency mode rotates with other deep analysis modes
+**When** the 4-hour rotation fires
+**Then** doc consistency runs in its assigned slot (alongside conflict analysis, CI analysis, process waste)
+**And** each mode gets roughly equal rotation time
+
+## Technical Notes
+
+- Parse `docs/prd/epics-and-stories.md` for story status entries
+- Parse `docs/prd/epic-list.md` for epic completion status
+- Parse `ROADMAP.md` for epic/story status
+- Glob `docs/stories/*.story.md` and parse status lines
+- Cross-reference all four sources
+- Focus on actionable drift: status mismatches, missing entries, orphaned stories
+- Do NOT duplicate project-watchdog's merge-time governance — this is a periodic batch audit
+
+## Tasks
+
+### Task 1: Implement planning doc parsers
+- Parse story status from each of the 4 doc types
+- Extract epic completion status
+- Build unified view of expected vs actual state
+
+### Task 2: Implement cross-reference logic
+- Compare story file status against epics-and-stories entries
+- Compare epic-list status against ROADMAP entries
+- Detect orphaned stories (files exist but no planning doc reference)
+- Detect ghost entries (planning doc references but no story file)
+
+### Task 3: Implement reporting
+- JSONL entries for findings
+- Supervisor message for inconsistencies (skip for clean runs)
+- Recommend which doc to fix and what the correct state should be
+
+### Task 4: Implement rotation scheduling
+- 4-hour deep analysis rotation
+- Doc consistency as one of 4 rotating modes
+- State tracking to ensure fair rotation
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.6.story.md
+++ b/docs/stories/51.6.story.md
@@ -1,0 +1,88 @@
+# Story 51.6: BOARD.md Recommendation Pipeline
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (D-4, D-8)
+- Depends on: Stories 51.3, 51.4, 51.5
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to file structured recommendations to BOARD.md,
+So that improvement proposals are visible, auditable, and actionable.
+
+## Background
+
+The retrospector's primary output mechanism is BOARD.md recommendations. Decisions D-4 (authority model) and D-8 (Watchmen safeguards) define how this works: the agent proposes, humans review. Each recommendation includes a confidence score, supporting evidence, and specific action. The recommendation pipeline is the unified output layer for both the spec-chain loop and the operational loop.
+
+## Acceptance Criteria
+
+**Given** the retrospector has accumulated findings from per-PR retros or batch analysis
+**When** it identifies an actionable improvement
+**Then** it creates a BOARD.md entry in the "Pending Recommendations" section
+**And** the entry includes: ID (P-NNN), recommendation text, date, source (retrospector), confidence (High/Medium/Low), evidence count, specific action
+
+**Given** a recommendation is filed
+**When** reviewed by a human
+**Then** the recommendation includes enough context to accept or reject without additional investigation
+**And** the evidence trail links back to specific PR numbers and JSONL findings
+
+**Given** the confidence scoring system is active
+**When** the retrospector rates a recommendation
+**Then** High = 5+ supporting data points across multiple PRs
+**And** Medium = 2-4 supporting data points
+**And** Low = 1 data point or extrapolation from limited evidence
+
+**Given** the kill switch safeguard is active
+**When** 3+ consecutive recommendations are rejected by human
+**Then** the retrospector auto-reduces to read-only mode
+**And** messages supervisor requesting recalibration
+
+**Given** the recommendation audit trail is maintained
+**When** any recommendation is filed
+**Then** the full rationale is preserved in BOARD.md
+**And** the corresponding JSONL entries are cross-referenced
+
+## Technical Notes
+
+- Write to `docs/decisions/BOARD.md` in the "Pending Recommendations" section
+- Follow existing BOARD.md format (see P-001 through P-006 for examples)
+- Auto-assign recommendation IDs by scanning existing P-NNN entries
+- Include link to findings log entries as evidence
+- Track recommendation outcomes: accepted, rejected, deferred
+- Kill switch: maintain rejection counter in state file
+
+## Tasks
+
+### Task 1: Implement BOARD.md writer
+- Parse existing BOARD.md to find "Pending Recommendations" section
+- Auto-assign next P-NNN ID
+- Append recommendation in existing table format
+- Include confidence score, evidence count, and source
+
+### Task 2: Implement confidence scoring
+- Count supporting data points from JSONL findings
+- Apply scoring rules: 5+ = High, 2-4 = Medium, 1 = Low
+- Include evidence references in recommendation
+
+### Task 3: Implement kill switch
+- Track recommendation outcomes (accepted/rejected/deferred)
+- Count consecutive rejections
+- Auto-reduce to read-only after 3 consecutive rejections
+- Alert supervisor for recalibration
+
+### Task 4: Implement batch analysis → recommendation pipeline
+- Aggregate per-PR findings every 4-6 hours or every 10 PRs
+- Cross-PR pattern detection
+- Produce ranked recommendations (highest confidence first)
+- Rate-limit: max 3 recommendations per batch cycle
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.7.story.md
+++ b/docs/stories/51.7.story.md
@@ -1,0 +1,59 @@
+# Story 51.7: Merge Conflict Rate Analysis
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (Phase 2, Merge Conflict Rate Analysis section)
+- Depends on: Stories 51.3, 51.6 (Phase 1 MVP must be validated first)
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to analyze merge conflict rate patterns,
+So that I can optimize worker parallelization and avoid conflict cascades.
+
+## Background
+
+Phase 2 feature. After 2 weeks of MVP validation, the retrospector gains merge conflict analysis capabilities. This includes hot file detection (files in 3+ concurrent PRs), epic collision zones, parallel dispatch safety scoring, and rebase churn analysis. Findings feed into the BOARD.md recommendation pipeline.
+
+## Acceptance Criteria
+
+**Given** the retrospector has accumulated merge data from Phase 1
+**When** it runs conflict rate analysis (rotating deep analysis mode)
+**Then** it identifies hot files (appearing in 3+ concurrent PRs)
+**And** it identifies epic collision zones (epics that routinely conflict)
+**And** it calculates parallel dispatch safety scores
+**And** it flags PRs requiring 3+ rebases
+
+**Given** hot files are detected
+**When** the analysis reports findings
+**Then** it recommends sequencing for conflicting PRs
+**And** includes specific file paths and the PRs that conflict
+
+**Given** rebase churn exceeds threshold (3+ rebases on a PR)
+**When** the analysis identifies root cause
+**Then** it traces the cause to: concurrent PRs touching same files, long-lived branches, or dependency chains
+**And** recommends specific mitigation (sequencing, smaller PRs, etc.)
+
+## Technical Notes
+
+- Data model per PR: files changed, epic/story reference, worker name, creation-to-merge time, rebase attempts, conflict files, concurrent PRs
+- Use JSONL findings log data + `gh pr list` for concurrent PR detection
+- Pattern detection queries: hot file analysis, epic collision zones, parallel dispatch safety, rebase churn
+- Output: BOARD.md recommendations via Story 51.6 pipeline
+
+## Tasks
+
+### Task 1: Implement per-PR conflict data collection
+### Task 2: Implement hot file detection algorithm
+### Task 3: Implement rebase churn analysis
+### Task 4: Integrate with BOARD.md recommendation pipeline
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.8.story.md
+++ b/docs/stories/51.8.story.md
@@ -1,0 +1,58 @@
+# Story 51.8: CI Failure Rate Analysis & Coding Standard Proposals
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (Phase 2, CI Failure Rate Analysis section)
+- Depends on: Stories 51.3, 51.6 (Phase 1 MVP must be validated first)
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to analyze CI failure patterns and trace them to fixable spec-chain layers,
+So that recurring CI failures are prevented at the source rather than fixed one PR at a time.
+
+## Background
+
+Phase 2 feature. CI failures have a taxonomy: race conditions (fix via story spec), lint failures (fix via CLAUDE.md pre-commit rule), test flakiness (fix via coding standards), build failures (fix via architecture), coverage regressions (fix via story spec). The retrospector classifies failures and proposes fixes at the appropriate spec-chain layer.
+
+## Acceptance Criteria
+
+**Given** the retrospector has accumulated CI data from Phase 1
+**When** it runs CI failure analysis (rotating deep analysis mode)
+**Then** it classifies failures by taxonomy: race condition, lint, flakiness, build, coverage
+**And** traces each category to the fixable spec-chain layer
+
+**Given** a CI failure pattern recurs across 3+ PRs
+**When** the retrospector identifies the pattern
+**Then** it files a BOARD.md recommendation proposing a spec-chain fix
+**And** the fix targets the correct layer (story spec, CLAUDE.md, coding standards, architecture)
+
+**Given** the failure taxonomy is maintained
+**When** new CI failure types emerge
+**Then** they are categorized as "unclassified" and flagged for human review
+**And** the taxonomy can be extended via BOARD.md recommendation
+
+## Technical Notes
+
+- Failure taxonomy table from party mode artifact
+- Use `gh run list` and `gh run view --log` for CI failure data
+- Classify by detection signal (test name patterns, error messages)
+- Trace to fix layer using the spec-chain model: Code → Story ACs → PRD → Architecture → CLAUDE.md/SOUL.md
+- Output: BOARD.md recommendations with specific CLAUDE.md rule proposals or story template updates
+
+## Tasks
+
+### Task 1: Implement CI failure data collection
+### Task 2: Implement failure taxonomy classifier
+### Task 3: Implement spec-chain layer tracing
+### Task 4: Integrate with BOARD.md recommendation pipeline
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)

--- a/docs/stories/51.9.story.md
+++ b/docs/stories/51.9.story.md
@@ -1,0 +1,57 @@
+# Story 51.9: Research Lifecycle Tracking
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md` (Phase 2, item 8)
+- Depends on: Stories 51.3, 51.6 (Phase 1 MVP must be validated first)
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector to track research artifacts through their lifecycle,
+So that completed research is formalized into stories and abandoned research is explicitly closed.
+
+## Background
+
+Phase 2 feature. Research artifacts in `_bmad-output/planning-artifacts/` follow a lifecycle: requested → in-progress → completed → formalized (stories created) → abandoned. Currently no agent tracks this lifecycle, leading to completed research that never gets formalized and abandoned research that clutters the planning artifacts directory.
+
+## Acceptance Criteria
+
+**Given** the retrospector scans `_bmad-output/planning-artifacts/`
+**When** it finds research artifacts
+**Then** it classifies each by lifecycle state: active (referenced in open issues/stories), formalized (has corresponding epic/stories), stale (>2 weeks old with no references), abandoned (>4 weeks old with no references)
+
+**Given** a research artifact has been completed for >2 weeks
+**When** no corresponding epic or story exists
+**Then** the retrospector flags it as "stale research — needs formalization or explicit closure"
+**And** messages the supervisor with the artifact name and suggested action
+
+**Given** research lifecycle data is tracked
+**When** batch analysis runs
+**Then** it reports: total artifacts, active count, formalized count, stale count
+**And** identifies the oldest unformalized research
+
+## Technical Notes
+
+- Scan `_bmad-output/planning-artifacts/*.md` for research artifacts
+- Cross-reference against `docs/stories/` and `docs/prd/epics-and-stories.md` for formalization status
+- Check BOARD.md for pending recommendations referencing each artifact
+- Use file modification dates for staleness detection
+- Lifecycle classification is heuristic — err on the side of "stale" to prompt review
+
+## Tasks
+
+### Task 1: Implement research artifact scanner
+### Task 2: Implement lifecycle classification logic
+### Task 3: Implement staleness alerting
+### Task 4: Integrate with BOARD.md recommendation pipeline
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

Creates **Epic 51: SLAES — Self-Learning Agentic Engineering System** with 10 stories across 3 phases, based on the party mode artifact (PR #434) and subagent abuse investigation (PR #435).

**SLAES** is a continuous improvement meta-system with a persistent `retrospector` agent that:
- Monitors PR merges and collects structured data (JSONL findings log)
- Detects process waste sagas (2+ workers dispatched for same fix)
- Audits planning doc consistency (epic-list ↔ epics-and-stories ↔ ROADMAP ↔ story files)
- Files improvement recommendations to BOARD.md with confidence scoring
- Analyzes merge conflict rates, CI failure patterns, and research lifecycle

### Stories

| Phase | Story | Title |
|-------|-------|-------|
| Phase 0 (Bootstrap) | 51.1 | Retrospector Agent Definition (Responsibility+WHY Format) |
| Phase 0 (Bootstrap) | 51.2 | Rewrite 5 Operational Agent Definitions |
| Phase 1 (MVP) | 51.3 | JSONL Findings Log & Per-Merge Lightweight Retro |
| Phase 1 (MVP) | 51.4 | Saga Detection (Dispatch Waste Alerting) |
| Phase 1 (MVP) | 51.5 | Doc Consistency Audit (Periodic Cross-Check) |
| Phase 1 (MVP) | 51.6 | BOARD.md Recommendation Pipeline |
| Phase 2 | 51.7 | Merge Conflict Rate Analysis |
| Phase 2 | 51.8 | CI Failure Rate Analysis & Coding Standard Proposals |
| Phase 2 | 51.9 | Research Lifecycle Tracking |
| Phase 2 | 51.10 | PR Creation Authority & Trend Reporting |

### Key Design Decisions (from party mode)

- **D-1**: Single agent (not 3) — avoids pushing agent count to 8
- **D-2**: System = SLAES, Agent = `retrospector`
- **D-3**: Persistent, 15-min polling (not cron, not 5-min)
- **D-4**: Level 2 authority (read + propose PRs, not auto-apply)
- **D-6**: Dual-loop architecture (spec-chain quality + operational efficiency)
- **D-8**: 5 Watchmen safeguards (no self-mod, audit trail, confidence scoring, human review, kill switch)
- **D-10**: Prevention over detection — responsibility+WHY definition methodology

### Epic Number Collision Note

Initially allocated as Epic 50 but **renumbered to 51** after discovering Epic 50 was already allocated to In-App Bug Reporting (PR #445). Merge conflicts from the daemon refresh were resolved — Epic 50 content preserved, SLAES renumbered. This is exactly the kind of collision INC-003 documented and that SLAES Story 51.5 (doc consistency audit) would catch.

### Opportunities (not implemented)

- Cross-repo SLAES deployment (designed for single-repo MVP with hooks for hierarchical model)
- Integration with `threedoors doctor` (Epic 49) for dispatch hygiene checks
- Pre-dispatch hooks for Agent tool enforcement

## Test plan

- [ ] Verify all 10 story files exist at `docs/stories/51.{1-10}.story.md`
- [ ] Verify no conflict markers in any planning docs
- [ ] Verify ROADMAP.md, epic-list.md, and epics-and-stories.md all reference Epic 51 consistently
- [ ] Verify no stale Epic 50 references in 51.x story files
- [ ] Verify Epic 50 (In-App Bug Reporting) content is preserved intact