### PR TITLE
docs: add Epic 59 — GitHub Pages User Guide (4 stories)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -374,6 +374,21 @@ Detect supervisor context window degradation via daemon monitoring, serialize op
 
 **Dependency graph:** Stories 58.1 & 58.2 can parallelize. Story 58.3 depends on both. Story 58.4 depends on 58.2 & 58.3. Phase 2 stories (58.5-58.7) can parallelize after Phase 1 completes.
 
+### Epic 59: GitHub Pages User Guide (P2) — 0/4 stories done
+
+Publish the ThreeDoors user guide as a searchable, mobile-responsive website on GitHub Pages using MkDocs + Material for MkDocs. Makes documentation discoverable via search engines and accessible without cloning the repo. Content split from monolithic `docs/user-guide.md` (1,173 lines) into ~25 structured pages.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 59.1 | MkDocs Infrastructure & GitHub Pages Deployment | Not Started | P2 | None |
+| 59.2 | Content Split — Getting Started & Core Guide | Not Started | P2 | 59.1 |
+| 59.3 | Content Split — Integrations / Task Sources | Not Started | P2 | 59.1 |
+| 59.4 | Content Split — CLI, MCP, Configuration & Advanced | Not Started | P2 | 59.1 |
+
+**Dependency graph:** 59.1 is the prerequisite. 59.2, 59.3, and 59.4 can be parallelized after 59.1 merges (they touch different files within `docs-site/`).
+
+**Note:** Story 59.1 PR adds `.github/workflows/docs.yml` which requires manual merge by project owner (merge-queue OAuth token lacks `workflow` scope).
+
 ## Icebox (Deferred Indefinitely)
 
 | Epic | Title | Stories | Decision Date | Rationale |

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -370,7 +370,8 @@
 | 56 | Door Visual Redesign — Three-Layer Depth System | 2026-03-11 | Not Started (0/5) |
 | 57 | LLM CLI Services | 2026-03-11 | Not Started (0/8) |
 | 58 | Supervisor Shift Handover — Context-Aware Supervisor Rotation | 2026-03-11 | Not Started (0/7) |
-| 59 | *(next available)* | — | — |
+| 59 | GitHub Pages User Guide | 2026-03-11 | Not Started (0/4) |
+| 60 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -739,7 +739,23 @@
 - **Research:** See `_bmad-output/planning-artifacts/door-visual-redesign/party-mode-door-redesign.md` (5-round party mode, 6 agents)
 - **Decisions:** D-172 (three-layer depth system), X-109 through X-112 (4 rejected alternatives)
 
-**Epic 59+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 59: GitHub Pages User Guide** (P2)
+- **Goal:** Publish the ThreeDoors user guide as a searchable, mobile-responsive website on GitHub Pages using MkDocs + Material for MkDocs
+- **Prerequisites:** None
+- **Status:** Not Started
+- **Deliverables:**
+  - MkDocs infrastructure with Material theme, dark/light mode, client-side search
+  - GitHub Actions workflow for auto-deploy on push to main (path-filtered to `docs-site/`)
+  - Getting Started pages (installation, quickstart, concepts)
+  - Core Guide pages (task management, search/commands, doors interaction, keybindings, sessions)
+  - Integration pages (overview + 7 provider-specific: local files, Apple Notes, Apple Reminders, Jira, GitHub Issues, Todoist, Obsidian)
+  - CLI reference, MCP server docs, configuration reference, themes, task dependencies, custom providers
+  - Troubleshooting and changelog
+- **Stories:** 59.1-59.4 (4 stories: infrastructure, then 3 parallelizable content splits)
+- **Research:** See `_bmad-output/planning-artifacts/gh-pages-user-guide-plan.md`, PRs #481, #500
+- **Decisions:** MkDocs Material over Hugo/Jekyll/Docusaurus/mdBook (GoReleaser precedent), `docs-site/` separate from internal `docs/`
+
+**Epic 60+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -809,5 +825,6 @@
 | Epic 56: Door Visual Redesign | 5 | Not Started |
 | Epic 57: LLM CLI Services | 8 | Not Started |
 | Epic 58: Supervisor Shift Handover | 7 | Not Started |
