### PR TITLE
docs: CI churn reduction follow-up stories (Stories 0.36, 0.37)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,9 +28,21 @@ Renovate manages Go module dependencies (grouping, auto-merge, OSV vulnerability
 
 ### Story 0.20: CI Churn Reduction (P1)
 
-**Status:** Story created (PR #231). Research complete (PR #233). Implementation not started.
+**Status:** Done (PR #260).
 
-Branch protection & merge queue optimization to reduce cascading CI reruns.
+Branch protection & merge queue optimization to reduce cascading CI reruns. Relaxed up-to-date requirement, added path filtering for docs-only PRs, deferred GitHub merge queue (ADR-0030).
+
+### Story 0.36: CI Circuit Breaker — Post-Merge Main Branch Monitoring (P1)
+
+**Status:** Not Started.
+
+Operationalize merge-queue emergency mode: proactively check push-to-main CI after each merge, halt merges if main is red. Prerequisite safety net for the relaxed up-to-date rule (Story 0.20).
+
+### Story 0.37: CI Efficiency Metrics — Track Runs Per Merged PR (P2)
+
+**Status:** Not Started.
+
+Shell script to measure CI efficiency (runs per merged PR, churn ratio, docs-skip rate). Validates Story 0.20 improvements and monitors ADR-0030 re-entry gate for GitHub merge queue.
 
 ### Story 0.31: CI/Security Hardening — Secrets, Supply Chain & Reproducibility (P1)
 
@@ -219,7 +231,7 @@ In-app `:bug` command for frictionless bug reporting without leaving the TUI. Br
 
 | Epic | Title | Stories |
 |------|-------|---------|
-| 0 | Infrastructure & Process (Backfill) | 11/13 |
+| 0 | Infrastructure & Process (Backfill) | 12/16 |
 | 1 | Three Doors Technical Demo | 7/7 |
 | 2 | Apple Notes Integration | 6/6 |
 | 3 | Enhanced Interaction | 7/7 |

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -251,6 +251,8 @@
 | D-156 | Conservative auto-fix with `--fix` flag (Epic 49) | 2026-03-10 | Only fix safe, reversible operations (temp files, derived caches, permissions); user data never auto-modified; rejected: aggressive auto-fix (risky), no auto-fix (misses easy wins) | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
 | D-157 | 24-hour cached version check, gh CLI pattern (Epic 49) | 2026-03-10 | Proven pattern; respects rate limits; non-blocking; opt-out via env var and config; rejected: check every run (chatty), weekly (too stale) | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
 | D-158 | Channel-aware version: show within channel + cross-channel if higher (Epic 49) | 2026-03-10 | Alpha users should know about newer stable releases; matches rustup approach; rejected: strict isolation (misses important releases), all channels (noisy) | [Research](../../_bmad-output/planning-artifacts/threedoors-doctor-research.md) |
+| D-159 | CI circuit breaker as agent prompt update, not code (Story 0.36) | 2026-03-10 | Merge-queue is LLM-driven; post-merge CI check is a workflow instruction, not compiled logic; `gh run list` provides the check mechanism | [ADR-0030](../ADRs/ADR-0030-ci-churn-reduction.md) |
+| D-160 | Shell script for CI metrics, not GitHub Action (Story 0.37) | 2026-03-10 | No external deps beyond `gh`; can be promoted to Action later; immediately runnable by retrospector agent (Story 51.8) | [Research](../research/ci-churn-reduction-research.md) |
 
 ## Rejected
 

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -660,7 +660,7 @@
 
 | Epic | Stories | Status |
 |------|---------|--------|
-| Epic 0: Infrastructure & Process (Backfill) | 14 | Partial (10/14) |
+| Epic 0: Infrastructure & Process (Backfill) | 16 | Partial (12/16) |
 | Epic 1: Technical Demo | 7 | Complete |
 | Epic 2: Apple Notes Integration | 6 | Complete |
 | Epic 3: Enhanced Interaction | 7 | Complete |

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -197,7 +197,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 
 | Requirement | Epic | Description |
 |------------|------|-------------|
-| (cross-cutting) | Epic 0 | Infrastructure & Process Backfill (19/22 complete) |
+| (cross-cutting) | Epic 0 | Infrastructure & Process Backfill (12/16 complete) |
 | TD1-TD9 | Epic 1 ✅ | Three Doors Technical Demo (COMPLETE) |
 | FR2, FR4, FR5, FR12, FR15 | Epic 2 ✅ | Apple Notes Integration (COMPLETE) |
 | FR3, FR6-FR10, FR16, FR18, FR19 | Epic 3 ✅ | Enhanced Interaction (COMPLETE) |
@@ -236,7 +236,7 @@ This document provides the complete epic and story breakdown for ThreeDoors, dec
 ### Epic 0: Infrastructure & Process (Backfill)
 Retroactive stories covering CI, documentation, tooling, quality standards, and research work from 29 unstory'd PRs. Now also includes forward-looking infrastructure improvements.
 **FRs covered:** None (cross-cutting infrastructure)
-**Status:** 10 of 14 stories complete. Stories 0.24 (Renovate + Dependabot), 0.31, 0.32, 0.34 not started.
+**Status:** 12 of 16 stories complete. Stories 0.29, 0.36, 0.37 not started.
 
 ### Epic 1: Three Doors Technical Demo ✅ COMPLETE
 Build and validate the Three Doors interface with minimal viable functionality to prove the UX concept.
@@ -407,7 +407,7 @@ Time-based seasonal theme variants that auto-switch based on the current date, e
 
 **Epic Goal:** Retroactively track infrastructure, documentation, tooling, and process work that was performed outside of story-level planning. These backfill stories capture work from 29 merged PRs that had no backing story. Now also includes forward-looking infrastructure improvements.
 
-**Status:** 10 of 14 stories complete. Stories 0.24 (Renovate + Dependabot), 0.31, 0.32, 0.34 not started.
+**Status:** 12 of 16 stories complete. Stories 0.29, 0.36, 0.37 not started.
 
 **Origin:** PR-Story Gap Analysis (2026-03-03), see `../../_bmad-output/planning-artifacts/pr-story-gap-analysis.md`
 
@@ -671,7 +671,7 @@ As a development team running multiple parallel agents,
 I want CI to run efficiently without cascading reruns,
 So that PRs merge quickly without wasting 5-10x CI runs per PR.
 
-**Status:** Not Started
+**Status:** Done (PR #260)
 
 **Acceptance Criteria:**
 - **AC1:** Branch protection "Require branches to be up to date" DISABLED (Phase 1)
@@ -680,6 +680,36 @@ So that PRs merge quickly without wasting 5-10x CI runs per PR.
 - **AC4:** merge-queue and pr-shepherd agents updated (Phase 1)
 - **AC5:** CI workflows use path-based triggers for docs-only PRs (Phase 2)
 - **AC6:** Evaluate and implement GitHub Native Merge Queue if feasible (Phase 3)
+
+### Story 0.36: CI Circuit Breaker — Post-Merge Main Branch Monitoring
+
+As the merge-queue agent merging PRs without requiring up-to-date branches,
+I need to detect push-to-main CI failures immediately after each merge,
+So that I can halt further merges before cascading breakage onto a red main.
+
+**Status:** Not Started
+
+**Acceptance Criteria:**
+- **AC1:** Merge-queue agent checks push-to-main CI status after each merge via `gh run list`
+- **AC2:** Emergency mode entered on main CI failure: halt merges, message supervisor, label PR
+- **AC3:** Automatic recovery when subsequent push-to-main CI succeeds
+- **AC4:** Timeout handling: 10-minute timeout does not block merges
+- **AC5:** Agent prompt updated with explicit post-merge CI check workflow
+
+### Story 0.37: CI Efficiency Metrics — Track Runs Per Merged PR
+
+As a project maintainer running parallel CI workflows,
+I want to track CI efficiency metrics (runs per merged PR, churn ratio),
+So that I can measure the impact of CI churn reduction and know when to reconsider deferred options.
+
+**Status:** Not Started
+
+**Acceptance Criteria:**
+- **AC1:** `scripts/ci-metrics.sh` computes total runs, merged PRs, runs-per-PR ratio, docs-skip count, main-failure count
+- **AC2:** Script uses `gh` CLI only — no external dependencies
+- **AC3:** Human-readable summary and JSON output modes
+- **AC4:** Baseline comparison against pre-optimization metrics (5-10 runs/PR)
+- **AC5:** ADR-0030 re-entry gate warning when main CI failures exceed 3/week
 
 ### Story 0.21: Homebrew Public Distribution — Custom Tap, CI Hardening, and homebrew-core Submission
 

--- a/docs/stories/0.36.story.md
+++ b/docs/stories/0.36.story.md
@@ -1,0 +1,80 @@
+# Story 0.36: CI Circuit Breaker — Post-Merge Main Branch Monitoring
+
+**Status:** Not Started
+**Epic:** 0 — Infrastructure & Process
+**Depends on:** Story 0.20 (Done, PR #260)
+
+## User Story
+
+As the merge-queue agent merging PRs without requiring up-to-date branches,
+I need to detect push-to-main CI failures immediately after each merge,
+So that I can halt further merges before cascading breakage onto a red main.
+
+## Problem Statement
+
+Story 0.20 (PR #260) relaxed the "require branches to be up to date" rule, which eliminated O(n^2) CI churn. The safety net for this change is the push-to-main CI trigger — if two PRs break when combined, the post-merge CI run catches it.
+
+However, the merge-queue agent currently has no proactive mechanism to check whether push-to-main CI succeeded after a merge. Emergency mode is defined in the agent prompt but depends on the agent noticing the failure — there's no systematic check. If multiple PRs merge in quick succession, several could land on main before anyone notices it's red.
+
+The party mode consensus (PR #233) explicitly identified this circuit breaker as a **prerequisite** for the relaxed up-to-date rule (Step 2 enables Step 3).
+
+## Acceptance Criteria
+
+**AC-1: Post-merge CI check**
+**Given** the merge-queue agent has just merged a PR
+**When** the push-to-main CI run completes (or after a configurable timeout)
+**Then** the agent checks the status of the latest main branch CI run via `gh run list --branch main --limit 1`
+
+**AC-2: Emergency mode on failure**
+**Given** the push-to-main CI run has failed
+**When** the merge-queue detects the failure
+**Then** the agent:
+  - Enters emergency mode (halts all pending merges)
+  - Messages the supervisor with the failing run URL and commit SHA
+  - Labels the most recently merged PR with a `broke-main` label
+  - Does NOT attempt to merge any other PR until main is green
+
+**AC-3: Automatic recovery**
+**Given** the merge-queue is in emergency mode
+**When** a subsequent push-to-main CI run succeeds (e.g., after a fix is merged)
+**Then** the agent exits emergency mode and resumes normal merge operations
+
+**AC-4: Timeout handling**
+**Given** the merge-queue has merged a PR
+**When** the push-to-main CI run has not completed within 10 minutes
+**Then** the agent logs a warning but does NOT block merges — timeout is not treated as failure
+
+**AC-5: Agent prompt updated**
+**Given** the merge-queue agent definition
+**When** the story is complete
+**Then** `agents/merge-queue.md` includes explicit post-merge CI check instructions under Operational Notes
+
+## Technical Notes
+
+- The merge-queue agent is an LLM-driven agent, not compiled code. "Implementation" means updating the agent prompt with clear, actionable instructions for the post-merge check workflow.
+- Use `gh run list --branch main --limit 1 --json status,conclusion,url,headSha` to check main CI status.
+- The agent should wait ~30 seconds after merge before checking (GitHub Actions takes a moment to trigger).
+- If multiple merges happen in quick succession, check after each one — don't batch.
+- The `broke-main` label should be created if it doesn't exist: `gh label create broke-main --color D73A4A --description "This PR broke the main branch CI"`.
+
+## Quality Gate
+
+- **QG1:** Agent prompt includes explicit post-merge CI check workflow
+- **QG2:** Emergency mode entry and exit conditions are unambiguous
+- **QG3:** No code changes required — this is an agent definition update
+- **QG4:** ADR-0030 updated to note circuit breaker is now operational
+
+## References
+
+- Party mode consensus: `_bmad-output/planning-artifacts/ci-churn-reduction-party-mode.md` (Step 2)
+- Research: `docs/research/ci-churn-reduction-research.md`
+- ADR: `docs/ADRs/ADR-0030-ci-churn-reduction.md`
+- Merge-queue agent: `agents/merge-queue.md`
+
+## Tasks
+
+1. Update `agents/merge-queue.md` with post-merge CI check workflow
+2. Add emergency mode entry/exit protocol with specific `gh` commands
+3. Update ADR-0030 to note circuit breaker is operational
+4. Update `docs/decisions/BOARD.md` with this decision
+5. Test: verify `gh run list --branch main --limit 1 --json status,conclusion,url,headSha` works

--- a/docs/stories/0.37.story.md
+++ b/docs/stories/0.37.story.md
@@ -1,0 +1,91 @@
+# Story 0.37: CI Efficiency Metrics — Track Runs Per Merged PR
+
+**Status:** Not Started
+**Epic:** 0 — Infrastructure & Process
+**Depends on:** Story 0.20 (Done, PR #260)
+
+## User Story
+
+As a project maintainer running parallel CI workflows,
+I want to track CI efficiency metrics (runs per merged PR, churn ratio),
+So that I can measure the impact of CI churn reduction and know when to reconsider deferred options.
+
+## Problem Statement
+
+Story 0.20 (PR #260) implemented path filtering and relaxed the up-to-date rule, targeting ~80% CI churn reduction. The research (PR #233) established baseline metrics:
+- **Before:** ~5-10 CI runs per merged PR, 60% churn reruns, ~210 wasted job-minutes/hour
+- **Target:** ~1.5 CI runs per merged PR (one on branch, one on main push)
+
+Without ongoing measurement, we can't:
+1. Confirm the improvements actually worked
+2. Detect regression if workflow changes reintroduce churn
+3. Make informed decisions about deferred options (benchmarks non-blocking, GitHub merge queue)
+
+ADR-0030 includes a re-entry gate: "If main branch CI fails more than 3 times in a week due to incompatible PR merges, reconsider GitHub native merge queue." This gate requires data we're not currently collecting.
+
+## Acceptance Criteria
+
+**AC-1: Weekly CI metrics script**
+**Given** the repository has CI workflow runs
+**When** a metrics script is executed (manually or via cron)
+**Then** it computes and outputs:
+  - Total CI runs in the period
+  - Merged PRs in the period
+  - CI runs per merged PR (ratio)
+  - Docs-only PRs that were skipped (path filter effectiveness)
+  - Push-to-main CI failure count (for ADR-0030 re-entry gate)
+
+**AC-2: Script uses GitHub API**
+**Given** the script runs
+**When** it queries CI data
+**Then** it uses `gh api` or `gh run list` — no external dependencies beyond `gh` CLI and standard shell tools
+
+**AC-3: Output format**
+**Given** the metrics are computed
+**When** the script produces output
+**Then** it prints a human-readable summary AND a machine-readable JSON line for trending
+
+**AC-4: Baseline comparison**
+**Given** the pre-optimization baseline (5-10 runs/PR, 60% churn)
+**When** the script runs
+**Then** it includes a comparison against the baseline with percentage improvement
+
+**AC-5: ADR re-entry gate check**
+**Given** the push-to-main CI failure count
+**When** failures exceed 3 in the measurement period
+**Then** the script outputs a prominent warning: "ADR-0030 re-entry gate triggered — consider GitHub Native Merge Queue"
+
+## Technical Notes
+
+- Script location: `scripts/ci-metrics.sh`
+- Use `gh run list --branch main --limit 100 --json event,conclusion,createdAt,headBranch` for raw data
+- Use `gh pr list --state merged --limit 50 --json number,mergedAt` for PR merge data
+- Correlate by time window (default: last 7 days)
+- The script should be runnable by the retrospector agent (Story 51.8) once SLAES is operational
+- Keep it simple — a shell script, not a GitHub Action. Can be promoted to an Action later if useful.
+
+## Quality Gate
+
+- **QG1:** Script runs successfully with `bash scripts/ci-metrics.sh`
+- **QG2:** Output includes all five metrics from AC-1
+- **QG3:** JSON output is valid and parseable
+- **QG4:** Script handles edge cases: no merges in period, no CI runs, API rate limits
+
+## References
+
+- Research baseline: `docs/research/ci-churn-reduction-research.md` (Appendix: CI Run Data)
+- ADR re-entry gate: `docs/ADRs/ADR-0030-ci-churn-reduction.md` (Phase 3 section)
+- Party mode metric: `_bmad-output/planning-artifacts/ci-churn-reduction-party-mode.md` ("CI runs per merged PR")
+- SLAES integration: Story 51.8 (CI Failure Rate Analysis)
+
+## Tasks
+
+1. Write `scripts/ci-metrics.sh` with `gh` API queries
+2. Implement time-window filtering (default 7 days, configurable via arg)
+3. Compute runs-per-merged-PR ratio
+4. Add docs-skip and main-failure counts
+5. Add JSON output mode (`--json` flag)
+6. Add baseline comparison
+7. Add ADR-0030 re-entry gate warning
+8. Test with current repository data
+9. Add brief usage instructions to script header


### PR DESCRIPTION
## Summary

Creates implementation-ready stories based on PR #233 CI churn reduction research findings. Story 0.20 (PR #260) already implemented the core changes (path filtering + relaxed up-to-date rule). These stories cover the remaining recommended improvements:

- **Story 0.36: CI Circuit Breaker** — Operationalize merge-queue emergency mode: proactively check push-to-main CI after each merge via `gh run list`, halt merges if main is red, auto-recover when green. This was identified as the prerequisite safety net for the relaxed up-to-date rule (Step 2 in party mode consensus).

- **Story 0.37: CI Efficiency Metrics** — Shell script (`scripts/ci-metrics.sh`) to track CI runs per merged PR, churn ratio, docs-skip rate. Validates Story 0.20 improvements against baseline (5-10 runs/PR → target 1.5). Monitors ADR-0030 re-entry gate for GitHub merge queue (3+ main CI failures/week).

Also updates planning docs:
- Marks Story 0.20 as Done (PR #260) in ROADMAP.md and epics-and-stories.md
- Updates Epic 0 story count from 14→16 (epic-list.md, epics-and-stories.md)
- Adds decisions D-159, D-160 to BOARD.md

## Test plan

- [ ] Story files have clear acceptance criteria and technical notes
- [ ] All three planning docs (ROADMAP.md, epic-list.md, epics-and-stories.md) are consistent
- [ ] BOARD.md entries reference correct ADRs and research artifacts
- [ ] No code changes — docs only