### PR TITLE
docs: governance sync — Epic 51 ROADMAP drift

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -301,7 +301,7 @@ In-app `:bug` command for frictionless bug reporting without leaving the TUI. Br
 | 40 | Beautiful Stats Display | 10/10 |
 | 41 | Charm Ecosystem Adoption & TUI Polish | 6/6 |
 
-### Epic 51: SLAES — Self-Learning Agentic Engineering System (P1) — 1/10 stories done
+### Epic 51: SLAES — Self-Learning Agentic Engineering System (P1) — 4/10 stories done
 
 Continuous improvement meta-system with a persistent `retrospector` agent that monitors PR merges, detects process waste, audits doc consistency, and files improvement recommendations to BOARD.md. Dual-loop architecture: spec-chain quality (did we build the right thing?) and operational efficiency (are we building efficiently?).
 
@@ -309,13 +309,13 @@ Continuous improvement meta-system with a persistent `retrospector` agent that m
 |-------|-------|--------|----------|------------|
 | 51.1 | Retrospector Agent Definition (Responsibility+WHY Format) | Not Started | P1 | None |
 | 51.2 | Rewrite Operational Agent Definitions (Responsibility+WHY Format) | Done (PR #460) | P1 | None |
-| 51.3 | JSONL Findings Log & Per-Merge Lightweight Retro | Not Started | P1 | 51.1 |
+| 51.3 | JSONL Findings Log & Per-Merge Lightweight Retro | In Review (PR #462) | P1 | 51.1 |
 | 51.4 | Saga Detection (Dispatch Waste Alerting) | Not Started | P1 | 51.1 |
 | 51.5 | Doc Consistency Audit (Periodic Cross-Check) | In Review | P1 | 51.1 |
 | 51.6 | BOARD.md Recommendation Pipeline | Not Started | P1 | 51.3, 51.4, 51.5 |
-| 51.7 | Merge Conflict Rate Analysis | Not Started | P2 | 51.3, 51.6 |
-| 51.8 | CI Failure Rate Analysis & Coding Standard Proposals | Not Started | P2 | 51.3, 51.6 |
-| 51.9 | Research Lifecycle Tracking | Not Started | P2 | 51.3, 51.6 |
+| 51.7 | Merge Conflict Rate Analysis | Done (PR #506) | P2 | 51.3, 51.6 |
+| 51.8 | CI Failure Rate Analysis & Coding Standard Proposals | Done (PR #505) | P2 | 51.3, 51.6 |
+| 51.9 | Research Lifecycle Tracking | Done (PR #507) | P2 | 51.3, 51.6 |
 | 51.10 | PR Creation Authority & Trend Reporting | Not Started | P2 | 51.1-51.9 |
 
 **Phasing:** Phase 0 (stories 51.1-51.2): Bootstrap — rewrite agent definitions. Phase 1 (stories 51.3-51.6): MVP monitoring. Phase 2 (stories 51.7-51.10): Advanced analysis after 2 weeks of MVP validation.

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -712,6 +712,6 @@
 | Epic 48: Door-Like Doors | 4 | Not Started |
 | Epic 49: ThreeDoors Doctor | 10 | Not Started |
 | Epic 50: In-App Bug Reporting | 3 | Not Started |
-| Epic 51: SLAES | 10 | Not Started |
+| Epic 51: SLAES | 10 | In Progress (4/10 done) |
 | **Total** | **274** | **146 complete, 4 epics in progress, 128 not started** |
 ---


### PR DESCRIPTION
## Summary

- Fix ROADMAP.md Epic 51 status drift after PRs #505, #506, #507 merged
- Story 51.3: Not Started → In Review (PR #462)
- Stories 51.7, 51.8, 51.9: Not Started → Done (PRs #506, #505, #507)
- Epic 51 header: 1/10 → 4/10 stories done
- epic-list.md: Not Started → In Progress (4/10 done)

## Context

Workers implemented Phase 2 stories but ROADMAP wasn't updated (story files were already corrected on main). This sync aligns ROADMAP.md and epic-list.md with the authoritative story file statuses.

## Processed PRs

- PR #505 (Story 51.8)
- PR #506 (Story 51.7)
- PR #507 (Story 51.9)