+| Epic 59: GitHub Pages User Guide | 4 | Not Started |
 | **Total** | **312** | **152 complete, 9 epics in progress, 152 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 1-15, 3.5, 17-28, 32-41, 43, 45, 48-49, 52, 55 are COMPLETE. Epic 29 is 3/4 (29.3 In Review). Epic 0 is partial (12/19). Epic 16 is ICEBOX. Epic 42 (4/5), Epic 44 (6/7), Epic 46 (1/4), Epic 51 (5/11), Epic 54 (2/5) IN PROGRESS. Epics 30-31, 47, 50, 53, 58 NOT STARTED or IN PROGRESS. 590+ merged PRs total. Last audit: 2026-03-12.
+**Implementation Status:** Epics 1-15, 3.5, 17-28, 32-41, 43, 45, 48-49, 52, 55 are COMPLETE. Epic 29 is 3/4 (29.3 In Review). Epic 0 is partial (12/19). Epic 16 is ICEBOX. Epic 42 (4/5), Epic 44 (6/7), Epic 46 (1/4), Epic 51 (5/11), Epic 54 (2/5) IN PROGRESS. Epics 30-31, 47, 50, 53, 58-59 NOT STARTED or IN PROGRESS. 590+ merged PRs total. Last audit: 2026-03-12.
 
 ## Requirements Inventory
 
@@ -5739,6 +5739,120 @@ Stories 56.1 & 56.2 can parallelize. Stories 56.3 & 56.4 can parallelize after 5
 - S3-D5: 32KB input size limit for MVP — YAGNI on chunking
 - S4-D1: Explicit commands for MVP; contextual suggestions P1; ambient P2
 - S5-D6: Streaming, conversation, tool use deferred — P0 is request-response only
