### PR TITLE
docs: add Epic 59 — Full-Terminal Vertical Layout (2 stories)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -374,6 +374,19 @@ Detect supervisor context window degradation via daemon monitoring, serialize op
 
 **Dependency graph:** Stories 58.1 & 58.2 can parallelize. Story 58.3 depends on both. Story 58.4 depends on 58.2 & 58.3. Phase 2 stories (58.5-58.7) can parallelize after Phase 1 completes.
 
+### Epic 59: Full-Terminal Vertical Layout (P1) — 0/2 stories done
+
+Transform ThreeDoors from a content-driven partial-terminal app into a full-terminal experience. AltScreen, fixed-header/flex-content/fixed-footer layout engine, capped door height with perceptual centering, and graceful degradation across terminal sizes. Based on full-terminal layout research (PR #329) and party mode consensus.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 59.1 | AltScreen + Layout Engine + Door Height Cap | Not Started | P1 | None |
+| 59.2 | Header/Footer Extraction + Graceful Degradation + Secondary Views Fill Height | Not Started | P1 | 59.1 |
+
+**Dependency graph:** Linear chain: 59.1 → 59.2. Story 59.1 is the foundation (AltScreen, layout engine, door cap). Story 59.2 is the follow-up (header/footer extraction, degradation breakpoints, all views fill height).
+
+**Note:** Story 59.1 is a prerequisite for Story 39.2 (keybinding bar footer slot) per D-121.
+
 ## Icebox (Deferred Indefinitely)
 
 | Epic | Title | Stories | Decision Date | Rationale |

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -370,7 +370,8 @@
 | 56 | Door Visual Redesign — Three-Layer Depth System | 2026-03-11 | Not Started (0/5) |
 | 57 | LLM CLI Services | 2026-03-11 | Not Started (0/8) |
 | 58 | Supervisor Shift Handover — Context-Aware Supervisor Rotation | 2026-03-11 | Not Started (0/7) |
-| 59 | *(next available)* | — | — |
+| 59 | Full-Terminal Vertical Layout | 2026-03-11 | Not Started (0/2) |
+| 60 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -739,7 +739,25 @@
 - **Research:** See `_bmad-output/planning-artifacts/door-visual-redesign/party-mode-door-redesign.md` (5-round party mode, 6 agents)
 - **Decisions:** D-172 (three-layer depth system), X-109 through X-112 (4 rejected alternatives)
 
-**Epic 59+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 59: Full-Terminal Vertical Layout** (P1)
+- **Goal:** Transform ThreeDoors from a content-driven partial-terminal app into a full-terminal experience using AltScreen, a fixed-header/flex-content/fixed-footer layout engine, capped door height with perceptual centering, and graceful degradation across terminal sizes
+- **Prerequisites:** None (foundational layout work)
+- **Status:** Not Started
+- **Deliverables:**
+  - AltScreen for full-terminal ownership (standard TUI pattern)
+  - Layout engine: fixed header + flex middle + fixed footer (layoutFull function)
+  - Door height capped at 25 lines with `min(max(10, available * 0.5), 25)` formula
+  - 40/60 top/bottom padding split for perceptual centering
+  - Help view dynamic page size (replaces hardcoded 20 lines)
+  - SetHeight propagation to all views
+  - Header/footer extraction from DoorsView into MainModel
+  - Breakpoint-based graceful degradation (<10, 10-15, 16-24, 25-40, 40+ lines)
+  - All secondary views fill available terminal height
+- **Stories:** 59.1-59.2 (2 stories: MVP + follow-up per D-120)
+- **Research:** See `_bmad-output/planning-artifacts/full-terminal-layout-research.md` and `full-terminal-layout-party-mode.md`
+- **Decisions:** D-114 (AltScreen), D-115 (layout model), D-116 (door cap), D-117 (40/60 padding), D-118 (dynamic height), D-119 (degradation), D-120 (two-story split), D-121 (prerequisite for 39.2)
+
+**Epic 60+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -809,5 +827,6 @@
 | Epic 56: Door Visual Redesign | 5 | Not Started |
 | Epic 57: LLM CLI Services | 8 | Not Started |
 | Epic 58: Supervisor Shift Handover | 7 | Not Started |
+| Epic 59: Full-Terminal Vertical Layout | 2 | Not Started |
 | **Total** | **312** | **152 complete, 9 epics in progress, 152 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 1-15, 3.5, 17-28, 32-41, 43, 45, 48-49, 52, 55 are COMPLETE. Epic 29 is 3/4 (29.3 In Review). Epic 0 is partial (12/19). Epic 16 is ICEBOX. Epic 42 (4/5), Epic 44 (6/7), Epic 46 (1/4), Epic 51 (5/11), Epic 54 (2/5) IN PROGRESS. Epics 30-31, 47, 50, 53, 58 NOT STARTED or IN PROGRESS. 590+ merged PRs total. Last audit: 2026-03-12.
+**Implementation Status:** Epics 1-15, 3.5, 17-28, 32-41, 43, 45, 48-49, 52, 55 are COMPLETE. Epic 29 is 3/4 (29.3 In Review). Epic 0 is partial (12/19). Epic 16 is ICEBOX. Epic 42 (4/5), Epic 44 (6/7), Epic 46 (1/4), Epic 51 (5/11), Epic 54 (2/5) IN PROGRESS. Epics 30-31, 47, 50, 53, 58-59 NOT STARTED or IN PROGRESS. 590+ merged PRs total. Last audit: 2026-03-12.
 
 ## Requirements Inventory
 
@@ -5772,3 +5772,84 @@ Phase 2 (Hardening):  58.5, 58.6, 58.7 can parallelize after Phase 1
 
 - Full research: `_bmad-output/planning-artifacts/supervisor-shift-handover/` (5 party mode sessions)
 - Synthesis: `_bmad-output/planning-artifacts/supervisor-shift-handover/synthesis-supervisor-shift-handover.md`
+
+## Epic 59: Full-Terminal Vertical Layout (P1)
+
+**Goal:** Transform ThreeDoors from a content-driven partial-terminal app into a full-terminal experience using AltScreen, a fixed-header/flex-content/fixed-footer layout engine, capped door height with perceptual centering, and graceful degradation across terminal sizes.
+
+**Prerequisites:** None (foundational layout work)
+
+**Status:** Not Started (0/2 stories)
+
+**Phasing:**
+- Story A (MVP): AltScreen, layout engine, door height cap, vertical centering, help dynamic height, SetHeight propagation
+- Story B (Follow-up): Header/footer extraction from DoorsView, graceful degradation breakpoints, all secondary views fill terminal height
+
+### Story 59.1: AltScreen + Layout Engine + Door Height Cap
+
+**As a** user, **I want** ThreeDoors to fill my entire terminal with a clean layout, **so that** the app feels like a focused, deliberate experience that owns its space.
+
+**Acceptance Criteria:**
+- Program uses `tea.WithAltScreen()` — terminal content preserved/restored on exit
+- `layoutFull()` function pads output to exactly terminal height
+- Door height: `min(max(10, available * 0.5), 25)` — capped at 25 lines
+- 40/60 top/bottom padding split for perceptual centering
+- Help view uses terminal height instead of hardcoded 20 lines
+- `SetHeight()` propagated to all views that currently lack it
+- All tests pass including `go test -race ./internal/tui/...`
+
+**Technical Notes:**
+- One-line change for AltScreen at `cmd/threedoors/main.go:173`
+- Layout engine in `MainModel.View()` — reference: `keybinding_overlay.go` already does full-height
+- Door height change in `doors_view.go:268-273`
+- Help view in `help_view.go` — replace `helpPageSize = 20` with dynamic
+- Height propagation in `main_model.go:253-308`
+
+**Priority:** P1 | **Depends On:** None
+
+### Story 59.2: Header/Footer Extraction + Graceful Degradation + Secondary Views Fill Height
+
+**As a** user, **I want** all views to fill my terminal height and the app to degrade gracefully on small terminals, **so that** every screen feels consistent and works well at any size.
+
+**Acceptance Criteria:**
+- `DoorsView.RenderDoors()` returns only doors; `RenderStatusSection()` returns status indicators
+- Header (greeting, time context) and footer (help text, footer message) rendered by MainModel
+- Breakpoint degradation: <10 minimal, 10-15 compact, 16-24 standard, 25-40 comfortable, 40+ spacious
+- All secondary views (stats, search, sync log, themes, etc.) fill available terminal height
+- Degradation is invisible — no error messages or warnings
+- All tests pass including `go test -race ./internal/tui/...`
+
+**Technical Notes:**
+- DoorsView refactor: split View() into RenderDoors() and RenderStatusSection()
+- Breakpoint function: `layoutBreakpoint(height int)` returns tier
+- Secondary views use their height parameter for content sizing
+
+**Priority:** P1 | **Depends On:** 59.1
+
+### Dependency Graph
+
+```
+59.1 (AltScreen + Layout Engine + Door Cap)
+ └──▶ 59.2 (Header/Footer Extraction + Degradation + All Views)
+```
+
+59.1 is foundation. 59.2 depends on 59.1. Sequential implementation required.
+
+### Decisions
+
+- D-114: Use `tea.WithAltScreen()` for full-terminal ownership
+- D-115: Fixed header + Flex middle + Fixed footer layout model
+- D-116: Door height capped at 25 lines: `min(max(10, available * 0.5), 25)`
+- D-117: 40/60 top/bottom padding split for vertical centering
+- D-118: Help/stats/search views use full available terminal height
+- D-119: Breakpoint-based graceful degradation for small terminals
+- D-120: Two-story implementation (MVP + refactor)
+- D-121: Layout engine is prerequisite for Story 39.2 (keybinding bar)
+- X-059: Stay in normal scrollback buffer (rejected)
+- X-060: Unlimited door height growth (rejected)
+- X-065: Single large story (rejected — too much scope risk)
+
+### Research
+
+- Full research: `_bmad-output/planning-artifacts/full-terminal-layout-research.md`
+- Party mode: `_bmad-output/planning-artifacts/full-terminal-layout-party-mode.md`

--- a/docs/stories/59.1.story.md
+++ b/docs/stories/59.1.story.md
@@ -1,0 +1,152 @@
+# Story 59.1: AltScreen + Layout Engine + Door Height Cap
+
+## Status: Not Started
+
+## Epic
+
+Epic 59: Full-Terminal Vertical Layout
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/full-terminal-layout-research.md`
+- Party Mode: `_bmad-output/planning-artifacts/full-terminal-layout-party-mode.md`
+- Decisions: D-114 (AltScreen), D-115 (layout model), D-116 (door height cap), D-117 (40/60 padding), D-118 (dynamic help height), D-120 (two-story split), D-121 (prerequisite for 39.2)
+- Prior Art: `internal/tui/keybinding_overlay.go` (reference implementation for full-height rendering)
+- Related: D-088 (bar rendered by MainModel), D-094 (bar auto-hide below 10 lines)
+
+## Story
+
+As a user,
+I want ThreeDoors to fill my entire terminal with a clean layout instead of floating in the middle of my scrollback buffer,
+So that the app feels like a focused, deliberate experience that owns its space.
+
+## Background
+
+ThreeDoors currently renders in content-driven height without filling the terminal. The program runs in normal scrollback buffer (no AltScreen), most views don't receive height information, and help uses a hardcoded 20-line page size. Every serious Bubbletea TUI (lazygit, k9s, soft-serve) uses AltScreen with fixed-header/flex-content/fixed-footer.
+
+The party mode consensus (D-114 through D-121) established:
+1. AltScreen for full-terminal ownership (unanimous)
+2. Fixed header + Flex middle + Fixed footer layout model
+3. Door height capped at 25 with `min(max(10, available * 0.5), 25)`
+4. 40/60 top/bottom padding split for perceptual centering
+5. Help view uses terminal height instead of hardcoded 20
+6. This layout engine is a prerequisite for the keybinding bar footer slot (D-088)
+
+This is the MVP story — delivers 80% of the value. The follow-up story (59.2) handles header/footer extraction from DoorsView and graceful degradation breakpoints.
+
+```
+┌─ FIXED: Header region (2-3 lines) ─────────────────┐
+│ Status bar, greeting                                 │
+├─ FLEX: Main content region (fills remaining) ────────┤
+│ Doors (centered vertically within this region)       │
+│ Status indicators below doors                        │
+│                                                      │
+│ (breathing room / padding)                           │
+│                                                      │
+├─ FIXED: Footer region (2-3 lines) ──────────────────┤
+│ Keybinding bar (Epic 39), footer message             │
+└──────────────────────────────────────────────────────┘
+```
+
+## Acceptance Criteria
+
+**Given** the ThreeDoors program is launched
+**When** the terminal initializes
+**Then** the program runs in alternate screen buffer (`tea.WithAltScreen()`)
+**And** the previous terminal content is preserved and restored on exit
+
+**Given** the main model renders any view
+**When** `View()` is called
+**Then** the output is exactly `m.height` lines tall (fills the terminal vertically)
+**And** a `layoutFull(header, content, footer string) string` function pads output to the exact terminal height
+
+**Given** the doors view is displayed on a terminal with height > 40 lines
+**When** door height is calculated
+**Then** door height = `min(max(10, availableHeight * 0.5), 25)` where `availableHeight` = terminal height minus header and footer lines
+**And** doors are never taller than 25 lines regardless of terminal size
+
+**Given** the doors view is rendered with padding
+**When** vertical space remains after doors and status indicators
+**Then** padding is distributed 40% above doors and 60% below doors (perceptual centering)
+
+**Given** the help view (`:help` / `?`) is displayed
+**When** the terminal height changes
+**Then** the help page size adapts to use available terminal height instead of the hardcoded 20 lines
+**And** the help view receives height via `SetHeight()`
+
+**Given** any view that currently lacks `SetHeight()`
+**When** a `tea.WindowSizeMsg` is received
+**Then** height is propagated to that view
+**And** the view can use the height for layout decisions
+
+**Given** the doors view on a 24-line terminal
+**When** door height is calculated
+**Then** doors render at minimum 10 lines (compact but usable)
+
+**Given** the doors view on a 100-line terminal
+**When** door height is calculated
+**Then** doors render at exactly 25 lines (capped)
+**And** generous padding fills the remaining space
+
+**Given** existing golden file and unit tests
+**When** AltScreen and layout changes are applied
+**Then** all tests pass (golden files may need regeneration for new padding/height behavior)
+**And** `go test -race ./internal/tui/...` passes
+
+## Technical Notes
+
+- **AltScreen**: One-line change at `cmd/threedoors/main.go:173` — add `tea.WithAltScreen()` option
+- **Layout engine**: Add `layoutFull(header, content, footer string) string` to `MainModel` that pads output to exactly `m.height` lines. Reference: `keybinding_overlay.go:44` already uses `innerHeight := height - 5`
+- **Door height**: Modify `internal/tui/doors_view.go:268-273` — change from `0.6 * full height` to `min(max(10, available * 0.5), 25)` where available = height minus header/footer
+- **Help view**: Modify `internal/tui/help_view.go` — replace `helpPageSize = 20` with dynamic calculation from terminal height. Add `SetHeight()` method
+- **Height propagation**: In `internal/tui/main_model.go:253-308`, add height to all views that currently only receive width (most views listed in research)
+- **Padding**: In DoorsView or layoutFull, calculate remaining space after content, split 40% top / 60% bottom
+- **teatest compatibility**: AltScreen may affect test infrastructure — verify golden snapshot tests still work (they test `View()` output, not terminal behavior, so should pass)
+- Must pass `go test -race ./internal/tui/...` (mandatory per CLAUDE.md for TUI changes)
+
+## Tasks
+
+### Task 1: Add AltScreen to program initialization
+- Add `tea.WithAltScreen()` to `tea.NewProgram()` call in `cmd/threedoors/main.go`
+- Verify terminal content is preserved/restored on exit
+
+### Task 2: Build layout engine in MainModel
+- Add `layoutFull(header, content, footer string) string` function
+- Pads output to exactly `m.height` lines
+- Counts lines in header/content/footer, distributes remaining as padding
+- Integrate into `MainModel.View()` for all view modes
+
+### Task 3: Update door height calculation
+- Change door height formula from `0.6 * full height` to `min(max(10, available * 0.5), 25)`
+- Use available height (after header/footer) instead of full terminal height
+- Verify at 24-line, 40-line, and 100-line terminal heights
+
+### Task 4: Implement 40/60 vertical centering
+- Calculate remaining space after doors + status indicators
+- Distribute padding: 40% above, 60% below
+- Ensure content sits slightly above mathematical center
+
+### Task 5: Make help view height-adaptive
+- Add `SetHeight(h int)` to help view
+- Replace `helpPageSize = 20` with dynamic calculation from height
+- Propagate height in WindowSizeMsg handler
+
+### Task 6: Propagate SetHeight to remaining views
+- Add `SetHeight()` to views that currently only receive `SetWidth()`
+- Propagate in `tea.WindowSizeMsg` handler alongside existing width propagation
+- Views: DetailView, MoodView, SearchView, HealthView, InsightsView, AddTaskView, ValuesView, FeedbackView, ImprovementView, NextStepsView, OnboardingView, ConflictView, SyncLogView, ThemePickerView, DevQueueView
+
+### Task 7: Update tests
+- Regenerate golden files affected by height/padding changes
+- Add tests for layout engine (correct total line count)
+- Add tests for door height formula at various terminal heights
+- Run `go test -race ./internal/tui/...`
+
+## Dependencies
+
+- None (this is the foundational layout story)
+- Note: Story 39.2 (keybinding bar) depends on this story's footer slot (D-121)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)

--- a/docs/stories/59.2.story.md
+++ b/docs/stories/59.2.story.md
@@ -1,0 +1,156 @@
+# Story 59.2: Header/Footer Extraction + Graceful Degradation + Secondary Views Fill Height
+
+## Status: Not Started
+
+## Epic
+
+Epic 59: Full-Terminal Vertical Layout
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/full-terminal-layout-research.md`
+- Party Mode: `_bmad-output/planning-artifacts/full-terminal-layout-party-mode.md`
+- Decisions: D-115 (layout model), D-118 (all views use full height), D-119 (graceful degradation), D-120 (two-story split)
+- Prior Art: Story 59.1 (layout engine foundation)
+
+## Story
+
+As a user,
+I want all views to fill my terminal height and the app to degrade gracefully on small terminals,
+So that every screen feels consistent and the app works well at any terminal size.
+
+## Background
+
+Story 59.1 establishes the layout engine, AltScreen, and door height cap. This follow-up story completes the architectural refactoring:
+
+1. **Header/footer extraction**: Currently `DoorsView.View()` renders everything — header, doors, footer — in one method. The layout engine needs these separated so MainModel can manage the three-zone layout properly. Header (greeting, time context) and footer (help text, footer message) move to MainModel.
+2. **Graceful degradation**: Breakpoint-based behavior for small terminals (D-119) ensures the app degrades invisibly — no error messages, just progressive collapse.
+3. **Secondary views fill height**: Stats, search, sync log, themes, and all other non-door views use the full available terminal height instead of fixed heights.
+
+### Graceful Degradation Breakpoints (D-119)
+
+| Height | Behavior |
+|--------|----------|
+| < 10 | Minimal: doors only, no header/footer, no keybinding bar |
+| 10-15 | Compact: 1-line header, doors at min 10, 1-line footer |
+| 16-24 | Standard: full header, proportional doors, footer with bar |
+| 25-40 | Comfortable: breathing room appears |
+| 40+ | Spacious: doors capped at 25, generous padding |
+
+Key principle: degradation is invisible. No error messages or warnings.
+
+## Acceptance Criteria
+
+**Given** the DoorsView component
+**When** rendering is refactored
+**Then** `DoorsView.RenderDoors()` returns only the three doors (no header/footer)
+**And** `DoorsView.RenderStatusSection()` returns completion count, conflicts, proposals, sync bar
+**And** header content (greeting, multi-dimensional greeting, time context badge) is rendered by MainModel
+**And** footer content (help text, footer message) is rendered by MainModel
+
+**Given** a terminal height < 10 lines
+**When** the doors view is rendered
+**Then** only the doors are shown (no header, no footer, no keybinding bar)
+**And** no error message or "terminal too small" warning is displayed
+
+**Given** a terminal height of 10-15 lines
+**When** the doors view is rendered
+**Then** a compact 1-line header is shown
+**And** doors render at minimum height (10 lines)
+**And** a compact 1-line footer is shown
+
+**Given** a terminal height of 16-24 lines
+**When** the doors view is rendered
+**Then** the full header is shown
+**And** doors are proportionally sized
+**And** the full footer with keybinding bar slot is shown
+
+**Given** a terminal height of 25-40 lines
+**When** the doors view is rendered
+**Then** breathing room (padding) appears between content zones
+
+**Given** a terminal height > 40 lines
+**When** the doors view is rendered
+**Then** doors are capped at 25 lines
+**And** generous padding fills remaining space
+
+**Given** the stats view (`:stats`) is displayed
+**When** the terminal height is 50 lines
+**Then** the stats view fills the available terminal height (not a fixed height)
+
+**Given** the search view (`/`) is displayed
+**When** the terminal height is 50 lines
+**Then** search results fill the available terminal height
+
+**Given** the sync log view (`:synclog`) is displayed
+**When** the terminal height is 50 lines
+**Then** the sync log fills the available terminal height
+
+**Given** any secondary view (themes, detail, mood, health, insights, add task, values, feedback, onboarding, conflict, dev queue)
+**When** the terminal height changes
+**Then** the view adapts to use the available height
+
+**Given** the breakpoint degradation
+**When** the terminal is resized across breakpoints
+**Then** transitions are smooth (no flicker, no error states)
+
+**Given** existing tests
+**When** the refactoring is applied
+**Then** all tests pass and golden files are regenerated
+**And** `go test -race ./internal/tui/...` passes
+
+## Technical Notes
+
+- **Header extraction**: Move greeting, multi-dimensional greeting, and time context badge rendering from `DoorsView.View()` to MainModel. DoorsView exposes data; MainModel formats it into the header zone
+- **Footer extraction**: Move help text and footer message rendering from `DoorsView.View()` to MainModel. Footer zone includes the keybinding bar slot (D-088)
+- **DoorsView refactor**: Split `DoorsView.View()` into `RenderDoors()` (just doors) and `RenderStatusSection()` (completion, conflicts, proposals, sync). MainModel composes these into the flex middle zone
+- **Breakpoint logic**: Add a `layoutBreakpoint(height int) breakpoint` function that returns the current tier. Layout engine uses this to determine which zones to render
+- **Secondary views**: Each view needs to use its height parameter for content sizing. Some views (like stats) may need scrollable content areas
+- **Smooth transitions**: Ensure no intermediate render states during resize. Bubbletea handles this naturally via WindowSizeMsg → full re-render cycle
+- Must pass `go test -race ./internal/tui/...`
+
+## Tasks
+
+### Task 1: Extract header rendering from DoorsView
+- Move greeting, multi-dimensional greeting, time context badge to MainModel
+- DoorsView exposes the data needed (e.g., greeting text, time context)
+- MainModel formats into the fixed header zone
+
+### Task 2: Extract footer rendering from DoorsView
+- Move help text and footer message to MainModel
+- Footer zone includes keybinding bar slot
+- MainModel formats into the fixed footer zone
+
+### Task 3: Split DoorsView.View() into sub-renderers
+- `RenderDoors()` — returns just the three doors
+- `RenderStatusSection()` — returns status indicators (completion, conflicts, proposals, sync)
+- MainModel composes these into the flex middle zone
+
+### Task 4: Implement breakpoint degradation
+- Add `layoutBreakpoint(height int)` function
+- < 10: minimal (doors only)
+- 10-15: compact (1-line header/footer)
+- 16-24: standard (full header/footer)
+- 25-40: comfortable (padding)
+- 40+: spacious (capped doors, generous padding)
+
+### Task 5: Make secondary views height-adaptive
+- Stats view: use available height for chart/data display
+- Search view: use available height for results list
+- Sync log view: use available height for log entries
+- All other views: use height for content sizing
+
+### Task 6: Update tests
+- Regenerate golden files
+- Add tests for breakpoint degradation at each tier
+- Test header/footer extraction produces same visual output
+- Test secondary views at various heights
+- Run `go test -race ./internal/tui/...`
+
+## Dependencies
+
+- **Depends on Story 59.1** — layout engine, AltScreen, and SetHeight propagation must be in place
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q2 (lint), AC-Q3 (test coverage), AC-Q4 (rebase), AC-Q5 (scope)


### PR DESCRIPTION
## Summary

- Add Epic 59: Full-Terminal Vertical Layout with 2 stories based on research (PR #329) and party mode consensus
- Story 59.1 (MVP): AltScreen, layout engine (`layoutFull`), door height cap at 25 lines, 40/60 perceptual centering, help dynamic height, `SetHeight()` propagation to all views
- Story 59.2 (Follow-up): Header/footer extraction from DoorsView, breakpoint graceful degradation (<10/10-15/16-24/25-40/40+), all secondary views fill terminal height
- Updates ROADMAP.md, epic-list.md, epics-and-stories.md, and BOARD.md Epic Number Registry (Epic 59 allocated)
- Implements decisions D-114 through D-121 from party mode consensus
- Note: Story 59.1 is prerequisite for Story 39.2 (keybinding bar footer slot) per D-121

## Research Artifacts

- `_bmad-output/planning-artifacts/full-terminal-layout-research.md` (merged in PR #329)
- `_bmad-output/planning-artifacts/full-terminal-layout-party-mode.md` (merged in PR #329)

## Test plan

- [ ] Verify story files are well-formed and contain complete acceptance criteria
- [ ] Verify ROADMAP.md entry is consistent with story files
- [ ] Verify epic-list.md entry matches epics-and-stories.md
- [ ] Verify BOARD.md Epic Number Registry updated correctly (59 allocated, 60 next available)
- [ ] Verify decisions D-114 through D-121 are correctly referenced