### PR TITLE
docs: Epic 54 — Gemini Research Supervisor planning

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,6 +322,20 @@ Continuous improvement meta-system with a persistent `retrospector` agent that m
 
 **Dependency graph:** Stories 51.1 & 51.2 can parallelize. Stories 51.3-51.5 can parallelize after 51.1. Story 51.6 depends on 51.3-51.5. Phase 2 stories depend on Phase 1 validation.
 
+### Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure (P2) — 0/5 stories done
+
+Persistent research-supervisor agent that manages Gemini Deep Research queries on behalf of the multiclaude agent system. Uses `24601/agent-deep-research` as the execution layer (D-154). Features context-aware grounding (8 curated bundles, 60KB budget), three-layer result shielding (executive summary → detailed report → raw data), and budget management (50 queries/day, priority queue, batch optimization).
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 54.1 | Research-Supervisor Agent Definition | Not Started | P2 | None |
+| 54.2 | agent-deep-research CLI Integration & Tool Setup | Not Started | P2 | None |
+| 54.3 | Context Packaging & Prompt Engineering | Not Started | P2 | 54.1 |
+| 54.4 | Result Shielding & Artifact Storage | Not Started | P2 | 54.1, 54.2 |
+| 54.5 | Rate Limiting, Budget Management & Query Scheduling | Not Started | P2 | 54.1, 54.2 |
+
+**Dependency graph:** Stories 54.1 & 54.2 can parallelize. Stories 54.3, 54.4, 54.5 can parallelize after 54.1+54.2 complete.
+
 ## Icebox (Deferred Indefinitely)
 
 | Epic | Title | Stories | Decision Date | Rationale |

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -175,6 +175,7 @@
 | D-151 | Last-writer-wins with remote-wins for metadata, local-wins for ThreeDoors fields | 2026-03-09 | Simple and predictable; source system authoritative for metadata; ThreeDoors owns its enrichments | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
 | D-152 | Named connections with ULID IDs for multi-instance provider support | 2026-03-09 | Supports multiple instances of same provider type; user-friendly labels; globally unique IDs | [Research](../../_bmad-output/planning-artifacts/data-source-setup-ux-research.md) |
 | D-153 | Tiered remote collaboration: SSH+CLI today, MCP bridge near-term | 2026-03-10 | SSH provides zero-development access; MCP bridge adds native Claude Code integration; avoids over-engineering network-native multiclaude | [Investigation](../../_bmad-output/planning-artifacts/remote-collaboration-investigation.md), [Problem Solving](../../_bmad-output/planning-artifacts/remote-collab-creative-problem-solving.md), [Feasibility](../../_bmad-output/planning-artifacts/remote-collab-analyst-feasibility.md) |
+| D-154 | agent-deep-research (24601) as Gemini Deep Research execution layer | 2026-03-11 | Purpose-built CLI for agent consumption: dual JSON/human output, adaptive polling, `--context` for RAG grounding, `--dry-run` for cost estimation, `--depth` control, non-interactive mode. Rejected: Gemini CLI (agent-in-agent complexity, paid API key needed), direct curl/Python (must reimplement polling/retry/parsing), MCP server (engineering effort, poor fit for 5-45min async), browser UI (not automatable) | [Design](../../_bmad-output/planning-artifacts/gemini-research-supervisor-design.md) |
 
 ## Rejected
 
@@ -345,7 +346,8 @@
 | 51 | SLAES — Self-Learning Agentic Engineering System | 2026-03-10 | In Progress (0/10) |
 | 52 | Envoy Three-Layer Firewall | 2026-03-10 | Not Started (0/4) |
 | 53 | Remote Collaboration — multiclaude Cross-Machine Access | 2026-03-10 | Not Started (0/5) |
-| 54 | *(next available)* | — | — |
+| 54 | Gemini Research Supervisor — Deep Research Agent Infrastructure | 2026-03-11 | Not Started (0/5) |
+| 55 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -650,7 +650,33 @@
 - **Research:** See `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md`, `_bmad-output/planning-artifacts/subagent-abuse-investigation.md`
 - **Decisions:** D-1 (single agent), D-2 (SLAES/retrospector naming), D-3 (persistent 15-min polling), D-4 (Level 2 authority), D-5 (consumer model), D-6 (dual-loop), D-7 (per-PR + batch), D-8 (5 Watchmen safeguards), D-9 (mode rotation), D-10 (responsibility+WHY definitions)
 
