### PR TITLE
docs: GitHub community standards stories (0.42, 0.43)

### DIFF
--- a/docs/stories/0.42.story.md
+++ b/docs/stories/0.42.story.md
@@ -1,0 +1,51 @@
+# Story 0.42: GitHub Issue & PR Templates
+
+**Epic:** 0 — Infrastructure & Process
+**Priority:** P1
+**Status:** Not Started
+**Depends On:** None
+
+## Context
+
+ThreeDoors' GitHub Community Health Score is 42%. No issue templates or PR template exist, leading to unstructured issue reports and PRs that miss story-driven development requirements. Adding structured YAML-form issue templates and a project-specific PR template will improve contributor experience and enforce development standards from the first interaction.
+
+**Planning artifact:** `_bmad-output/planning-artifacts/community-standards-plan.md`
+
+## Description
+
+Create GitHub issue templates (bug report, feature request, question) using YAML form format, a config file to disable blank issues, and a PR template that enforces the story-driven development checklist.
+
+## Acceptance Criteria
+
+- [ ] `.github/ISSUE_TEMPLATE/bug-report.yml` exists with structured fields: description, expected behavior, steps to reproduce, interface dropdown (TUI/CLI/MCP), version, OS, optional logs and task file
+- [ ] `.github/ISSUE_TEMPLATE/feature-request.yml` exists with: problem/motivation, proposed solution, alternatives considered, area dropdown, SOUL.md philosophy checkbox (required)
+- [ ] `.github/ISSUE_TEMPLATE/question.yml` exists with: question textarea, topic dropdown
+- [ ] `.github/ISSUE_TEMPLATE/config.yml` exists: `blank_issues_enabled: false`, contact link to docs
+- [ ] `.github/PULL_REQUEST_TEMPLATE.md` exists with: Summary section (story file link), Changes section, Checklist (story file, tests, make fmt/lint/test, race detector, commit message format), Testing section, Opportunities section
+- [ ] Bug report template uses labels `["bug", "triage"]`
+- [ ] Feature request template uses labels `["enhancement", "triage"]`
+- [ ] Question template uses labels `["question"]`
+- [ ] All YAML templates are valid and parse correctly
+- [ ] PR template checklist includes race detector requirement for `internal/tui/` and `internal/cli/` changes
+
+## Implementation Notes
+
+- Use YAML form format (not markdown) for issue templates — provides structured input fields recognized by GitHub
+- Issue template labels reference: `bug`, `enhancement`, `triage`, `question` — verify these labels exist in the repo or note them for creation
+- The PR template should reference the project's story-driven workflow without requiring contributors to understand BMAD internals
+- Feature request template must include SOUL.md philosophy acknowledgment to filter requests that conflict with project values
+- Keep templates concise — overly long templates discourage submissions
+
+## Files to Create
+
+- `.github/ISSUE_TEMPLATE/bug-report.yml`
+- `.github/ISSUE_TEMPLATE/feature-request.yml`
+- `.github/ISSUE_TEMPLATE/question.yml`
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+
+## Out of Scope
+
+- Creating or modifying GitHub labels (note needed labels in PR description)
+- Enabling private vulnerability reporting (repo settings, not code)
+- Root-level community docs (CODE_OF_CONDUCT.md, etc.) — see Story 0.43

