### PR TITLE
docs: add synclog_detail_view.go to source tree

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -95,6 +95,7 @@ ThreeDoors/
 │   │   ├── source_detail_view.go   # Source detail: status, sync log, actions (Epic 44)
 │   │   ├── connect_wizard.go        # Setup wizard using huh forms (Epic 44)
 │   │   ├── disconnect_dialog.go    # Disconnect confirmation with task preservation (Epic 44)
+│   │   ├── synclog_detail_view.go  # Sync event log viewer per connection (Epic 44)
 │   │   ├── styles.go                # Lipgloss style definitions
 │   │   └── messages.go              # Bubbletea message types
 │   │


### PR DESCRIPTION
## Summary
- Adds `synclog_detail_view.go` to Post-MVP source tree in `docs/architecture/source-tree.md`
- Epic 44 sync log detail TUI component introduced in PR #582

## Correlation
Triggered by PR #582 (Story 44.4 — Sync Log Detail View)

## Test plan
- [ ] Verify source-tree.md renders correctly