-**Epic 52+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 52: Envoy Three-Layer Firewall** (P1)
+- **Goal:** Restructure the envoy agent definition into a formal three-layer firewall architecture for issue screening, with clear entry/exit criteria at each layer.
+- **Prerequisites:** Epic 37 (Persistent BMAD Agents — complete)
+- **Status:** Not Started
+- **Stories:** 52.1-52.4 (4 stories)
+
+**Epic 53: Remote Collaboration — multiclaude Cross-Machine Access** (P2)
+- **Goal:** Document and enable remote collaboration with multiclaude via SSH, with future MCP bridge support.
+- **Prerequisites:** None
+- **Status:** Not Started
+- **Stories:** 53.1-53.5 (5 stories)
+
+**Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure** (P2)
+- **Goal:** Deploy a persistent research-supervisor agent that manages Gemini Deep Research queries on behalf of the multiclaude agent system, with context-aware grounding, result shielding, and budget management.
+- **Prerequisites:** Epic 37 (Persistent BMAD Agents — complete), `uv` installed, Gemini API key
+- **Status:** Not Started
+- **Deliverables:**
+  - Research-supervisor persistent agent definition (Responsibility+WHY format)
+  - agent-deep-research CLI tool integration (`_tools/agent-deep-research/`)
+  - Context packaging system (8 curated bundles, 60KB budget, keyword auto-detection)
+  - Three-layer result shielding (executive summary → detailed report → raw data)
+  - Rate limiting and budget management (50 queries/day, priority queue, batch optimization, deduplication)
+- **Stories:** 54.1-54.5 (5 stories)
+- **Research:** See `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md`
+- **Decisions:** D-154 (agent-deep-research as execution layer)
+
+**Epic 55+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -713,5 +739,8 @@
 | Epic 49: ThreeDoors Doctor | 10 | Not Started |
 | Epic 50: In-App Bug Reporting | 3 | Not Started |
 | Epic 51: SLAES | 10 | In Progress (5/10 done) |
-| **Total** | **274** | **146 complete, 4 epics in progress, 128 not started** |
+| Epic 52: Envoy Three-Layer Firewall | 4 | Not Started |
+| Epic 53: Remote Collaboration | 5 | Not Started |
+| Epic 54: Gemini Research Supervisor | 5 | Not Started |
+| **Total** | **288** | **146 complete, 4 epics in progress, 142 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -5156,3 +5156,113 @@ Expand retrospector authority to create PRs proposing improvements. Generate wee
 
 - SLAES Party Mode: `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md`
 - Subagent Abuse Investigation: `_bmad-output/planning-artifacts/subagent-abuse-investigation.md`