--- a/docs/stories/0.43.story.md
+++ b/docs/stories/0.43.story.md
@@ -1,0 +1,73 @@
+# Story 0.43: Community Standards Documentation
+
+**Epic:** 0 — Infrastructure & Process
+**Priority:** P1
+**Status:** Not Started
+**Depends On:** Story 0.42 (issue/PR templates referenced by CONTRIBUTING.md and SUPPORT.md)
+
+## Context
+
+ThreeDoors is missing four root-level community standards files that GitHub uses to calculate the Community Health Score: CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, and SUPPORT.md. These files set expectations for contributors, establish security reporting procedures, and point users to the right resources. Combined with Story 0.42 (templates), this brings the health score from 42% to 100%.
+
+**Planning artifact:** `_bmad-output/planning-artifacts/community-standards-plan.md`
+
+## Description
+
+Create the four root-level community standards documents, customized for ThreeDoors' unique development model (solo maintainer + AI agent team, story-driven development, opinionated design philosophy).
+
+## Acceptance Criteria
+
+### CODE_OF_CONDUCT.md
+- [ ] Uses Contributor Covenant v2.1 (standard text recognized by GitHub)
+- [ ] Contact method specified (GitHub Issues with `conduct` label or project owner contact)
+- [ ] Enforcement section names project maintainers
+
+### CONTRIBUTING.md
+- [ ] Prerequisites section: Go 1.25.4+, make, gofumpt, golangci-lint
+- [ ] Getting started: clone, build, test, lint, format commands
+- [ ] How to contribute: bug reports, feature requests, code submissions
+- [ ] Code submissions workflow: fork, branch, story file, tests, quality gate, PR
+- [ ] Code standards: references CLAUDE.md quality rules, gofumpt, golangci-lint, table-driven tests, race detector
+- [ ] "What NOT to contribute" section: SOUL.md conflicts, heavy dependencies, telemetry, testify
+- [ ] Architecture overview: cmd/, internal/tasks/, internal/tui/, TaskProvider interface
+- [ ] License: MIT — contributions under same license
+- [ ] Explains development model (solo maintainer + AI agents) without requiring contributors to use it
+
+### SECURITY.md
+- [ ] Supported versions: latest release on main only
+- [ ] Reporting method: GitHub private vulnerability reporting (preferred), not public issues
+- [ ] Expected response time stated (within 7 days)
+- [ ] Scope section: local-first app, no network services by default, local data storage, integration tokens stored locally
+- [ ] Security design principles: local-first, no cloud sync, no telemetry
+
+### SUPPORT.md
+- [ ] Links to README, docs/, SOUL.md
+- [ ] Links to issue templates (bug report, feature request, question) using GitHub template URLs
+- [ ] References SECURITY.md for vulnerability reporting
+
+## Implementation Notes
+
+- CODE_OF_CONDUCT.md: Use the exact Contributor Covenant 2.1 text — don't modify core sections, only fill in project-specific placeholders (contact, enforcement)
+- CONTRIBUTING.md: Most substantial file. Reference SOUL.md philosophy throughout. Don't expose BMAD internals — story-driven development is the public-facing process
+- SECURITY.md: Keep scope section honest about ThreeDoors being local-first. Note that integration adapters use user-provided tokens stored locally
+- SUPPORT.md: Brief — just a routing file pointing to the right places
+- All files should be consistent in tone: welcoming, direct, respecting contributors' time
+
+## Owner Decision Points
+
+These items require project owner input before or during implementation:
+1. **Contact email** for CoC and SECURITY.md — or use GitHub-only channels (Issues for CoC, private vulnerability reporting for security)
+2. **Enable private vulnerability reporting** — must be done in repo Settings → Security (not a code change)
+
+## Files to Create
+
+- `CODE_OF_CONDUCT.md`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+
+## Out of Scope
+
+- Issue/PR templates — see Story 0.42
+- Label creation in GitHub (note needed labels in Story 0.42)
+- Repo settings changes (private vulnerability reporting toggle)


### PR DESCRIPTION
## Summary

**Stories:** `docs/stories/0.42.story.md`, `docs/stories/0.43.story.md`

Creates two infrastructure stories for implementing GitHub community standards, based on the planning artifact at `_bmad-output/planning-artifacts/community-standards-plan.md`.

## Changes

- **Story 0.42: GitHub Issue & PR Templates** — Bug report, feature request, and question issue templates (YAML form format); config to disable blank issues; PR template with story-driven checklist
- **Story 0.43: Community Standards Documentation** — CODE_OF_CONDUCT.md (Contributor Covenant 2.1), CONTRIBUTING.md, SECURITY.md, SUPPORT.md — all customized for ThreeDoors' solo-maintainer + AI-agent development model

## Design Decisions

- **Two stories, not one:** Split templates (.github/ YAML files) from root-level docs (markdown) since they have different implementation concerns and Story 0.43 depends on 0.42 (CONTRIBUTING.md and SUPPORT.md reference the issue templates)
- **Single story per group, not per file:** All files within each story are tightly related and should ship as atomic PRs
- **Epic 0 numbering:** Continues from 0.41 (latest infra story)

## Owner Decision Points (flagged in Story 0.43)

1. Contact email for CoC and SECURITY.md — or use GitHub-only channels
2. Enable private vulnerability reporting in repo Settings → Security

## Checklist

- [x] Story files created with clear acceptance criteria
- [x] Planning artifact referenced
- [x] `make fmt` — no changes
- [x] `make lint` — zero warnings
- [x] `make test` — all tests pass
- [x] Commit message follows format

## Opportunities

- Labels referenced by templates (`triage`, `question`) may need to be created in GitHub — not a code change, should be done when Story 0.42 is implemented