### PR TITLE
docs: Story 51.11 — Retrospector Autonomy Fixes planning

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -293,7 +293,7 @@ Document and enable remote collaboration with multiclaude via SSH, with future M
 | 53.4 | Remote Worker Dispatch | Not Started | P2 | 53.2, 53.3 |
 | 53.5 | MCP Bridge Prototype | Not Started | P2 | 53.1 |
 
-### Epic 51: SLAES — Self-Learning Agentic Engineering System (P1) — 5/10 stories done
+### Epic 51: SLAES — Self-Learning Agentic Engineering System (P1) — 5/11 stories done
 
 Continuous improvement meta-system with a persistent `retrospector` agent that monitors PR merges, detects process waste, audits doc consistency, and files improvement recommendations to BOARD.md. Dual-loop architecture: spec-chain quality (did we build the right thing?) and operational efficiency (are we building efficiently?).
 
@@ -309,6 +309,7 @@ Continuous improvement meta-system with a persistent `retrospector` agent that m
 | 51.8 | CI Failure Rate Analysis & Coding Standard Proposals | Done (PR #505) | P2 | 51.3, 51.6 |
 | 51.9 | Research Lifecycle Tracking | Done (PR #507) | P2 | 51.3, 51.6 |
 | 51.10 | PR Creation Authority & Trend Reporting | Done (PR #509) | P2 | 51.1-51.9 |
+| 51.11 | Retrospector Autonomy Fixes — Agent Definition Rewrite | Not Started | P1 | 51.1 |
 
 **Phasing:** Phase 0 (stories 51.1-51.2): Bootstrap — rewrite agent definitions. Phase 1 (stories 51.3-51.6): MVP monitoring. Phase 2 (stories 51.7-51.10): Advanced analysis after 2 weeks of MVP validation.
 

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -646,7 +646,7 @@
   - Phase 1 (MVP): JSONL findings log with per-merge lightweight retro, saga detection (2+ workers on same fix), doc consistency audit (periodic cross-check of planning docs), BOARD.md recommendation pipeline with confidence scoring
   - Phase 2: Merge conflict rate analysis (hot files, parallelization safety), CI failure taxonomy and spec-chain tracing, research lifecycle tracking, PR creation authority, weekly trend reporting
   - 5 Watchmen safeguards: no self-modification, audit trail, confidence scoring, periodic human review, kill switch (3 rejections → read-only)
-- **Stories:** 51.1-51.10 (10 stories)
+- **Stories:** 51.1-51.11 (11 stories)
 - **Research:** See `_bmad-output/planning-artifacts/agentic-engineering-agent-party-mode.md`, `_bmad-output/planning-artifacts/subagent-abuse-investigation.md`
 - **Decisions:** D-1 (single agent), D-2 (SLAES/retrospector naming), D-3 (persistent 15-min polling), D-4 (Level 2 authority), D-5 (consumer model), D-6 (dual-loop), D-7 (per-PR + batch), D-8 (5 Watchmen safeguards), D-9 (mode rotation), D-10 (responsibility+WHY definitions)
 
@@ -784,12 +784,12 @@
 | Epic 48: Door-Like Doors | 4 | Complete (4/4 done) |
 | Epic 49: ThreeDoors Doctor | 10 | Complete (10/10 done) |
 | Epic 50: In-App Bug Reporting | 3 | In Progress (50.1 In Review) |
-| Epic 51: SLAES | 10 | In Progress (5/10 done) |
+| Epic 51: SLAES | 11 | In Progress (5/11 done) |
 | Epic 52: Envoy Three-Layer Firewall | 4 | Complete (4/4 done) |
 | Epic 53: Remote Collaboration | 5 | Not Started |
 | Epic 54: Gemini Research Supervisor | 5 | In Progress (2/5 done) |
 | Epic 55: CI Optimization Phase 1 | 3 | Complete (3/3 done) |
 | Epic 56: Door Visual Redesign | 5 | Not Started |
 | Epic 58: Supervisor Shift Handover | 7 | Not Started |
-| **Total** | **303** | **152 complete, 9 epics in progress, 143 not started** |
+| **Total** | **304** | **152 complete, 9 epics in progress, 144 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 1-15, 3.5, 17-28, 32-41, 43, 45, 48-49, 52, 55 are COMPLETE. Epic 29 is 3/4 (29.3 In Review). Epic 0 is partial (12/19). Epic 16 is ICEBOX. Epic 42 (4/5), Epic 44 (6/7), Epic 46 (1/4), Epic 51 (5/10), Epic 54 (2/5) IN PROGRESS. Epics 30-31, 47, 50, 53, 58 NOT STARTED or IN PROGRESS. 590+ merged PRs total. Last audit: 2026-03-12.
+**Implementation Status:** Epics 1-15, 3.5, 17-28, 32-41, 43, 45, 48-49, 52, 55 are COMPLETE. Epic 29 is 3/4 (29.3 In Review). Epic 0 is partial (12/19). Epic 16 is ICEBOX. Epic 42 (4/5), Epic 44 (6/7), Epic 46 (1/4), Epic 51 (5/11), Epic 54 (2/5) IN PROGRESS. Epics 30-31, 47, 50, 53, 58 NOT STARTED or IN PROGRESS. 590+ merged PRs total. Last audit: 2026-03-12.
 
 ## Requirements Inventory
 
@@ -5063,7 +5063,7 @@ Three tiered submission methods from the preview screen: (1) Browser URL — ope
 
 **Prerequisites:** Epic 37 (Persistent BMAD Agents — complete)
 
-**Status:** In Progress (5/10 stories done; 5 In Review)
+**Status:** In Progress (5/11 stories done; 5 In Review)
 
 **Phasing:**
 - Phase 0 (Bootstrap): Stories 51.1-51.2 — Agent definition rewrites
@@ -5131,6 +5131,12 @@ Track research artifacts through lifecycle: active → formalized → stale → 
 Expand retrospector authority to create PRs proposing improvements. Generate weekly trend reports with project health metrics.
 
 **AC:** PR creation on `slaes/` branches for high-confidence recommendations pending >48 hours. Self-modification safeguard (never touch own definition). Weekly trend report with CI first-pass rate, rebase count, saga count, recommendation acceptance rate. Metric regression detection. Depends on all Phase 1 + Phase 2 stories.
+
+#### Story 51.11: Retrospector Autonomy Fixes — Agent Definition Rewrite
+
+Rewrite `agents/retrospector.md` to eliminate language that causes Claude to seek human confirmation. Five targeted changes: add imperative "Your Rhythm" polling loop with bash commands, reframe "Periodic Human Review" as passive/async, change "Kill Switch" to self-monitor BOARD.md, move communication rules higher in doc, add anti-prompting guardrail. Text-only changes — no code modifications.
+
+**AC:** Imperative polling loop with explicit bash commands (matching arch-watchdog/envoy/project-watchdog pattern). "Periodic Human Review" reframed as passive — not agent's responsibility. "Kill Switch" detects rejections via BOARD.md state, not interactive feedback. Communication section positioned before Watchmen Safeguards. Anti-prompting guardrail in Incident-Hardened Guardrails section. All 5 Watchmen safeguards preserved (reframed, not removed). Retrospector operates autonomously after restart.
 
 ### Design Decisions
 

--- a/docs/stories/51.11.story.md
+++ b/docs/stories/51.11.story.md
@@ -1,0 +1,107 @@
+# Story 51.11: Retrospector Autonomy Fixes — Agent Definition Rewrite
+
+## Status: Not Started
+
+## Epic
+
+Epic 51: SLAES — Self-Learning Agentic Engineering System
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/retrospector-autonomy-investigation.md` (PR #597)
+- Depends on: 51.1 (retrospector agent definition exists)
+- Agent file: `agents/retrospector.md`
+
+## Story
+
+As a multiclaude operator,
+I want the retrospector agent definition rewritten to eliminate language that causes Claude to seek human confirmation,
+So that the retrospector operates fully autonomously like other persistent agents instead of prompting the user at the console.
+
+## Background
+
+Investigation (PR #597) found that the retrospector agent prompts the end user at the console for input/confirmation instead of acting autonomously. The spawn mechanism (`--dangerously-skip-permissions`) and Claude settings are correct — the root cause is agent definition language that primes Claude to expect human interaction.
+
+Five specific patterns in `agents/retrospector.md` cause the problem:
+1. No imperative "Your Rhythm" polling loop (other agents have explicit bash-command polling templates)
+2. "Periodic Human Review" safeguard implies active human interaction in the work loop
+3. "Kill Switch" requires tracking interactive human rejections
+4. Communication rules (`multiclaude message send`) are buried below cautionary safeguards
+5. No explicit anti-prompting guardrail
+
+The fix is prompt engineering — reframing language, not removing safeguards.
+
+## Acceptance Criteria
+
+**Given** the retrospector definition is updated with an imperative "Your Rhythm" section
+**When** the retrospector starts up
+**Then** it immediately begins its autonomous polling loop without waiting for human input
+**And** the section includes explicit bash commands for each polling step (matching the pattern used by arch-watchdog, envoy, and project-watchdog)
+
+**Given** the "Periodic Human Review" safeguard is reframed
+**When** Claude reads the definition
+**Then** it understands human review is passive/asynchronous — not something the agent solicits
+**And** the safeguard still exists (not removed) but is marked as "Not Your Responsibility"
+
+**Given** the "Kill Switch" safeguard is reframed
+**When** the retrospector checks for rejection state
+**Then** it monitors BOARD.md entries for "Rejected" markers instead of waiting for interactive human feedback
+**And** 3 consecutive rejections in BOARD.md trigger read-only mode
+
+**Given** the Communication section is repositioned
+**When** Claude processes the definition
+**Then** the "All messages MUST use the messaging system" instruction appears before the Watchmen safeguards section
+**And** `multiclaude message send` is the only communication mechanism referenced
+
+**Given** the anti-prompting guardrail is added
+**When** the retrospector encounters a situation where it might seek user input
+**Then** it has an explicit prohibition against prompting, asking questions in tmux, waiting for human feedback, or using AskUserQuestion
+**And** the guardrail is placed in the Incident-Hardened Guardrails section
+
+**Given** all 5 changes are applied
+**When** the retrospector is restarted with the updated definition
+**Then** it operates fully autonomously (no console prompts)
+**And** all existing functionality (post-merge retro, saga detection, doc audit, BOARD.md recommendations) is preserved
+**And** all 5 Watchmen safeguards remain intact (reframed, not removed)
+
+## Technical Notes
+
+- This is a text-only change to `agents/retrospector.md` — no code changes
+- The retrospector must be restarted after merge (definitions are baked in at spawn time)
+- Do NOT remove Watchmen safeguards — reframe their language to be compatible with autonomous operation
+- Use the exact patterns from working agents (arch-watchdog, envoy, project-watchdog) as templates for the polling loop
+- The "Your Rhythm" section should appear near the top, after "What You Own and Why"
+- Position matters for Claude's interpretation — cautionary content should follow action-oriented content, not precede it
+
+## Tasks
+
+### Task 1: Add "Your Rhythm — Autonomous Polling Loop" section
+Add imperative polling loop section after "What You Own and Why" with explicit bash commands for:
+- Startup state rebuild from JSONL
+- 15-minute merged PR polling (`gh pr list --state merged --limit 10 --json number,title,mergedAt,headRefName`)
+- Per-merge lightweight retro trigger
+- 4-hour deep analysis mode rotation
+- Saga detection threshold monitoring
+- `multiclaude message send` for all communication
+
+### Task 2: Reframe "Periodic Human Review" as passive
+Change header to "Periodic Human Review (Passive — Not Your Responsibility)". Rewrite body to make clear this is asynchronous and the agent does NOT prompt for, wait for, or solicit this review.
+
+### Task 3: Reframe "Kill Switch" as self-monitored via BOARD.md
+Change header to "Kill Switch (Self-Monitored)". Rewrite to detect rejections by reading BOARD.md state instead of interactive human feedback. 3 consecutive "Rejected" markers → read-only mode + message supervisor.
+
+### Task 4: Move Communication section before Watchmen Safeguards
+Relocate the "All messages MUST use the messaging system" block and `multiclaude message send` examples to appear before the Watchmen Safeguards section. This ensures Claude reads action-oriented communication rules before cautionary content.
+
+### Task 5: Add anti-prompting guardrail to Incident-Hardened Guardrails
+Add explicit prohibition: NEVER prompt user, NEVER ask questions in tmux expecting response, NEVER wait for human feedback, NEVER use AskUserQuestion. All communication via `multiclaude message send`.
+
+### Task 6: Validation
+- Verify all 5 Watchmen safeguards are preserved (reframed, not removed)
+- Verify no procedural "do X then Y" leaks (responsibility+WHY format maintained)
+- Verify authority table unchanged
+- Run `make fmt` and `make lint` (no-op for .md but good hygiene)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

- Creates `docs/stories/51.11.story.md` for the Retrospector Autonomy Fixes under Epic 51 (SLAES)
- Updates `ROADMAP.md`, `docs/prd/epic-list.md`, and `docs/prd/epics-and-stories.md` with Story 51.11
- Based on research artifact from PR #597 (retrospector autonomy investigation)

## Context

The retrospector agent prompts the user at the console instead of operating autonomously. Root cause: agent definition language primes Claude to seek human confirmation. Five targeted changes to `agents/retrospector.md`:

1. Add imperative "Your Rhythm" polling loop with explicit bash commands
2. Reframe "Periodic Human Review" as passive/async (not agent's responsibility)
3. Change "Kill Switch" to self-monitor BOARD.md for rejection markers
4. Move communication rules higher in doc (before cautionary safeguards)
5. Add anti-prompting guardrail to Incident-Hardened Guardrails

Story number 51.11 confirmed by supervisor via project-watchdog.

## Test plan

- [ ] Story file has complete ACs covering all 5 changes
- [ ] Planning docs are consistent (epic-list, epics-and-stories, ROADMAP all reference 51.11)
- [ ] Story count updated in all three planning docs
- [ ] No code changes — docs only