### PR TITLE
docs: PR #438 vulnerability investigation (Story 42.5)

### DIFF
--- a/_bmad-output/planning-artifacts/pr-438-vulnerability-investigation.md
+++ b/_bmad-output/planning-artifacts/pr-438-vulnerability-investigation.md
@@ -1,0 +1,89 @@
+# PR #438 Vulnerability Investigation — Story 42.5 CI Supply Chain Hardening
+
+**Date:** 2026-03-10
+**PR:** https://github.com/arcaven/ThreeDoors/pull/438
+**Branch:** `work/kind-rabbit`
+**CI Failures:** 7 consecutive failures (all from govulncheck step)
+
+## Root Cause Analysis
+
+PR #438 correctly implements its stated scope (SHA-pinning third-party actions + adding govulncheck to CI). The problem is that **govulncheck immediately found 9 real vulnerabilities** that pre-exist in the codebase. The PR introduced a quality gate that the codebase cannot currently pass.
+
+This is not a bug in the PR — it's working as designed. The story's AC-3 says "the build fails if govulncheck reports any known vulnerabilities," and that's exactly what's happening.
+
+## Vulnerabilities Found (9 total)
+
+### Go Standard Library (7 vulns) — requires Go 1.25.8
+
+| ID | Package | Severity | Fixed In | Affected Code |
+|----|---------|----------|----------|---------------|
+| GO-2026-4602 | `os` | FileInfo escape from Root | go1.25.8 | `internal/mcp/middleware.go` (os.ReadDir) |
+| GO-2026-4601 | `net/url` | IPv6 host literal parsing | go1.25.8 | `internal/intelligence/llm/ollama.go`, `internal/mcp/transport.go` |
+| GO-2026-4341 | `net/url` | Memory exhaustion in query parsing | go1.25.6 | `internal/enrichment/enrichment.go`, `internal/adapters/github/github_client.go` |
+| GO-2026-4340 | `crypto/tls` | Handshake at wrong encryption level | go1.25.6 | `internal/mcp/transport.go`, `internal/intelligence/llm/claude.go` |
+| GO-2026-4337 | `crypto/tls` | Unexpected session resumption | go1.25.7 | Same TLS paths |
+| GO-2025-4175 | `crypto/x509` | Wildcard DNS name constraint bypass | go1.25.5 | `internal/docaudit/report.go` |
+| GO-2025-4155 | `crypto/x509` | DoS in host cert validation | go1.25.5 | `internal/docaudit/report.go` |
+
+**Fix:** Update `go.mod` from `go 1.25.4` → `go 1.25.8` (covers all stdlib vulns).
+
+### Third-Party Dependency (2 vulns) — requires jose2go update
+
+| ID | Package | Severity | Found | Fixed In | Affected Code |
+|----|---------|----------|-------|----------|---------------|
+| GO-2025-4123 | `jose2go` | DoS via JWE compression ratio | v1.5.0 | v1.7.0 | `internal/core/connection/credential_ring.go` |
+| GO-2023-2409 | `jose2go` | DoS in decryption | v1.5.0 | v1.5.1+ | Same credential_ring code |
+
+**Fix:** `go get github.com/dvsekhvalnov/jose2go@v1.7.0 && go mod tidy`
+
+Note: `jose2go` is an indirect dependency (pulled in by the `keyring` package). The update should be straightforward.
+
+## Assessment
+
+### The story scope is correct but incomplete
+
+Story 42.5 correctly identified two things to do:
+1. Pin third-party actions to SHAs (done correctly)
+2. Add govulncheck as a blocking CI gate (done correctly)
+
+What the story **didn't anticipate** is that govulncheck would immediately flag pre-existing vulnerabilities. The story assumed "no current CVEs expected" (from the PR's test plan), which turned out to be wrong.
+
+### The implementation is correct
+
+The PR's code changes are sound. The SHA pins are correct, and govulncheck is properly configured as a blocking step. The worker did exactly what was asked.
+
+## Recommended Fix Approach
+
+**Option A (Recommended): Expand PR #438 to also fix the vulnerabilities**
+
+Add two commits to the existing PR:
+1. Bump `go 1.25.4` → `go 1.25.8` in `go.mod` (fixes all 7 stdlib vulns)
+2. `go get github.com/dvsekhvalnov/jose2go@v1.7.0 && go mod tidy` (fixes 2 dep vulns)
+
+This is the simplest path. The dependency updates are mechanical, low-risk, and directly related to the govulncheck gate being added. No new story needed.
+
+**Option B: Split into two PRs**
+
+1. PR #438 as-is but with govulncheck set to non-blocking (warn only) — merge first
+2. New story/PR for "Fix govulncheck findings" — bump Go + update jose2go
+
+This is more process-correct but slower. The vulns are real and should be fixed promptly.
+
+**Option C (Not recommended): Close PR #438 and redo**
+
+Unnecessary — the existing work is correct. Just needs the vulnerability fixes added.
+
+## Recommendation
+
+**Go with Option A.** Dispatch a worker to:
+1. Update `go.mod` to `go 1.25.8`
+2. Update `jose2go` to `v1.7.0`
+3. Run `go mod tidy`
+4. Verify `govulncheck ./...` passes locally
+5. Push to the `work/kind-rabbit` branch
+
+The CI setup changes in PR #438 and the also check whether `actions/setup-go` in CI uses `go-version-file: 'go.mod'` (it does), so bumping go.mod is sufficient — CI will automatically use the new Go version.
+
+## CI Workflow Note
+
+The CI uses `go-version-file: 'go.mod'` for all jobs, so updating go.mod to `go 1.25.8` will automatically make CI download and use Go 1.25.8. No workflow file changes needed beyond what PR #438 already has.


### PR DESCRIPTION
## Summary

- Investigation artifact for why PR #438 (Story 42.5 — CI Supply Chain Hardening) fails CI repeatedly
- govulncheck (added by PR #438) correctly finds **9 pre-existing vulnerabilities** the codebase can't pass
- Root cause: Go 1.25.4 has 7 known stdlib CVEs; jose2go v1.5.0 has 2 known CVEs

## Findings

**Go stdlib (7 vulns):** `os`, `net/url`, `crypto/tls`, `crypto/x509` — all fixed in Go 1.25.8
**Third-party (2 vulns):** `jose2go` DoS vulnerabilities — fixed in v1.7.0

## Recommended Fix

Expand PR #438 with two additional commits:
1. Bump `go.mod` from `go 1.25.4` → `go 1.25.8`
2. Update `jose2go` to `v1.7.0` via `go get` + `go mod tidy`

Full analysis: `_bmad-output/planning-artifacts/pr-438-vulnerability-investigation.md`

## Test Plan

- [x] Artifact is well-structured and actionable
- [x] No code changes — investigation/planning only