### PR TITLE
docs: add reauth_dialog.go to source tree (PR #654)

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -111,6 +111,7 @@ ThreeDoors/
 │   │   ├── mood_view.go            # Mood tracking view
 │   │   ├── next_steps_view.go      # Next steps suggestions view
 │   │   ├── orphaned_view.go       # Orphaned task handling view (Epic 47)
+│   │   ├── reauth_dialog.go      # Re-authentication dialog for expired connections (Epic 44)
 │   │   ├── proposals_view.go       # Task proposals view
 │   │   ├── planning_view.go        # Planning mode view
 │   │   ├── planning_select.go      # Planning task selection


### PR DESCRIPTION
## Summary

- Adds `internal/tui/reauth_dialog.go` to `docs/architecture/source-tree.md`
- Introduced by PR #654 (Story 44.7 — Re-Authentication Flow)

## Test plan

- [ ] Docs-only change, no code impact