+
+## Epic 59: GitHub Pages User Guide (P2)
+
+**Goal:** Publish the ThreeDoors user guide as a searchable, mobile-responsive website on GitHub Pages using MkDocs + Material for MkDocs. Makes documentation discoverable via search engines and accessible without cloning the repo.
+
+**Prerequisites:** None
+
+**Status:** Not Started (0/4 stories)
+
+**Research:** `_bmad-output/planning-artifacts/gh-pages-user-guide-plan.md`, PRs #481, #500
+
+**Key Decisions:**
+- MkDocs Material over Hugo/Jekyll/Docusaurus/mdBook — GoReleaser precedent, markdown-native, best docs theme, built-in search, dark mode
+- `docs-site/` directory separate from internal `docs/` — avoids mixing 262 story files and 33 ADRs with user-facing content
+- Start with `arcaven.github.io/ThreeDoors` — custom domain deferred
+- No versioning initially — add mike when stable releases begin
+
+### Story 59.1: MkDocs Infrastructure & GitHub Pages Deployment ⬜
+
+**As** a potential user discovering ThreeDoors,
+**I want** the user guide published as a searchable website on GitHub Pages,
+**So that** I can read documentation without cloning the repo, and find it via search engines.
+
+**Acceptance Criteria:**
+- `docs-site/mkdocs.yml` with Material theme, dark/light toggle, search, navigation tabs, code copy
+- `docs-site/requirements-docs.txt` with pinned MkDocs + Material versions
+- `docs-site/docs/index.md` landing page with branding, feature highlights, install reference, "Get Started" link
+- `docs-site/docs/philosophy.md` extracted from SOUL.md
+- `.github/workflows/docs.yml` deploys on push to main (path-filtered to `docs-site/**`)
+- Site deploys to `https://arcaven.github.io/ThreeDoors/`
+- Dark/light mode toggle works, client-side search works
+- `make docs` and `make docs-serve` Makefile targets added
+- Existing `docs/user-guide.md` NOT modified or moved
+
+**Priority:** P2 | **Depends On:** None
+
+**Note:** `.github/workflows/docs.yml` requires manual merge by project owner (merge-queue OAuth token lacks `workflow` scope).
+
+### Story 59.2: Content Split — Getting Started & Core Guide ⬜
+
+**As** a new ThreeDoors user,
+**I want** structured getting-started and core guide pages on the docs site,
+**So that** I can learn how to use ThreeDoors through a well-organized, searchable guide.
+
+**Acceptance Criteria:**
+- `getting-started/installation.md` — all install methods with prerequisites
+- `getting-started/quickstart.md` — first launch, onboarding wizard, first completed task in 5 minutes
+- `getting-started/concepts.md` — Three Doors philosophy, selection algorithm, behavioral science
+- `guide/task-management.md` — statuses, transitions, quick add, categorization, undo
+- `guide/search-and-commands.md` — search (`/`), command palette (`:`), commands
+- `guide/doors-interaction.md` — door selection, refresh, feedback options, mood logging
+- `guide/keybindings.md` — complete key binding tables for all views
+- `guide/sessions.md` — session metrics, mood correlation, pattern insights
+- All content accurately reflects current implementation
+- Navigation updated in `mkdocs.yml`, no broken links (`mkdocs build --strict`)
+
+**Priority:** P2 | **Depends On:** 59.1
+
+### Story 59.3: Content Split — Integrations / Task Sources ⬜
+
+**As** a user setting up a new task source,
+**I want** dedicated per-integration pages with setup instructions, configuration, and troubleshooting,
+**So that** I can quickly find exactly how to connect my preferred task source.
+
+**Acceptance Criteria:**
+- `providers/overview.md` — multi-source architecture, connection manager, mixing sources
+- `providers/local-files.md` — YAML format, file location, examples
+- `providers/apple-notes.md` — prerequisites, setup, sync, limitations, troubleshooting
+- `providers/apple-reminders.md` — prerequisites, setup, sync, limitations
+- `providers/jira.md` — OAuth setup, field mapping, JQL filtering, config examples
+- `providers/github-issues.md` — token setup, repo filtering, label mapping
+- `providers/todoist.md` — API key setup, project mapping, sync behavior
+- `providers/obsidian.md` — vault path, task format, frontmatter mapping
+- Each page follows consistent structure: Overview → Prerequisites → Setup → Configuration → Usage → Troubleshooting
+- Navigation updated, no broken links
+
+**Priority:** P2 | **Depends On:** 59.1
+
+### Story 59.4: Content Split — CLI, MCP, Configuration & Advanced ⬜
+
+**As** a power user or developer,
+**I want** complete CLI reference, MCP server docs, configuration reference, and advanced feature pages,
+**So that** I can find detailed reference material without digging through the monolithic user guide.
+
+**Acceptance Criteria:**
+- `cli/commands.md` — full CLI command reference with subcommands, flags, examples
+- `cli/mcp-server.md` — MCP server setup, tools list, usage with LLM agents
+- `configuration/config-file.md` — complete config.yaml schema with defaults
+- `configuration/environment.md` — environment variables
+- `configuration/data-directory.md` — data directory layout, log/session files
+- `guide/themes.md` — available themes with descriptions (screenshots out of scope)
+- `advanced/task-dependencies.md` — dependency types, linking, blocking behavior
+- `advanced/extending.md` — writing custom TaskProvider implementations
+- `troubleshooting.md` — common issues, diagnostics, FAQ
+- `changelog.md` — formatted from CHANGELOG.md
+- All navigation finalized, full site builds without warnings (`mkdocs build --strict`)
+
+**Priority:** P2 | **Depends On:** 59.1
+
+### Dependency Graph
+
+```
+59.1 (Infrastructure) ──▶ 59.2 (Getting Started + Core Guide)
+                       ├──▶ 59.3 (Integrations / Task Sources)
+                       └──▶ 59.4 (CLI, Config, Advanced)
+```
+
+59.1 is the prerequisite. 59.2, 59.3, and 59.4 can be parallelized after 59.1 merges (different files within `docs-site/`).
+
+### Decisions
+
+- MkDocs Material chosen over Hugo (complex Docsy theme), Jekyll (slow, dated), Docusaurus (React overkill), mdBook (too minimal). GoReleaser precedent as strongest signal.
+- `docs-site/` directory avoids mixing with internal `docs/` (262 story files, 33 ADRs, 17 PRD files)
+- Existing `docs/user-guide.md` preserved during migration; deletion/deprecation decision deferred to after 59.4 completes
 
 ### Research
 