+
+---
+
+## Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure (P2)
+
+**Goal:** Deploy a persistent research-supervisor agent that manages Gemini Deep Research queries on behalf of the multiclaude agent system, with context-aware grounding, result shielding, and budget management.
+
+**Prerequisites:** Epic 37 (Persistent BMAD Agents — complete), `uv` installed, Gemini API key
+
+**Dependencies:** None (agent infrastructure, not application code)
+
+### Story 54.1: Research-Supervisor Agent Definition
+
+**As** the supervisor agent,
+**I want** a persistent research-supervisor agent with a clear definition file, polling loop, request protocol, and authority matrix,
+**So that** any agent can request deep research via messaging and receive structured findings without blocking.
+
+**Acceptance Criteria:**
+- Agent definition at `agents/research-supervisor.md` follows Responsibility+WHY format (Story 51.2)
+- 5-minute polling loop documented: check messages → dispatch queued → monitor running → process completed
+- Request protocol: `RESEARCH priority=<high|normal|low> depth=<quick|standard|deep> [context=<bundles>]: <question>`
+- Authority matrix: CAN (receive, queue, dispatch, store, summarize, deliver) / CANNOT (decide, execute, create stories, modify code) / ESCALATE (budget exhausted, security vuln, repeated failures)
+- Communication protocols: RESEARCH-RESULT, RESEARCH-ERROR, RESEARCH-BUDGET message formats
+
+**Priority:** P2 | **Depends On:** None
+
+### Story 54.2: agent-deep-research CLI Integration & Tool Setup
+
+**As** the research-supervisor agent,
+**I want** the agent-deep-research tool installed, configured, and verified in `_tools/`,
+**So that** I can dispatch Gemini Deep Research queries via `uv run` with structured JSON output and local file grounding.
+
+**Acceptance Criteria:**
+- agent-deep-research cloned to `_tools/agent-deep-research/` (gitignored)
+- `_bmad-output/research-reports/` directory created with per-query subdirectory layout
+- `_tools/` added to `.gitignore`
+- API key documented as environment variable (never committed)
+- Dry-run verification command succeeds
+- Setup script at `scripts/setup-research-tool.sh` automates clone + verify
+
+**Priority:** P2 | **Depends On:** None
+
+### Story 54.3: Context Packaging & Prompt Engineering
+
+**As** the research-supervisor agent,
+**I want** pre-defined context bundles and a prompt template that tailor each query with relevant project files,
+**So that** Gemini receives focused, project-specific grounding that improves result relevance within token budgets.
+
+**Acceptance Criteria:**
+- 8 context bundles documented: core, architecture, prd, stories, decisions, code-sample, tui, tasks
+- Keyword-to-bundle auto-detection mapping
+- 60KB context budget with priority shedding order (drop code-sample → truncate stories → drop prd)
+- Standard prompt template with: project context, grounding instructions, question, output requirements
+- `--context` and `--context-extensions` flag usage documented
+
+**Priority:** P2 | **Depends On:** 54.1
+
+### Story 54.4: Result Shielding & Artifact Storage
+
+**As** the supervisor (or any requesting agent),
+**I want** research results delivered as concise executive summaries with full reports on disk,
+**So that** context windows are not overwhelmed by 5,000-15,000 word reports.
+
+**Acceptance Criteria:**
+- Three-layer summary architecture: executive summary (≤500 words) → detailed report → raw data
+- Per-query directory: `YYYYMMDD-HHMMSS-<slug>/` with report.md, executive-summary.md, metadata.json, sources.json, context-bundle.md, request.json
+- Only executive summary sent via messaging; full report path included
+- RESEARCH-RESULT message format documented
+- Gating flow documented: research → summary → human/supervisor decision → optional action
+- No autonomous action restriction in CANNOT section
+
+**Priority:** P2 | **Depends On:** 54.1, 54.2
+
+### Story 54.5: Rate Limiting, Budget Management & Query Scheduling
+
+**As** the supervisor,
+**I want** daily query budget tracking, priority queuing, deduplication, and batch optimization,
+**So that** the 50 queries/day Gemini quota is used efficiently.
+
+**Acceptance Criteria:**
+- `budget.json` schema: date, daily_limit, queries_used, queries_remaining, query history
+- Daily reset at midnight UTC
+- Reserve pool: 5 queries held back after 6pm UTC for high-priority
+- Priority queue: high=immediate, normal=FIFO, low=budget-permitting
+- Batch optimization: 3+ related queries combined with merged prompt
+- Deduplication: 7-day lookback against existing `request.json` files
+- Dry-run gate for deep-depth queries
+- 2-minute cooldown between dispatches
+- RESEARCH-BUDGET escalation message for exhausted budget
+
+**Priority:** P2 | **Depends On:** 54.1, 54.2
+
+### Dependency Graph
+
+```
+54.1 (Agent Definition) ─┬──▶ 54.3 (Context Packaging)
+54.2 (CLI Integration)  ─┤
+                          ├──▶ 54.4 (Result Shielding) ← depends on 54.1 + 54.2
+                          └──▶ 54.5 (Rate Limiting) ← depends on 54.1 + 54.2
+```
+
+Stories 54.1 and 54.2 can parallelize. Stories 54.3, 54.4, and 54.5 can parallelize after 54.1+54.2 complete.
+
+### Decisions
+
+- D-154: agent-deep-research (24601) as Gemini Deep Research execution layer — rejected Gemini CLI, direct API, MCP server, browser UI, ephemeral worker model
+
+### Research
+
+- Design Artifact: `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md`

