### PR TITLE
docs: add bug report components to source tree

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -97,6 +97,8 @@ ThreeDoors/
 │   │   ├── disconnect_dialog.go    # Disconnect confirmation with task preservation (Epic 44)
 │   │   ├── synclog_detail_view.go  # Sync event log viewer per connection (Epic 44)
 │   │   ├── import_view.go          # :import command — bulk task import from text
+│   │   ├── bug_report.go           # Bug report environment collection (Epic 50)
+│   │   ├── bug_report_view.go      # Bug report TUI view (Epic 50)
 │   │   ├── styles.go                # Lipgloss style definitions
 │   │   └── messages.go              # Bubbletea message types
 │   │


### PR DESCRIPTION
## Summary
- Adds `bug_report.go` and `bug_report_view.go` to TUI section in source tree
- Epic 50 bug report environment collection and TUI view

## Correlation
Triggered by PR #624 (Story 50.2 — Bug Report View & Environment Collection)

## Test plan
- [ ] Verify source-tree.md renders correctly