### PR TITLE
docs: enforce D-162 — workers update story files only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,23 +41,20 @@ go test -race ./...   # Race detector — run before pushing
 - If no story exists for needed work, create one (or ask the supervisor/PM to create one) before writing code
 - Research, spikes, and documentation tasks are exempt — but should still reference a story when possible
 
-## Doc Maintenance — MANDATORY
+## Doc Maintenance — MANDATORY (D-162)
 
-### Story File Updates (Workers)
+Do NOT edit `ROADMAP.md`, `docs/prd/epic-list.md`, or `docs/prd/epics-and-stories.md` unless you are running `/plan-work`, or you are project-watchdog or supervisor.
 
-Workers update ONLY their story file when completing implementation:
+### Story File Updates (Implementation Workers)
 
-- Update the story file status line: `Done (PR #NNN)`
-- Workers MUST NOT update `ROADMAP.md`, `docs/prd/epic-list.md`, or `docs/prd/epics-and-stories.md` — these are owned by project-watchdog (see D-162)
+- Update the story file status line: `Done (PR #NNN)` — this is the ONLY doc update implementation workers make
+- Do NOT update planning docs — project-watchdog syncs them from story files
 
-### Planning Doc Updates (project-watchdog / PM)
+### Planning Doc Updates (project-watchdog / PM / /plan-work)
 
-project-watchdog initiates all planning doc updates after story PRs merge:
-
-- Update `ROADMAP.md` epic progress when stories complete
-- Update `docs/prd/epic-list.md` and `docs/prd/epics-and-stories.md` when the last story in an epic completes
-- When **creating a new epic or story**, ensure it is added to all three docs: `ROADMAP.md`, `docs/prd/epic-list.md`, and `docs/prd/epics-and-stories.md`
-- project-watchdog batches multiple story status updates into a single PR when possible (see D-161)
+- project-watchdog initiates planning doc updates after story PRs merge, batching multiple updates into a single PR when possible (D-161)
+- `/plan-work` workers create new epics/stories in all three planning docs as part of their pipeline
+- When **creating a new epic or story**, request the epic number from project-watchdog — do NOT self-assign
 - ROADMAP.md ownership belongs to the PM role
 - These three planning docs plus the story files form the source-of-truth chain — story files are authoritative for individual story status; planning docs must be kept consistent
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -30,11 +30,11 @@ Your task description defines your scope. Do not expand beyond it, even for "obv
 |---|---|---|
 | Implement the assigned task within its defined scope | Expand scope beyond the assigned task | Task is out of scope per ROADMAP.md |
 | Create PRs with detailed descriptions | Merge PRs (that's merge-queue's job) | Story acceptance criteria are ambiguous or contradictory |
-| Run tests, linting, and formatting | Modify ROADMAP.md, SOUL.md, or CLAUDE.md | Implementation requires an architectural decision not in existing docs |
+| Run tests, linting, and formatting | Modify ROADMAP.md, SOUL.md, CLAUDE.md, epic-list.md, or epics-and-stories.md unless running /plan-work (D-162) | Implementation requires an architectural decision not in existing docs |
 | Read any file in the codebase for context | Make architectural decisions not specified in the story | Tests reveal pre-existing bugs unrelated to the current task |
 | Create new files required by the task | Push to main directly — always use feature branches | |
 | Modify existing files within the task's scope | Delete or modify other agents' branches | |
-| Update story file status to `Done (PR #NNN)` | Update planning docs: ROADMAP.md, epic-list.md, epics-and-stories.md (D-162) | |
+| Update story file status to `Done (PR #NNN)` | Update planning docs unless running /plan-work (D-162) | |
 | | Implement "improvements" not in the task description | |
 | | Run manual git sync (INC-002) | |
 


### PR DESCRIPTION
## Summary
- Rewrites CLAUDE.md Doc Maintenance section: workers update ONLY story file status
- Expands worker.md CANNOT column: adds epic-list.md, epics-and-stories.md
- Marks Q-003 and Q-004 as resolved on BOARD.md (D-161, D-162)

## Context
D-162 (Option B) decided workers should not touch planning docs. PR #484 recorded the decision but didn't update the files agents actually read. This PR closes that gap.

## Test plan
- [ ] Verify CLAUDE.md no longer instructs workers to update ROADMAP.md
- [ ] Verify worker.md CANNOT column includes all planning docs
- [ ] Verify Q-003/Q-004 marked resolved on BOARD.md