### PR TITLE
docs: add ProviderBridge, ConnAwareScheduler, ResolveFromConfig to arch docs

### DIFF
--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -425,6 +425,44 @@ type Syncer interface {
 - **Factory functions** for all exported types (`NewConnectionManager`, `NewConnectionService`, `NewEnvCredentialStore`)
 - **Rollback on failure** in `ConnectionService.Add()` — transactional semantics across manager + credential store + config
 
+#### Component: ProviderBridge (Story 43.6)
+
+**Responsibility:** Adapt existing `TaskProvider` implementations to the `HealthChecker` and `Syncer` interfaces so `ConnectionService` can perform health checks and force-syncs through the existing provider API.
+
+**Key Behaviors:**
+- `Register(connID, provider)` — associates a `TaskProvider` with a connection ID
+- `CheckHealth()` — delegates to `provider.HealthCheck()`, maps `core.HealthCheckResult` → `connection.HealthCheckResult`
+- `Sync()` — calls `provider.LoadTasks()`, updates connection's task count and last sync time
+- Thread-safe via `sync.RWMutex`
+
+#### Component: ConnAwareScheduler (Story 43.6)
+
+**Responsibility:** Per-connection polling scheduler that respects connection state. When a connection is Paused or Disconnected, its sync cycle is silently skipped.
+
+**Key Interfaces:**
+```go
+func NewConnAwareScheduler(manager *ConnectionManager, bridge *ProviderBridge) *ConnAwareScheduler
+func (s *ConnAwareScheduler) AddConnection(connID string, provider TaskProvider, config ProviderLoopConfig)
+func (s *ConnAwareScheduler) Start(ctx context.Context) <-chan ConnSchedulerResult
+func (s *ConnAwareScheduler) Stop()
+```
+
+**Key Behaviors:**
+- Launches one goroutine per connection with adaptive polling intervals
+- Checks connection state before each poll — skips Paused/Disconnected
+- Integrates with `provider.Watch()` channels for push-based updates
+- Results channel carries `ConnSchedulerResult` with connection ID for routing
+
+#### Component: ResolveFromConfig (Story 43.6)
+
+**Responsibility:** Bootstrap function that reads `connections[]` from config, creates `TaskProvider` instances via the `Registry`, registers them with `ConnectionManager`, and returns a fully wired `ResolvedConnections` struct.
+
+**Key Behaviors:**
+- Graceful degradation: connections that fail to initialize are logged and skipped
+- Returns `nil` when no connections configured (caller falls back to legacy `providers[]` path)
+- Uses config-defined IDs for stable identity across restarts
+- Wires `ProviderBridge` as both `HealthChecker` and `Syncer` for the `ConnectionService`
+
 ### Adapter Layer Components
 
 #### Component: AdapterRegistry (Epic 7)

--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -111,6 +111,9 @@ ThreeDoors/
 │   │       ├── credential.go        # CredentialStore interface + Env/Chain implementations
 │   │       ├── credential_ring.go   # OS keyring CredentialStore (keychain/keyring)
 │   │       ├── health.go            # HealthChecker, Syncer interfaces + HealthCheckResult
+│   │       ├── bridge.go            # ProviderBridge — adapts TaskProvider to HealthChecker/Syncer
+│   │       ├── conn_scheduler.go    # ConnAwareScheduler — state-aware polling per connection
+│   │       ├── resolve.go           # ResolveFromConfig — wires config → manager → providers
 │   │       ├── sync_event.go        # SyncEventLog — per-connection JSONL audit log
 │   │       └── oauth/               # OAuth device code flow
 │   │           ├── devicecode.go    # Device code grant implementation


### PR DESCRIPTION
## Summary

- Adds `bridge.go`, `conn_scheduler.go`, `resolve.go` to `source-tree.md`
- Documents `ProviderBridge`, `ConnAwareScheduler`, and `ResolveFromConfig` in `components.md`
- These components were introduced in PR #540 (Story 43.6) to bridge existing adapters to the ConnectionManager pattern

## Context

Follow-up to PR #533 which documented the initial connection package. PR #540 added the adapter bridge layer that was missing from architecture docs.

## Test plan

- [ ] Verify source-tree.md matches actual files in `internal/core/connection/`
- [ ] Verify component descriptions match code interfaces