--- a/docs/stories/59.1.story.md
+++ b/docs/stories/59.1.story.md
@@ -1,0 +1,118 @@
+# Story 59.1: MkDocs Infrastructure & GitHub Pages Deployment
+
+## Status: Not Started
+
+## Epic
+
+Epic 59: GitHub Pages User Guide
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/gh-pages-user-guide-plan.md`
+- Research PRs: #481, #500
+- Material for MkDocs: https://squidfunk.github.io/mkdocs-material/
+- GoReleaser docs (exemplary MkDocs Material site): https://goreleaser.com
+
+## Story
+
+**As** a potential user discovering ThreeDoors,
+**I want** the user guide published as a searchable website on GitHub Pages,
+**So that** I can read documentation without cloning the repo, and find it via search engines.
+
+## Background
+
+ThreeDoors has a comprehensive 1,173-line user guide (`docs/user-guide.md`) and 745-line README, but no web-hosted documentation. Publishing via GitHub Pages with MkDocs Material provides search, dark mode, mobile-responsive navigation, and professional presentation — all out of the box. MkDocs Material was chosen over Hugo, Jekyll, Docusaurus, and mdBook based on party mode research (see planning artifact).
+
+The `docs-site/` directory is used instead of `docs/` because the existing `docs/` contains 262 story files, 33 ADRs, and 17 PRD files — none user-facing.
+
+## Acceptance Criteria
+
+**AC-1: MkDocs configuration**
+**Given** the `docs-site/` directory
+**When** reviewed
+**Then** `docs-site/mkdocs.yml` exists with Material theme, site metadata, navigation tabs, search plugin, dark/light toggle, code copy, and full navigation stub
+
+**AC-2: Dependencies pinned**
+**Given** `docs-site/requirements-docs.txt`
+**When** reviewed
+**Then** MkDocs and Material for MkDocs versions are pinned
+
+**AC-3: Landing page**
+**Given** `docs-site/docs/index.md`
+**When** viewed
+**Then** it contains project branding, feature highlights, install quick-reference, and "Get Started" link
+
+**AC-4: Philosophy page**
+**Given** `docs-site/docs/philosophy.md`
+**When** viewed
+**Then** it contains content extracted from SOUL.md explaining the Three Doors philosophy
+
+**AC-5: GitHub Actions workflow**
+**Given** `.github/workflows/docs.yml`
+**When** a push to `main` modifies files in `docs-site/**`
+**Then** the site builds and deploys to `https://arcaven.github.io/ThreeDoors/`
+
+**AC-6: Path filtering**
+**Given** `.github/workflows/docs.yml`
+**When** a push to `main` modifies only files outside `docs-site/`
+**Then** the docs workflow does NOT run
+
+**AC-7: Dark/light mode**
+**Given** the deployed site
+**When** the toggle is clicked
+**Then** dark and light modes switch correctly
+
+**AC-8: Search functional**
+**Given** the deployed site
+**When** a user searches for "install"
+**Then** client-side search returns relevant results
+
+**AC-9: Makefile targets**
+**Given** the project Makefile
+**When** `make docs` is run
+**Then** the site builds locally
+**And** `make docs-serve` starts a local preview server
+
+**AC-10: Existing docs preserved**
+**Given** `docs/user-guide.md`
+**When** this story is complete
+**Then** the file is NOT modified or moved
+
+## Technical Notes
+
+- Use `docs-site/` as root (separate from internal `docs/`)
+- Material theme with dark-first palette (deep purple + amber)
+- GitHub Actions workflow must use `actions/setup-python` + `pip install` + `mkdocs gh-deploy --force`
+- Path filter: `docs-site/**` and `.github/workflows/docs.yml`
+- The `.github/workflows/docs.yml` file requires manual merge by project owner (merge-queue OAuth token lacks `workflow` scope)
+
+## Tasks
+
+### Task 1: Create docs-site directory structure
+- Create `docs-site/` with `docs/` subdirectory
+
+### Task 2: Create mkdocs.yml
+- Material theme, dark-first palette, navigation tabs, search, code copy
+- Full navigation stub for all planned sections
+
+### Task 3: Create requirements-docs.txt
+- Pin mkdocs and mkdocs-material versions
+
+### Task 4: Create landing page
+- `docs-site/docs/index.md` with hero content from README
+
+### Task 5: Create philosophy page
+- `docs-site/docs/philosophy.md` from SOUL.md
+
+### Task 6: Create GitHub Actions workflow
+- `.github/workflows/docs.yml` with path filtering
+
+### Task 7: Add Makefile targets
+- `make docs` and `make docs-serve`
+
+### Task 8: Verify local build
+- `mkdocs build --strict` passes with no warnings
+
+## Quality Gate
+
+AC-Q1 (mkdocs.yml valid), AC-Q2 (local build succeeds), AC-Q3 (workflow YAML valid), AC-Q4 (scope: docs infrastructure only, no code changes)

--- a/docs/stories/59.2.story.md
+++ b/docs/stories/59.2.story.md
@@ -1,0 +1,106 @@
+# Story 59.2: Content Split — Getting Started & Core Guide
+
+## Status: Not Started
+
+## Epic
+
+Epic 59: GitHub Pages User Guide
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/gh-pages-user-guide-plan.md`
+- Content sources: `docs/user-guide.md`, `README.md`, `SOUL.md`
+- Depends on: Story 59.1
+
+## Story
+
+**As** a new ThreeDoors user,
+**I want** structured getting-started and core guide pages on the docs site,
+**So that** I can learn how to use ThreeDoors through a well-organized, searchable guide instead of a monolithic markdown file.
+
+## Background
+
+The monolithic `docs/user-guide.md` (1,173 lines) covers everything from installation to advanced features. This story extracts the getting-started and core guide sections into 8 focused pages within the MkDocs site, adding MkDocs-specific enhancements like admonitions, keyboard key rendering, and code copy buttons.
+
+## Acceptance Criteria
+
+**AC-1: Installation page**
+**Given** `docs-site/docs/getting-started/installation.md`
+**When** viewed
+**Then** it covers all install methods: Homebrew stable, Homebrew alpha, binary download, `go install`, and source build, with prerequisites
+
+**AC-2: Quick start page**
+**Given** `docs-site/docs/getting-started/quickstart.md`
+**When** viewed
+**Then** it walks through first launch, onboarding wizard, and completing a first task in under 5 minutes
+
+**AC-3: Concepts page**
+**Given** `docs-site/docs/getting-started/concepts.md`
+**When** viewed
+**Then** it explains Three Doors philosophy, selection algorithm, behavioral science foundation, and "progress over perfection"
+
+**AC-4: Task management page**
+**Given** `docs-site/docs/guide/task-management.md`
+**When** viewed
+**Then** it covers task statuses, transitions, quick add, categorization, and undo completion
+
+**AC-5: Search and commands page**
+**Given** `docs-site/docs/guide/search-and-commands.md`
+**When** viewed
+**Then** it covers search (`/`), command palette (`:`), and available commands
+
+**AC-6: Doors interaction page**
+**Given** `docs-site/docs/guide/doors-interaction.md`
+**When** viewed
+**Then** it covers door selection, refresh, feedback options (blocked/not now/needs breakdown), and mood logging
+
+**AC-7: Keybindings page**
+**Given** `docs-site/docs/guide/keybindings.md`
+**When** viewed
+**Then** it has complete key binding tables for all views (doors, detail, search, help) and keybinding overlay documentation
+
+**AC-8: Sessions page**
+**Given** `docs-site/docs/guide/sessions.md`
+**When** viewed
+**Then** it covers session metrics tracking, mood correlation, and pattern insights
+
+**AC-9: Content accuracy**
+**Given** all pages created in this story
+**When** reviewed against the current codebase
+**Then** all content accurately reflects the current implementation
+
+**AC-10: Navigation updated**
+**Given** `docs-site/mkdocs.yml`
+**When** reviewed
+**Then** navigation includes all 8 new pages in the correct sections
+
+**AC-11: No broken links**
+**Given** the full docs site
+**When** `mkdocs build --strict` is run
+**Then** no warnings or broken link errors are reported
+
+## Technical Notes
+
+- Extract from `docs/user-guide.md` sections: Getting Started, Core Concepts, Basic Usage, Task Management, Search and Commands, Snooze and Defer, Undo Completion, Intelligent Features, Session Metrics
+- Extract keybinding tables from `README.md`
+- Add MkDocs-specific enhancements: `!!! tip` admonitions, `++key++` keyboard rendering, code copy, tabbed content where appropriate
+- Verify content against current implementation — user-guide.md may be slightly outdated
+
+## Tasks
+
+### Task 1: Create getting-started pages (3 files)
+- `installation.md`, `quickstart.md`, `concepts.md`
+
+### Task 2: Create core guide pages (5 files)
+- `task-management.md`, `search-and-commands.md`, `doors-interaction.md`, `keybindings.md`, `sessions.md`
+
+### Task 3: Add MkDocs enhancements
+- Admonitions for tips/warnings, keyboard key rendering, code copy buttons
+
+### Task 4: Update mkdocs.yml navigation
+
+### Task 5: Verify with mkdocs build --strict
+
+## Quality Gate
+
+AC-Q1 (content matches current implementation), AC-Q2 (no broken links), AC-Q3 (scope: docs-site content only)

--- a/docs/stories/59.3.story.md
+++ b/docs/stories/59.3.story.md
@@ -1,0 +1,107 @@
+# Story 59.3: Content Split — Integrations / Task Sources
+
+## Status: Not Started
+
+## Epic
+
+Epic 59: GitHub Pages User Guide
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/gh-pages-user-guide-plan.md`
+- Content sources: `docs/user-guide.md`, `docs/adapter-developer-guide.md`, `README.md`
+- Depends on: Story 59.1
+
+## Story
+
+**As** a user setting up a new task source,
+**I want** dedicated per-integration pages with setup instructions, configuration, and troubleshooting,
+**So that** I can quickly find exactly how to connect my preferred task source.
+
+## Background
+
+ThreeDoors supports 7 task source integrations (local files, Apple Notes, Apple Reminders, Jira, GitHub Issues, Todoist, Obsidian). The monolithic user guide buries setup instructions within a single long document. Dedicated pages with consistent structure make each integration self-contained and discoverable.
+
+## Acceptance Criteria
+
+**AC-1: Provider overview page**
+**Given** `docs-site/docs/providers/overview.md`
+**When** viewed
+**Then** it explains multi-source architecture, connection manager, how providers work, and mixing sources
+
+**AC-2: Local files page**
+**Given** `docs-site/docs/providers/local-files.md`
+**When** viewed
+**Then** it covers YAML task file format, file location, and examples
+
+**AC-3: Apple Notes page**
+**Given** `docs-site/docs/providers/apple-notes.md`
+**When** viewed
+**Then** it covers prerequisites, setup, sync behavior, limitations, and troubleshooting
+
+**AC-4: Apple Reminders page**
+**Given** `docs-site/docs/providers/apple-reminders.md`
+**When** viewed
+**Then** it covers prerequisites, setup, sync behavior, and limitations
+
+**AC-5: Jira page**
+**Given** `docs-site/docs/providers/jira.md`
+**When** viewed
+**Then** it covers OAuth setup, field mapping, JQL filtering, and config examples
+
+**AC-6: GitHub Issues page**
+**Given** `docs-site/docs/providers/github-issues.md`
+**When** viewed
+**Then** it covers token setup, repo filtering, and label mapping
+
+**AC-7: Todoist page**
+**Given** `docs-site/docs/providers/todoist.md`
+**When** viewed
+**Then** it covers API key setup, project mapping, and sync behavior
+
+**AC-8: Obsidian page**
+**Given** `docs-site/docs/providers/obsidian.md`
+**When** viewed
+**Then** it covers vault path configuration, task format, and frontmatter mapping
+
+**AC-9: Consistent structure**
+**Given** all provider pages (AC-2 through AC-8)
+**When** reviewed
+**Then** each follows the structure: Overview → Prerequisites → Setup → Configuration → Usage → Troubleshooting
+
+**AC-10: Navigation updated**
+**Given** `docs-site/mkdocs.yml`
+**When** reviewed
+**Then** navigation includes all provider pages under "Task Sources"
+
+**AC-11: No broken links**
+**Given** the full docs site
+**When** `mkdocs build --strict` is run
+**Then** no warnings or broken link errors
+
+## Technical Notes
+
+- Extract from `docs/user-guide.md` sections: Task Sources through Obsidian Integration
+- Use `docs/adapter-developer-guide.md` for architecture context in overview page
+- Add `!!! warning` admonitions for platform-specific notes (e.g., Apple integrations macOS-only)
+- Each page should be self-contained — a user setting up Jira shouldn't need to read the Apple Notes page
+
+## Tasks
+
+### Task 1: Create provider overview page
+
+### Task 2: Create 7 individual provider pages
+- `local-files.md`, `apple-notes.md`, `apple-reminders.md`, `jira.md`, `github-issues.md`, `todoist.md`, `obsidian.md`
+
+### Task 3: Apply consistent page structure
+- Overview → Prerequisites → Setup → Configuration → Usage → Troubleshooting
+
+### Task 4: Add platform-specific admonitions
+
+### Task 5: Update mkdocs.yml navigation
+
+### Task 6: Verify with mkdocs build --strict
+
+## Quality Gate
+
+AC-Q1 (consistent structure across all pages), AC-Q2 (no broken links), AC-Q3 (scope: docs-site provider content only)

--- a/docs/stories/59.4.story.md
+++ b/docs/stories/59.4.story.md
@@ -1,0 +1,126 @@
+# Story 59.4: Content Split — CLI, MCP, Configuration & Advanced
+
+## Status: Not Started
+
+## Epic
+
+Epic 59: GitHub Pages User Guide
+
+## References
+
+- Research: `_bmad-output/planning-artifacts/gh-pages-user-guide-plan.md`
+- Content sources: `docs/user-guide.md`, `README.md`, `docs/adapter-developer-guide.md`, `CHANGELOG.md`
+- Depends on: Story 59.1
+
+## Story
+
+**As** a power user or developer,
+**I want** complete CLI reference, MCP server docs, configuration reference, and advanced feature pages on the docs site,
+**So that** I can find detailed reference material without digging through the monolithic user guide.
+
+## Background
+
+This is the final content split story, completing the migration from the monolithic `docs/user-guide.md` to the structured docs site. It covers CLI commands, MCP server, configuration, themes, task dependencies, custom providers, troubleshooting, and changelog.
+
+## Acceptance Criteria
+
+**AC-1: CLI commands page**
+**Given** `docs-site/docs/cli/commands.md`
+**When** viewed
+**Then** it contains full CLI command reference with all subcommands, flags, and examples
+
+**AC-2: MCP server page**
+**Given** `docs-site/docs/cli/mcp-server.md`
+**When** viewed
+**Then** it covers MCP server setup, available tools list, usage with LLM agents, and example prompts
+
+**AC-3: Config file page**
+**Given** `docs-site/docs/configuration/config-file.md`
+**When** viewed
+**Then** it has the complete `config.yaml` schema reference with all fields, defaults, and examples
+
+**AC-4: Environment variables page**
+**Given** `docs-site/docs/configuration/environment.md`
+**When** viewed
+**Then** it lists environment variables that affect ThreeDoors behavior
+
+**AC-5: Data directory page**
+**Given** `docs-site/docs/configuration/data-directory.md`
+**When** viewed
+**Then** it documents data directory layout, log files, and session files
+
+**AC-6: Themes page**
+**Given** `docs-site/docs/guide/themes.md`
+**When** viewed
+**Then** it lists available themes with descriptions (screenshots noted as future enhancement)
+
+**AC-7: Task dependencies page**
+**Given** `docs-site/docs/advanced/task-dependencies.md`
+**When** viewed
+**Then** it covers dependency types, linking syntax, and blocking behavior
+
+**AC-8: Custom providers page**
+**Given** `docs-site/docs/advanced/extending.md`
+**When** viewed
+**Then** it explains writing custom TaskProvider implementations (extracted from adapter-developer-guide.md)
+
+**AC-9: Troubleshooting page**
+**Given** `docs-site/docs/troubleshooting.md`
+**When** viewed
+**Then** it covers common issues, diagnostics commands, and FAQ
+
+**AC-10: Changelog page**
+**Given** `docs-site/docs/changelog.md`
+**When** viewed
+**Then** it contains formatted release history from CHANGELOG.md
+
+**AC-11: Navigation finalized**
+**Given** `docs-site/mkdocs.yml`
+**When** reviewed
+**Then** all navigation sections are complete with no stubs or placeholders
+
+**AC-12: Full site validation**
+**Given** the complete docs site (all 4 stories)
+**When** `mkdocs build --strict` is run
+**Then** no warnings, broken links, or errors
+
+**AC-13: Cross-links work**
+**Given** any internal link in the docs site
+**When** clicked
+**Then** it navigates to the correct page and section
+
+## Technical Notes
+
+- Extract CLI reference from `docs/user-guide.md` §CLI Reference and `README.md` §CLI Reference
+- Extract MCP server from `docs/user-guide.md` §MCP Server and `README.md` §MCP Server
+- Port adapter developer guide into `extending.md` — rewrite for end-user audience
+- Copy and format `CHANGELOG.md` content
+- Themes page: list themes with descriptions only; visual previews (screenshots/GIFs) are out of scope for this epic
+- After this story, the entire user guide content will be on the docs site
+
+## Tasks
+
+### Task 1: Create CLI reference pages (2 files)
+- `cli/commands.md`, `cli/mcp-server.md`
+
+### Task 2: Create configuration pages (3 files)
+- `configuration/config-file.md`, `configuration/environment.md`, `configuration/data-directory.md`
+
+### Task 3: Create themes page
+- `guide/themes.md`
+
+### Task 4: Create advanced pages (2 files)
+- `advanced/task-dependencies.md`, `advanced/extending.md`
+
+### Task 5: Create troubleshooting and changelog
+- `troubleshooting.md`, `changelog.md`
+
+### Task 6: Finalize all navigation in mkdocs.yml
+
+### Task 7: Run mkdocs build --strict for final validation
+
+### Task 8: Verify all cross-links
+
+## Quality Gate
+
+AC-Q1 (content matches current implementation), AC-Q2 (no broken links), AC-Q3 (full site builds clean), AC-Q4 (scope: docs-site content only)


### PR DESCRIPTION
## Summary

- Creates **Epic 59: GitHub Pages User Guide** with 4 stories for publishing the ThreeDoors user guide as a searchable website on GitHub Pages
- Uses **MkDocs + Material for MkDocs** (chosen over Hugo, Jekyll, Docusaurus, mdBook — GoReleaser precedent)
- Research from PRs #481 and #500 (`_bmad-output/planning-artifacts/gh-pages-user-guide-plan.md`)

### Stories

| Story | Title | Depends On |
|-------|-------|------------|
| 59.1 | MkDocs Infrastructure & GitHub Pages Deployment | None |
| 59.2 | Content Split — Getting Started & Core Guide (8 pages) | 59.1 |
| 59.3 | Content Split — Integrations / Task Sources (8 pages) | 59.1 |
| 59.4 | Content Split — CLI, MCP, Configuration & Advanced (10 pages) | 59.1 |

59.1 is the prerequisite. 59.2-59.4 can be parallelized after 59.1 merges.

### Files Changed

- **New:** 4 story files (`docs/stories/59.1-59.4.story.md`)
- **Updated:** `ROADMAP.md`, `docs/prd/epic-list.md`, `docs/prd/epics-and-stories.md`, `docs/decisions/BOARD.md`
- Epic Number Registry updated: claimed 59, bumped next-available to 60

### Key Decisions

- MkDocs Material over Hugo/Jekyll/Docusaurus/mdBook
- `docs-site/` directory separate from internal `docs/` (avoids mixing 262 story files with user-facing content)
- Start with `arcaven.github.io/ThreeDoors`, custom domain deferred
- Story 59.1 PR will need manual merge (adds `.github/workflows/docs.yml`, merge-queue OAuth lacks `workflow` scope)

## Test plan

- [ ] Story files have complete acceptance criteria
- [ ] All three planning docs updated consistently (ROADMAP, epic-list, epics-and-stories)
- [ ] BOARD.md Epic Number Registry updated
- [ ] No code changes — docs-only planning