### PR TITLE
docs: fix source tree drift — linear adapter + connection files

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -254,6 +254,8 @@ ThreeDoors/
 │   │       ├── form_spec.go         # FormSpec/FormField — provider config form definitions
 │   │       ├── sync_event.go        # SyncEventLog — per-connection JSONL audit log
 │   │       ├── health_warnings.go   # Proactive health notifications (Epic 47)
+│   │       ├── token_refresh.go    # OAuth token refresh logic
+│   │       ├── detect.go           # Provider detection utilities
 │   │       └── oauth/               # OAuth device code flow
 │   │           ├── devicecode.go    # Device code grant implementation
 │   │           └── browser.go       # Cross-platform browser launcher
@@ -287,6 +289,9 @@ ThreeDoors/
 │   │   │   ├── github_provider.go  # GitHub TaskProvider implementation
 │   │   │   └── oauth.go            # GitHub OAuth device code flow integration
 │   │   ├── linear/                  # Linear adapter (Epic 46)
+│   │   │   ├── client.go           # Linear GraphQL API client
+│   │   │   ├── config.go           # Linear adapter configuration
+│   │   │   ├── types.go            # GraphQL query/response types
 │   │   │   └── oauth.go            # Linear OAuth integration
 │   │   └── obsidian/                # Obsidian vault adapter (Epic 8)
 │   │       ├── adapter.go          # ObsidianAdapter


### PR DESCRIPTION
## Summary
- Add undocumented files to `docs/architecture/source-tree.md`:
  - `internal/adapters/linear/`: `client.go`, `config.go`, `types.go` (added by recent Linear OAuth work)
  - `internal/core/connection/`: `token_refresh.go`, `detect.go` (added by connection lifecycle work)
- Detected by arch-watchdog during catch-up scan of PRs #668–#678

## Test plan
- [ ] Verify source-tree.md renders correctly
- [ ] Confirm listed files exist in the codebase