### PR TITLE
docs: add linear adapter package to source tree (PR #671)

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -286,6 +286,8 @@ ThreeDoors/
 │   │   │   ├── github_client.go    # GitHub API client (issues, bug reports)
 │   │   │   ├── github_provider.go  # GitHub TaskProvider implementation
 │   │   │   └── oauth.go            # GitHub OAuth device code flow integration
+│   │   ├── linear/                  # Linear adapter (Epic 46)
+│   │   │   └── oauth.go            # Linear OAuth integration
 │   │   └── obsidian/                # Obsidian vault adapter (Epic 8)
 │   │       ├── adapter.go          # ObsidianAdapter
 │   │       ├── markdown.go         # Markdown task parser


### PR DESCRIPTION
## Summary

- Adds `internal/adapters/linear/` package to `docs/architecture/source-tree.md`
- Introduced by PR #671 (Story 46.3 — Linear OAuth Integration)

## Test plan

- [ ] Docs-only change, no code impact