### PR TITLE
docs: add Epic 44 TUI components to source tree

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -92,7 +92,9 @@ ThreeDoors/
 │   │   ├── source_badge.go          # Provider attribution badges (Epic 13)
 │   │   ├── decompose_view.go        # LLM decomposition results (Epic 14)
 │   │   ├── sources_view.go          # Sources dashboard — connection list/status (Epic 44)
+│   │   ├── source_detail_view.go   # Source detail: status, sync log, actions (Epic 44)
 │   │   ├── connect_wizard.go        # Setup wizard using huh forms (Epic 44)
+│   │   ├── disconnect_dialog.go    # Disconnect confirmation with task preservation (Epic 44)
 │   │   ├── styles.go                # Lipgloss style definitions
 │   │   └── messages.go              # Bubbletea message types
 │   │


### PR DESCRIPTION
## Summary
- Adds `disconnect_dialog.go` and `source_detail_view.go` to the Post-MVP source tree in `docs/architecture/source-tree.md`
- These Epic 44 TUI components were introduced in recent PRs but not reflected in architecture docs

## Correlation
Triggered by PR #581 (Story 44.6 — Disconnection Flow with Task Preservation)

## Test plan
- [ ] Verify source-tree.md renders correctly