### PR TITLE
docs: governance sync — Story 60.1 Done, add Epic 60 to ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -405,6 +405,20 @@ Transform ThreeDoors from a content-driven partial-terminal app into a full-term
 
 **Note:** Story 59.1 is a prerequisite for Story 39.2 (keybinding bar footer slot) per D-121.
 
+### Epic 60: README Overhaul (P2) — 1/5 stories done
+
+Polish the README with centered badge clusters, table of contents, foldable reference sections, updated feature list reflecting 35+ completed epics, and visual demo section with ASCII art mockup.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 60.1 | README Badges & Header Polish | Done (PR #604) | P2 | None |
+| 60.2 | README Table of Contents | Not Started | P2 | None |
+| 60.3 | Foldable Reference Sections | Not Started | P2 | None |
+| 60.4 | Feature List Audit & Update | Not Started | P2 | None |
+| 60.5 | Visual Demo Section | Not Started | P2 | 60.4 |
+
+**Dependency graph:** Stories 60.1-60.4 can parallelize. Story 60.5 depends on 60.4.
+
 ## Icebox (Deferred Indefinitely)
 
 | Epic | Title | Stories | Decision Date | Rationale |

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -760,7 +760,7 @@
 **Epic 60: README Overhaul** (P2)
 - **Goal:** Polish the README with centered badge clusters, table of contents, foldable reference sections, updated feature list reflecting 35+ completed epics, and visual demo section
 - **Prerequisites:** None (documentation-only epic)
-- **Status:** Not Started
+- **Status:** In Progress (1/5 done)
 - **Deliverables:**
   - Centered badge cluster with CI, release, Go Report Card, platform support badges
   - Table of contents with emoji-prefixed anchor links
@@ -859,7 +859,7 @@
 | Epic 57: LLM CLI Services | 8 | Not Started |
 | Epic 58: Supervisor Shift Handover | 7 | Not Started |
 | Epic 59: Full-Terminal Vertical Layout | 2 | Not Started |
-| Epic 60: README Overhaul | 5 | Not Started |
+| Epic 60: README Overhaul | 5 | In Progress (1/5 done) |
 | Epic 61: GitHub Pages User Guide | 4 | Not Started |
 | **Total** | **321** | **152 complete, 9 epics in progress, 161 not started** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -5881,7 +5881,7 @@ Phase 2 (Hardening):  58.5, 58.6, 58.7 can parallelize after Phase 1
 
 **Prerequisites:** None (documentation-only epic)
 
-**Status:** Not Started (0/5 stories)
+**Status:** In Progress (1/5 done)
 
 ### Story 60.1: README Badges & Header Polish
 


### PR DESCRIPTION
## Summary
- Story 60.1 (README Badges & Header Polish) Done (PR #604)
- Added Epic 60 (README Overhaul) to ROADMAP.md — was missing from scope gate
- Updated epic-list.md and epics-and-stories.md: Epic 60 status to In Progress (1/5 done)

## Test plan
- [ ] Verify ROADMAP.md includes Epic 60 with Story 60.1 Done
- [ ] Verify epic-list.md shows Epic 60 In Progress (1/5 done)
- [ ] Verify epics-and-stories.md Epic 60 status updated