### PR TITLE
docs: mark P-004 as Done — fork refs removed in Story 51.2

### DIFF
--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -27,7 +27,7 @@
 | P-001 | Migrate from Makefile to Justfile | 2026-03-04 | Research spike | [Analysis](../../_bmad-output/planning-artifacts/makefile-vs-justfile-analysis.md) | Owner sign-off |
 | P-002 | Envoy three-layer firewall implementation | 2026-03-08 | Party mode (8 sessions) | [Plan](../../_bmad-output/planning-artifacts/envoy-three-layer-firewall-plan.md), [Party Mode](../../_bmad-output/planning-artifacts/envoy-rules-of-behavior-party-mode.md) | **Done** — Epic 52 created (4 stories). Original artifact missing; plan reconstructed from available sources. Epic number provisional. |
 | P-003 | GitHub issue labeling taxonomy and triage flow | 2026-03-08 | Party mode (5 sessions) | [Artifact](../../_bmad-output/planning-artifacts/issue-labeling-and-triage-strategy.md) | **Done** — Story 0.46 (triage flow docs) |
-| P-004 | Update pr-shepherd definition to remove fork references | 2026-03-08 | Investigation | [Research](../../_bmad-output/planning-artifacts/persistent-agent-communication-research.md) | **Approved** — update then run `/sync-enhancements` after merge |
+| P-004 | Update pr-shepherd definition to remove fork references | 2026-03-08 | Investigation | [Research](../../_bmad-output/planning-artifacts/persistent-agent-communication-research.md) | **Done** — fork references already removed during Story 51.2 agent definition rewrite (PR #460) |
 | P-005 | Scoped label taxonomy: 27 labels with `.` separator, migration plan | 2026-03-08 | Party mode (3 rounds) + research spike | [Party Mode](../../_bmad-output/planning-artifacts/scoped-labels-party-mode.md), [Research](../../_bmad-output/planning-artifacts/scoped-labels-research.md) | **Done** — Stories 0.44 (migration), 0.45 (agent defs), 0.46 (authority docs) |
 
 ## Decided


### PR DESCRIPTION
## Summary

- Updates BOARD.md to mark P-004 (remove fork references from pr-shepherd.md) as **Done**
- Verified that all fork/upstream references were already removed from `agents/pr-shepherd.md` during the Story 51.2 agent definition rewrite (PR #460)
- No content changes needed to pr-shepherd.md — only the BOARD.md status update

## Context

P-004 was approved on 2026-03-08 to update pr-shepherd after the project switched from fork workflow to direct push (2026-03-07). The subsequent Story 51.2 rewrite of all agent definitions (PR #460) already addressed this by removing all fork-related references.

## Test plan

- [x] Verified no fork/upstream references remain in `agents/pr-shepherd.md`
- [x] Verified no fork/upstream references remain in any file under `agents/`
- [x] BOARD.md P-004 status updated to Done with rationale