### PR TITLE
fix: correct Story 0.55 status — plan-only PR incorrectly marked Done

### DIFF
--- a/docs/stories/0.55.story.md
+++ b/docs/stories/0.55.story.md
@@ -1,6 +1,6 @@
 # Story 0.55: Cron-Based Agent Heartbeat System
 
-## Status: Done (PR #681)
+## Status: Not Started
 
 ## Epic
 


### PR DESCRIPTION
## Summary
- Story 0.55 was marked Done (PR #681) but PR #681 only created the story file
- The actual implementation (agent definition HEARTBEAT handlers, polling loops, MEMORY.md updates) was never done
- Workers dispatched for `/implement-story 0.55` kept finding "Done" and bailing

## Test plan
- [ ] Verify story status shows "Not Started"
- [ ] After merge, redispatch `/implement-story 0.55`