### PR TITLE
docs: add orphaned_view.go to source tree (PR #650)

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -110,6 +110,7 @@ ThreeDoors/
 │   │   ├── insights_view.go        # Analytics insights view
 │   │   ├── mood_view.go            # Mood tracking view
 │   │   ├── next_steps_view.go      # Next steps suggestions view
+│   │   ├── orphaned_view.go       # Orphaned task handling view (Epic 47)
 │   │   ├── proposals_view.go       # Task proposals view
 │   │   ├── planning_view.go        # Planning mode view
 │   │   ├── planning_select.go      # Planning task selection


### PR DESCRIPTION
## Summary

- Adds `internal/tui/orphaned_view.go` to `docs/architecture/source-tree.md`
- Introduced by PR #650 (Story 47.2 — Orphaned Task Handling)

## Test plan

- [ ] Docs-only change, no code impact