### PR TITLE
docs: governance sync — Story 0.44 Done, Epic 52 numbering conflict

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ Fix data accuracy in BOARD.md Epic Number Registry (wrong epic mappings, missing
 
 ### Story 0.44: Scoped Label Migration — Rename and Create GitHub Labels (P1)
 
-**Status:** Not Started.
+**Status:** Done (PR #513).
 
 Migrate all 21 GitHub labels to scoped `.` separator format per finalized 27-label taxonomy (D-106, D-107). Rename-first strategy preserves label-issue associations (D-110). Create 6 new labels, delete 2 obsolete ones.
 


### PR DESCRIPTION
## Summary

- ROADMAP.md Story 0.44 (Scoped Label Migration): Not Started → Done (PR #513)

## Epic 52 Numbering Conflict — ESCALATION

Epic 52 stories (52.1-52.4) for **Envoy Three-Layer Firewall** have all merged (PRs #514-517), but `epic-list.md` already assigns **Epic 52+ to "Advanced Features"** (Voice interface, web interface, Apple Watch, etc.).

The story files themselves note: `"number provisional — pending project-watchdog confirmation"`.

**As project-watchdog (INC-003 MUTEX), I am flagging this conflict.** Options:
1. Reassign Envoy Firewall to a new epic number (e.g., Epic 54)
2. Reassign "Advanced Features" to a higher number range
3. Keep Epic 52 for Envoy Firewall and renumber Advanced Features

Supervisor decision needed before I can add Epic 52 stories to ROADMAP.md.

## Processed PRs

- PR #512 (Story 0.42 — GitHub Templates, infra backlog)
- PR #513 (Story 0.44 — Scoped Label Migration)
- PR #514 (Story 52.3 — Layer 1 Gate Specs)
- PR #515 (Story 52.1 — Envoy Firewall Architecture)
- PR #516 (Story 52.4 — Layer 3 BMAD Escalation)
- PR #517 (Story 52.2 — Operations Guide Flowcharts)