--- a/docs/stories/54.1.story.md
+++ b/docs/stories/54.1.story.md
@@ -1,0 +1,70 @@
+# Story 54.1: Research-Supervisor Agent Definition
+
+## Status: Not Started
+
+## Epic
+
+Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure
+
+## References
+
+- Design: `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md`
+- Tool: [24601/agent-deep-research](https://github.com/24601/agent-deep-research) (MIT)
+
+## Story
+
+As the supervisor agent,
+I want a persistent research-supervisor agent with a clear definition file, polling loop, request protocol, and authority matrix,
+So that any agent can request deep research via messaging and receive structured findings without blocking.
+
+## Background
+
+The multiclaude system currently has no way to perform deep, web-grounded research asynchronously. The research-supervisor fills this gap as a persistent agent (like envoy or arch-watchdog) that receives research requests via `multiclaude message send`, dispatches them to Gemini Deep Research via the agent-deep-research tool, and returns summarized findings to the requesting agent.
+
+The agent definition must specify: the 5-minute polling loop, the structured request message format (`RESEARCH priority=<P> depth=<D> [context=<bundles>]: <question>`), authority boundaries (information provider only — never decides or executes), communication protocols for results/errors/budget alerts, and the priority queue (high/normal/low).
+
+## Acceptance Criteria
+
+**Given** the agent definition file at `agents/research-supervisor.md`
+**When** a developer reads the file
+**Then** it follows the Responsibility+WHY format established in Story 51.2
+
+**Given** the agent definition
+**When** a persistent agent is spawned from it
+**Then** it describes a 5-minute polling loop that checks for new messages, monitors running queries, and processes completed results
+
+**Given** the request protocol section
+**When** an agent wants to request research
+**Then** the format `RESEARCH priority=<high|normal|low> depth=<quick|standard|deep> [context=<bundle-names>]: <question>` is clearly documented with examples
+
+**Given** the authority matrix
+**When** the research-supervisor processes results
+**Then** it is explicitly restricted to: receive, queue, dispatch, store, summarize, and deliver — never decide, execute, create stories, or modify code
+
+**Given** the communication protocols
+**When** the research-supervisor completes a query, encounters an error, or has a budget alert
+**Then** structured message formats are documented for each: `RESEARCH-RESULT`, `RESEARCH-ERROR`, `RESEARCH-BUDGET`
+
+**Given** the ESCALATE section
+**When** budget is exhausted, a security vulnerability is found, or queries fail repeatedly
+**Then** the definition specifies escalation to the supervisor
+
+## Technical Notes
+
+- This is a documentation/agent-definition change only. No Go code.
+- Follow the Responsibility+WHY format from Story 51.2 (see `agents/merge-queue.md` for reference).
+- The agent definition draft in the design artifact (Section 8) is the starting point — adapt to match existing agent definition conventions.
+- After creating the definition, the agent must be spawned via `multiclaude agents spawn --name research-supervisor --class persistent --prompt-file agents/research-supervisor.md`.
+- Add research-supervisor to the startup checklist in supervisor memory.
+
+## Tasks
+
+- [ ] Read existing persistent agent definitions (merge-queue, envoy, arch-watchdog) for format conventions
+- [ ] Create `agents/research-supervisor.md` following Responsibility+WHY format
+- [ ] Define polling loop (5-min cycle: check messages → dispatch queued → monitor running → process completed)
+- [ ] Document request protocol with message format and examples
+- [ ] Define authority matrix (CAN / CANNOT / ESCALATE)
+- [ ] Document communication protocols (RESEARCH-RESULT, RESEARCH-ERROR, RESEARCH-BUDGET)
+- [ ] Document spawning command and verify it matches multiclaude conventions
+- [ ] Run `make fmt` and `make lint` (no Go changes expected)
+- [ ] Update story status to Done

--- a/docs/stories/54.2.story.md
+++ b/docs/stories/54.2.story.md
@@ -1,0 +1,79 @@
+# Story 54.2: agent-deep-research CLI Integration & Tool Setup
+
+## Status: Not Started
+
+## Epic
+
+Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure
+
+## References
+
+- Design: `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md` (Sections 3, 4)
+- Tool: [24601/agent-deep-research](https://github.com/24601/agent-deep-research) (MIT)
+
+## Story
+
+As the research-supervisor agent,
+I want the agent-deep-research tool installed, configured, and verified in the project's `_tools/` directory,
+So that I can dispatch Gemini Deep Research queries via `uv run` with structured JSON output and local file grounding.
+
+## Background
+
+The design chose Option C: `24601/agent-deep-research` as the execution layer. This tool provides:
+- `--output-dir` for structured output (report.md, metadata.json, sources.json)
+- `--context` flag for local file grounding (RAG)
+- `--dry-run` for cost estimation
+- `--depth quick|standard|deep` for research duration control
+- Dual stdout=JSON / stderr=human output (agent-safe)
+- Non-interactive mode (auto-skips prompts)
+- Adaptive polling (already implemented)
+
+This story handles the one-time setup: cloning the tool, configuring gitignore, creating the output directory structure, and verifying connectivity.
+
+## Acceptance Criteria
+
+**Given** a fresh clone of the ThreeDoors repository
+**When** a developer runs the setup steps documented in this story
+**Then** the agent-deep-research tool is available at `_tools/agent-deep-research/`
+
+**Given** the `_tools/` directory
+**When** `git status` is run
+**Then** the `_tools/` directory is gitignored (not tracked)
+
+**Given** the `_bmad-output/research-reports/` directory
+**When** the research-supervisor stores artifacts
+**Then** the directory exists and follows the layout: `YYYYMMDD-HHMMSS-<slug>/` per-query subdirectories
+
+**Given** a valid `GEMINI_DEEP_RESEARCH_API_KEY` environment variable
+**When** `uv run _tools/agent-deep-research/scripts/research.py start "test" --depth quick --dry-run` is run
+**Then** the command succeeds and returns a dry-run cost estimate (no actual API call)
+
+**Given** the `.gitignore` file
+**When** checked
+**Then** `_tools/` is listed as an ignored pattern
+
+**Given** the setup documentation
+**When** a developer reads it
+**Then** it covers: cloning, API key configuration, uv verification, and connectivity testing
+
+## Technical Notes
+
+- `_tools/` is the conventional location for vendored external tools — add to `.gitignore` if not already present.
+- The tool uses `uv run` — `uv` is already a project convention (see CLAUDE.md personal directives).
+- API key should be set via environment variable, NOT committed to the repo. Document in the agent definition but do not hardcode.
+- The setup script or documentation should verify `uv --version` before proceeding.
+- `_bmad-output/research-reports/` should be created with a `.gitkeep` file so the directory structure is tracked even though report contents may or may not be tracked.
+- Consider whether research reports should be gitignored (they can be large). Recommend: gitignore the report contents but track `budget.json` for transparency.
+
+## Tasks
+
+- [ ] Add `_tools/` to `.gitignore` if not already present
+- [ ] Document clone step: `git clone https://github.com/24601/agent-deep-research.git _tools/agent-deep-research`
+- [ ] Create `_bmad-output/research-reports/` directory with `.gitkeep`
+- [ ] Add `_bmad-output/research-reports/*/` to `.gitignore` (ignore individual report dirs, keep budget.json)
+- [ ] Document API key setup (environment variable, NOT committed)
+- [ ] Document verification command: `uv run _tools/agent-deep-research/scripts/research.py start "test" --depth quick --dry-run`
+- [ ] Create a setup script at `scripts/setup-research-tool.sh` that automates clone + verify
+- [ ] Test the full setup flow on a clean worktree
+- [ ] Run `make fmt` and `make lint`
+- [ ] Update story status to Done

--- a/docs/stories/54.3.story.md
+++ b/docs/stories/54.3.story.md
@@ -1,0 +1,83 @@
+# Story 54.3: Context Packaging & Prompt Engineering
+
+## Status: Not Started
+
+## Epic
+
+Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure
+
+## References
+
+- Design: `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md` (Section 5)
+
+## Story
+
+As the research-supervisor agent,
+I want pre-defined context bundles and a prompt template that tailor each research query with relevant project files,
+So that Gemini Deep Research receives focused, project-specific grounding that improves result relevance without exceeding token budgets.
+
+## Background
+
+Gemini Deep Research can ground queries in uploaded files via `--context`, but dumping the entire repo would be wasteful and noisy. The design specifies curated context bundles:
+
+| Bundle | Files | Est. Size |
+|--------|-------|-----------|
+| `core` | CLAUDE.md, SOUL.md | ~8KB |
+| `architecture` | docs/architecture/*.md | ~15KB |
+| `prd` | docs/prd/epic-list.md + sections | ~10KB |
+| `stories` | Pattern-matched story files | ~5KB |
+| `decisions` | docs/decisions/BOARD.md | ~8KB |
+| `code-sample` | Grep-matched source files | ~20KB |
+| `tui` | internal/tui/ key files | ~15KB |
+| `tasks` | internal/tasks/ key files | ~15KB |
+
+The assembly algorithm: always include `core`, auto-detect additional bundles from query keywords, cap total context at ≤60KB (~15K tokens).
+
+A prompt template wraps every query with project context, output requirements (executive summary, detailed findings, relevance section, rejected approaches, ranked recommendations).
+
+## Acceptance Criteria
+
+**Given** the research-supervisor agent definition
+**When** it describes context assembly
+**Then** it lists all 8 bundle names with their file mappings and estimated sizes
+
+**Given** a research request with `context=architecture,tui`
+**When** the research-supervisor assembles context
+**Then** it includes core (always) + architecture + tui bundles
+
+**Given** a research request with no explicit context
+**When** the research-supervisor assembles context
+**Then** it auto-detects bundles from query keywords (e.g., "bubbletea" → tui, "provider" → tasks)
+
+**Given** assembled context exceeding 60KB
+**When** the budget is exceeded
+**Then** the agent follows the priority shedding order: drop code-sample → truncate stories to headers+ACs → drop prd → irreducible minimum is core+architecture+decisions (~31KB)
+
+**Given** any research query
+**When** the prompt is formulated
+**Then** it wraps the user's question in the standard prompt template with: project context paragraph, grounding file instructions, the question, and output requirements (executive summary ≤300 words, detailed findings, relevance section, rejected approaches, ranked recommendations)
+
+**Given** the prompt template
+**When** used across multiple queries
+**Then** it is stored as a reusable template in the agent definition, not hardcoded per-query
+
+## Technical Notes
+
+- Context assembly happens in the research-supervisor agent's reasoning — no Go code needed.
+- The agent copies relevant files to a temp directory and passes the path via `--context /tmp/research-context-<id>/`.
+- The `--context-extensions md,go` flag tells the tool which file types to include from the context directory.
+- Keyword-to-bundle mapping is a heuristic documented in the agent definition — it doesn't need to be a code implementation.
+- The prompt template should be embedded in the agent definition file as a clearly marked section.
+- For `code-sample` bundle, the agent uses `grep -r` to find relevant source files based on query keywords.
+
+## Tasks
+
+- [ ] Document all 8 context bundles with file paths and size estimates in the agent definition
+- [ ] Define keyword-to-bundle auto-detection mapping table
+- [ ] Define the 60KB budget cap and priority shedding order
+- [ ] Create the standard prompt template (project context, grounding instructions, question, output requirements)
+- [ ] Document the temp directory workflow for context assembly
+- [ ] Document `--context` and `--context-extensions` flag usage
+- [ ] Add examples of context assembly for different query types
+- [ ] Run `make fmt` and `make lint`
+- [ ] Update story status to Done

--- a/docs/stories/54.4.story.md
+++ b/docs/stories/54.4.story.md
@@ -1,0 +1,78 @@
+# Story 54.4: Result Shielding & Artifact Storage
+
+## Status: Not Started
+
+## Epic
+
+Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure
+
+## References
+
+- Design: `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md` (Section 6)
+
+## Story
+
+As the supervisor (or any requesting agent),
+I want research results delivered as concise executive summaries with full reports stored on disk,
+So that my context window is not overwhelmed by 5,000-15,000 word research reports while still having full access to detailed findings on demand.
+
+## Background
+
+Deep research reports are long. Piping them directly into an agent's context window is wasteful and risks information overload. The design specifies a three-layer summary architecture:
+
+1. **Layer 1: Executive Summary** (≤500 words) — Key findings, top recommendation, confidence level, path to full report. This is what gets sent to the requesting agent via messaging.
+2. **Layer 2: Detailed Findings** (full report.md) — Complete analysis with citations, comparative tables, relevance section, rejected alternatives. Stored on disk, read on demand.
+3. **Layer 3: Raw Data** (metadata.json, sources.json) — Interaction metadata, timing, cost, source URLs, transcript. Stored for auditing.
+
+Research results do NOT automatically enter the project workflow. The requesting agent reads the summary and decides whether to act, ignore, or investigate further. The research-supervisor is an information provider, not a decision-maker.
+
+## Acceptance Criteria
+
+**Given** a completed Gemini Deep Research query
+**When** the research-supervisor processes the output
+**Then** artifacts are stored at `_bmad-output/research-reports/YYYYMMDD-HHMMSS-<slug>/` containing: report.md, executive-summary.md, metadata.json, sources.json, context-bundle.md, request.json
+
+**Given** the full report.md from Gemini
+**When** the research-supervisor extracts a summary
+**Then** it produces an executive-summary.md of ≤500 words with: key findings (3-5 bullets), top recommendation, confidence level, and file path to the full report
+
+**Given** the executive summary
+**When** delivered to the requesting agent
+**Then** it is sent ONLY as a messaging text — the full report is NOT included in the message
+
+**Given** the result message format
+**When** the requesting agent receives it
+**Then** the message follows the format: `RESEARCH-RESULT for '<query-slug>': <summary text> Full report: <path>`
+
+**Given** the context-bundle.md file
+**When** stored alongside the report
+**Then** it records which context bundles were assembled and sent with the query (for reproducibility)
+
+**Given** the request.json file
+**When** stored alongside the report
+**Then** it records the original request metadata: requester, priority, depth, query text, timestamp
+
+**Given** research results
+**When** the requesting agent decides to act on findings
+**Then** the decision to act is made by the requesting agent or supervisor — the research-supervisor never autonomously triggers code changes, story creation, or ROADMAP edits
+
+## Technical Notes
+
+- The three-layer architecture is enforced by convention in the agent definition, not by Go code.
+- `executive-summary.md` extraction: if the report starts with an "Executive Summary" section, extract it. Otherwise, the research-supervisor reads and summarizes to ≤500 words.
+- `metadata.json` comes from agent-deep-research's `--output-dir` output. The research-supervisor adds `request.json` and `context-bundle.md`.
+- The `context-bundle.md` file lists which bundles were included and why (for debugging/tuning).
+- Message size limits in multiclaude messaging should be considered — executive summaries must be short enough to fit in a single message.
+- The gating flow (research → summary → decision → action) must be clearly documented to prevent autonomous action.
+
+## Tasks
+
+- [ ] Document the three-layer summary architecture in the agent definition
+- [ ] Define the per-query directory structure: `YYYYMMDD-HHMMSS-<slug>/`
+- [ ] Document executive summary extraction logic (extract existing section OR write new ≤500 words)
+- [ ] Define the RESEARCH-RESULT message format with examples
+- [ ] Document the context-bundle.md and request.json supplementary files
+- [ ] Document the gating flow: research → summary → human/supervisor decision → optional action
+- [ ] Add the "no autonomous action" restriction to the agent definition's CANNOT section
+- [ ] Run `make fmt` and `make lint`
+- [ ] Update story status to Done

--- a/docs/stories/54.5.story.md
+++ b/docs/stories/54.5.story.md
@@ -1,0 +1,90 @@
+# Story 54.5: Rate Limiting, Budget Management & Query Scheduling
+
+## Status: Not Started
+
+## Epic
+
+Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure
+
+## References
+
+- Design: `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md` (Section 7)
+
+## Story
+
+As the supervisor,
+I want the research-supervisor to track daily query budgets, prioritize requests, deduplicate similar queries, and batch related requests,
+So that the 50 queries/day Gemini quota is used efficiently and high-priority research is never blocked by low-priority bulk.
+
+## Background
+
+The user has Gemini Pro with ~50 deep research queries/day. Without budget management, agents could exhaust the quota on low-priority queries early in the day, leaving nothing for urgent requests. The design specifies:
+
+- **Daily budget:** 50 queries, tracked in `budget.json`, reset at midnight UTC
+- **Reserve pool:** 5 queries held back after 6pm UTC for high-priority requests
+- **Priority queue:** high (immediate), normal (FIFO), low (only if budget allows)
+- **Batch optimization:** 3+ related normal-priority requests combined into one deeper query
+- **Deduplication:** Check last 7 days of reports before dispatching similar queries
+- **Dry-run gate:** Always `--dry-run` first for deep-depth queries
+- **Cooldown:** Minimum 2 minutes between dispatches
+
+Cost model: quick ($0.50-$1.00, 2-5 min), standard ($2-$3, 5-20 min), deep ($3-$5, 20-45 min).
+
+## Acceptance Criteria
+
+**Given** the budget tracking file at `_bmad-output/research-reports/budget.json`
+**When** the research-supervisor dispatches a query
+**Then** the budget file is updated with: query ID, timestamp, depth, priority, requester, status, duration, estimated cost
+
+**Given** the start of a new UTC day
+**When** the research-supervisor checks the budget
+**Then** `queries_used` resets to 0 and `queries_remaining` resets to the daily limit (50)
+
+**Given** a high-priority request and budget is exhausted
+**When** the research-supervisor processes the request
+**Then** it escalates to the supervisor via `RESEARCH-BUDGET` message rather than silently dropping the request
+
+**Given** the time is after 6pm UTC
+**When** the research-supervisor has ≤5 queries remaining
+**Then** only high-priority requests are dispatched; normal and low are queued until the next day
+
+**Given** 3+ queued normal-priority requests with overlapping keywords
+**When** the research-supervisor evaluates the queue
+**Then** it combines them into a single deeper query with a merged prompt, saving budget
+
+**Given** a new research request
+**When** the research-supervisor checks for duplicates
+**Then** it searches `request.json` files from the last 7 days for similar queries (keyword match) and notifies the requester of existing results if found
+
+**Given** a deep-depth research request
+**When** the research-supervisor prepares to dispatch
+**Then** it runs `--dry-run` first and logs the cost estimate before committing
+
+**Given** two queries dispatched in sequence
+**When** timing is checked
+**Then** at least 2 minutes elapsed between dispatches (cooldown)
+
+## Technical Notes
+
+- Budget tracking is convention-based — the agent maintains `budget.json` through its own reasoning, not Go code.
+- `budget.json` schema: `{ date, daily_limit, queries_used, queries_remaining, queries: [...] }`
+- Batch detection is heuristic: keyword overlap between queued request texts. The agent uses its judgment to combine related queries.
+- Deduplication searches `request.json` files in recent report directories — the agent uses `find` + `grep` to locate matches.
+- The dry-run gate for deep queries is a safety measure — agent-deep-research's `--dry-run` flag returns cost estimate without API call.
+- The 2-minute cooldown prevents accidental rapid-fire from burst message arrivals.
+- End-of-day budget report: the agent sends a summary to the supervisor at the last poll cycle of the day.
+
+## Tasks
+
+- [ ] Define `budget.json` schema in the agent definition with all required fields
+- [ ] Document daily reset logic (midnight UTC)
+- [ ] Document reserve pool rule (5 queries held back after 6pm UTC)
+- [ ] Document priority queue behavior: high=immediate, normal=FIFO, low=budget-permitting
+- [ ] Document batch optimization: detection criteria, merge strategy, savings reporting
+- [ ] Document deduplication: 7-day lookback, keyword matching, notification to requester
+- [ ] Document dry-run gate for deep-depth queries
+- [ ] Document 2-minute cooldown between dispatches
+- [ ] Document end-of-day budget report format
+- [ ] Document RESEARCH-BUDGET escalation message format
+- [ ] Run `make fmt` and `make lint`
+- [ ] Update story status to Done


### PR DESCRIPTION
## Summary

- Create Epic 54: Gemini Research Supervisor — Deep Research Agent Infrastructure (P2)
- Add 5 story files (54.1-54.5) covering agent definition, CLI integration, context packaging, result shielding, and rate limiting
- Register decision D-154 (agent-deep-research as execution layer) in BOARD.md with rejected alternatives
- Reserve Epic 54 in BOARD.md Epic Number Registry
- Update all three planning docs: ROADMAP.md, epic-list.md, epics-and-stories.md

### Stories

| Story | Title |
|-------|-------|
| 54.1 | Research-Supervisor Agent Definition |
| 54.2 | agent-deep-research CLI Integration & Tool Setup |
| 54.3 | Context Packaging & Prompt Engineering |
| 54.4 | Result Shielding & Artifact Storage |
| 54.5 | Rate Limiting, Budget Management & Query Scheduling |

### Source

Design artifact: `_bmad-output/planning-artifacts/gemini-research-supervisor-design.md` (from clever-penguin worker)

## Test plan

- [ ] All story files have correct epic number (54), status (Not Started), and acceptance criteria
- [ ] BOARD.md has D-154 decision entry with rejected alternatives
- [ ] Epic Number Registry updated (54 allocated, 55 next available)
- [ ] ROADMAP.md has Epic 54 section with story table
- [ ] epic-list.md has Epic 54 entry with deliverables
- [ ] epics-and-stories.md has full Epic 54 section with all 5 stories
- [ ] No Go code changes — `make lint` passes clean
- [ ] Story dependency graph is consistent across all docs