### PR TITLE
fix: prevent /plan-work from marking stories Done — systemic guardrails

### DIFF
--- a/.claude/commands/implement-story.md
+++ b/.claude/commands/implement-story.md
@@ -26,8 +26,12 @@ This is the complete, end-to-end workflow for implementing a story from preparat
 1. Search for the story file matching the identifier "$ARGUMENTS" in:
    - `{project-root}/_bmad-output/implementation-artifacts/` (primary, pattern: `{epic}-{story}-*.md`)
    - `{project-root}/docs/stories/` (fallback, pattern: `{epic}.{story}.story.md`)
-2. If the story file exists and has status `ready-for-dev` or `in-progress`, note its path and proceed to Phase 2.
-3. If the story file does NOT exist or needs preparation:
+2. If the story file exists and has status `ready-for-dev`, `in-progress`, or `Not Started`, note its path and proceed to Phase 2.
+3. If the story file has status `Done`:
+   - HALT. Check if the Done status is correct by examining the referenced PR.
+   - If the PR is docs-only (story file creation, no implementation code), the Done status is incorrect — a `/plan-work` worker mistakenly set it. Reset the status to `Not Started` and proceed to Phase 2.
+   - If the PR contains implementation code, the story is already implemented — report to the user and stop.
+4. If the story file does NOT exist or needs preparation:
    - Launch `/sm` (Scrum Master agent) to create/prepare the story.
    - Provide the story identifier so SM knows which story to create.
    - Wait for SM to complete story creation.

--- a/.claude/commands/plan-work.md
+++ b/.claude/commands/plan-work.md
@@ -103,6 +103,11 @@ This is the complete planning workflow that takes research findings and formaliz
    - Ensure each story has: acceptance criteria, task breakdown, dev notes, dependencies
    - Story files go in `docs/stories/{epic}.{story}.story.md`
 3. Verify all stories reference the sprint change proposal and party mode artifact.
+4. Set the status of each newly created story to `Not Started`.
+
+<critical>
+Planning workers NEVER set story status to `Done` — that is reserved for `/implement-story` workers who have completed all acceptance criteria in code. A story file being *created* is not the same as a story being *implemented*.
+</critical>
 
 ---
 
@@ -121,6 +126,8 @@ This is the complete planning workflow that takes research findings and formaliz
 ## Phase 8: Create Pull Request
 
 **Goal:** Package all planning artifacts into a single PR.
+
+**IMPORTANT:** Do NOT set any story status to `Done`. Stories created by `/plan-work` must have status `Not Started` or `Draft`. Only `/implement-story` sets `Done` after all acceptance criteria are met in code.
 
 1. Stage all changed/created files:
    - Sprint change proposal artifact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ go test -race ./...   # Race detector — run before pushing
 - Before implementing, check `docs/decisions/BOARD.md` for relevant prior decisions, rejected options, and active research
 - Before implementing, verify the story file exists and read its acceptance criteria
 - **DO NOT check in code without first updating the story file**, verifying that the ACs and tasks were met
-- After implementation, update the story file status to `Done (PR #NNN)`
+- After implementation, update the story file status to `Done (PR #NNN)`. **`Done` means all acceptance criteria are met in code** — planning-only PRs (story creation, docs updates, research) do NOT qualify for `Done` status. `/plan-work` creates stories with status `Not Started`; only `/implement-story` sets `Done`.
 - If no story exists for needed work, create one (or ask the supervisor/PM to create one) before writing code
 - Research, spikes, and documentation tasks are exempt — but should still reference a story when possible
 

--- a/_bmad-output/planning-artifacts/plan-work-status-bug-research.md
+++ b/_bmad-output/planning-artifacts/plan-work-status-bug-research.md
@@ -1,0 +1,234 @@
+# /plan-work Story Status Bug — Research & Recommendations
+
+**Date:** 2026-03-12
+**Researcher:** gentle-otter (worker)
+**Trigger:** Story 0.55 (Cron-Based Agent Heartbeat System) was marked `Done (PR #681)` by kind-badger running `/plan-work`, despite zero implementation tasks being completed. All subsequent `/implement-story` workers saw "Done" and bailed.
+
+---
+
+## 1. Root Cause Analysis
+
+### The Bug
+
+Story 0.55 has 6 implementation tasks (add HEARTBEAT handlers to agent definitions, create polling loops, update MEMORY.md, update ops docs). PR #681 contains **only the story file** — a pure planning artifact. Yet the story status reads `Done (PR #681)`.
+
+### Why It Happened — Competing Instructions
+
+The worker running `/plan-work` receives instructions from **three sources** that conflict:
+
+| Source | Instruction | Effect |
+|--------|-------------|--------|
+| **Worker definition** (`agents/worker.md`, step 5) | "Update the story file status to `Done (PR #NNN)`" | Worker marks story Done after creating PR |
+| **CLAUDE.md** (line 43) | "After implementation, update the story file status to `Done (PR #NNN)`" | Says "after implementation" — but worker reads this as "after my task" |
+| **`/plan-work` skill** (`.claude/commands/plan-work.md`) | **No status instruction at all** | Silent — defers to worker's default behavior |
+
+The worker definition's step 5 is a blanket instruction: "after creating your PR, mark the story Done." It doesn't distinguish between *planning* PRs and *implementation* PRs. The worker completed its assigned task (planning), created a PR, and followed step 5 — marking the story Done.
+
+### The Deeper Problem
+
+The system conflates **two different concepts**:
+
+1. **Worker task completion** — "I finished the task I was assigned" (planning)
+2. **Story completion** — "All acceptance criteria are met and code is implemented"
+
+A `/plan-work` worker's task is to *create* a story, not to *implement* it. But the worker definition's step 5 doesn't know the difference.
+
+---
+
+## 2. Flow Trace: `/plan-work` → Story Status
+
+```
+Supervisor dispatches worker with /plan-work task
+  → Worker reads agents/worker.md (its system prompt)
+  → Worker executes /plan-work skill (8 phases)
+    → Phase 6: Story Creation — creates docs/stories/X.Y.story.md
+    → Phase 8: Create PR — commits and creates PR #NNN
+  → Worker follows agents/worker.md step 5:
+    "Update the story file status to Done (PR #NNN)"  ← BUG
+  → Worker runs multiclaude agent complete
+```
+
+### What `/plan-work` Phase 8 says (relevant excerpt):
+
+> 1. Stage all changed/created files: [...] Story files [...]
+> 2. Create a descriptive commit
+> 3. Push the branch and create a PR
+
+No mention of story status. The skill is silent, so the worker falls through to its default behavior (step 5 of its workflow).
+
+### What `/implement-story` Phase 8 says:
+
+> 1. Update the story file status to `In Review (PR #NNN)` (will be updated to `Done` after merge).
+
+This is more nuanced — it uses "In Review" not "Done", and notes Done happens after merge. But note: workers running `/implement-story` also get the worker definition's step 5 which says "Done" unconditionally. The `/implement-story` instruction and the worker definition contradict each other.
+
+---
+
+## 3. Flow Trace: `/implement-story` → Story Status
+
+```
+Supervisor dispatches worker with /implement-story task
+  → Worker reads agents/worker.md (its system prompt)
+  → Worker executes /implement-story skill (8 phases)
+    → Phase 1-7: Story prep, enrichment, TDD, implementation, review
+    → Phase 8: "Update story status to In Review (PR #NNN)"
+  → Worker ALSO has agents/worker.md step 5:
+    "Update the story file status to Done (PR #NNN)"
+  → Contradiction: skill says "In Review", worker def says "Done"
+  → In practice: workers have been setting "Done" (worker def wins)
+```
+
+The `/implement-story` skill's Phase 8 is actually correct in spirit — "In Review" until merge. But it's overridden by the worker definition. In practice this hasn't caused problems because the story IS implemented at that point, but it's still a contradiction.
+
+---
+
+## 4. Audit: Other Stories Incorrectly Marked Done
+
+### Methodology
+
+Searched for stories marked "Done" where the associated PR was docs-only (story file creation only, no implementation code).
+
+### Confirmed False Positives
+
+**Story 0.55** (PR #681) — Heartbeat system. 6 implementation tasks, zero done. **CONFIRMED BUG.**
+
+### Likely False Positives (0.x Infrastructure Stories)
+
+These 0.x stories need manual review — they describe implementation tasks but their PRs may have been docs-only:
+
+- **Story 0.50** (PR #556) — needs investigation
+- **Story 0.51** (PR #623) — needs investigation
+- **Story 0.52** (PR #619) — Multi-Adapter Integration Tests — needs investigation
+- **Story 0.53** (PR #621) — Docker E2E — needs investigation
+
+### Not False Positives
+
+Many stories in the 17.x-62.x range appear to have correct Done status — their PRs contain both story file updates AND implementation code. The audit tool's grep matches story file changes in implementation PRs, which is expected.
+
+---
+
+## 5. Recommendations
+
+### R1: Add Explicit Status Instructions to `/plan-work` [HIGH PRIORITY]
+
+**File:** `.claude/commands/plan-work.md`
+
+In Phase 6 (Story Creation), add:
+
+```markdown
+4. Set the status of each newly created story to `Not Started`.
+   - Planning workers NEVER set story status to `Done` — that is reserved
+     for implementation workers who have completed all acceptance criteria.
+```
+
+In Phase 8 (Create PR), add:
+
+```markdown
+0. **IMPORTANT:** Do NOT update story status to `Done`. Story files created
+   by /plan-work should have status `Not Started` or `Draft`. Only
+   /implement-story sets `Done` after all ACs are met.
+```
+
+### R2: Differentiate Worker Step 5 by Task Type [HIGH PRIORITY]
+
+**File:** `agents/worker.md`
+
+Change step 5 from:
+
+> 5. Update the story file status to `Done (PR #NNN)`
+
+To:
+
+> 5. Update story file status:
+>    - **Implementation tasks** (`/implement-story`, feature work, bug fixes): Set status to `Done (PR #NNN)` after all acceptance criteria are met
+>    - **Planning tasks** (`/plan-work`, story creation, docs-only): Set newly created story status to `Not Started` — NEVER `Done`
+>    - **Rule:** A story is only `Done` when its acceptance criteria are implemented in code, not when the story file is created
+
+### R3: Add Guard to `/implement-story` Phase 1 [MEDIUM PRIORITY]
+
+**File:** `.claude/commands/implement-story.md`
+
+In Phase 1 (Story Preparation), after finding the story file, add a check:
+
+```markdown
+4. If the story file has status `Done`:
+   - HALT. A story marked Done should not be re-implemented.
+   - Check if the Done status is correct by examining the referenced PR.
+   - If the PR is docs-only (no implementation code), the Done status is
+     incorrect — reset to `Not Started` and proceed.
+   - If the PR contains implementation, skip — the story is already done.
+```
+
+This prevents the cascading failure where workers see "Done" and bail.
+
+### R4: Add Separate Fields for Planning vs Implementation PRs [LOW PRIORITY]
+
+**Current format:**
+```markdown
+## Status: Done (PR #681)
+```
+
+**Proposed format:**
+```markdown
+## Status: Not Started
+**Planning PR:** #681
+**Implementation PR:** —
+```
+
+This makes the distinction explicit and machine-readable. However, this requires changes to the story template (`/new-story`), the status parser (`internal/docaudit/parse_story_files.go`), and all downstream tools. The cost is high relative to the benefit — R1+R2+R3 solve the immediate problem without schema changes.
+
+**Recommendation:** Defer R4 unless the bug recurs after R1-R3.
+
+### R5: Update CLAUDE.md Status Language [MEDIUM PRIORITY]
+
+**File:** `CLAUDE.md`
+
+The current language says:
+
+> After implementation, update the story file status to `Done (PR #NNN)`
+
+This is correct but insufficient. Add a clarification:
+
+> - **`Done (PR #NNN)` means implementation is complete** — all acceptance criteria met in code
+> - Planning-only PRs (story creation, docs updates, research) do NOT qualify for `Done` status
+> - `/plan-work` creates stories with status `Not Started`; only `/implement-story` sets `Done`
+
+### R6: Validate ACs Before Setting Done [LOW PRIORITY]
+
+Should `/implement-story` verify acceptance criteria are actually met before setting Done?
+
+It already does — Phase 7 (Acceptance Review) checks every AC. The issue isn't with `/implement-story` missing validation; it's with `/plan-work` setting Done when no validation was needed (because no implementation happened).
+
+R1-R3 fix the actual bug. AC validation in `/implement-story` is already adequate.
+
+---
+
+## 6. Immediate Fix for Story 0.55
+
+Reset `docs/stories/0.55.story.md` status from `Done (PR #681)` to `Not Started`. This unblocks `/implement-story` workers.
+
+---
+
+## 7. Summary of Recommended Changes
+
+| ID | File | Change | Priority |
+|----|------|--------|----------|
+| R1 | `.claude/commands/plan-work.md` | Add explicit "set status to Not Started" in Phase 6 & Phase 8 | HIGH |
+| R2 | `agents/worker.md` | Differentiate step 5 by task type (planning vs implementation) | HIGH |
+| R3 | `.claude/commands/implement-story.md` | Add Done-status guard in Phase 1 | MEDIUM |
+| R5 | `CLAUDE.md` | Clarify Done means implementation, not planning | MEDIUM |
+| R4 | Story template + parser | Separate Planning PR / Implementation PR fields | LOW (defer) |
+| R6 | `/implement-story` | Add AC validation before Done | LOW (already exists) |
+| Fix | `docs/stories/0.55.story.md` | Reset status to `Not Started` | IMMEDIATE |
+
+---
+
+## 8. Files Examined
+
+- `.claude/commands/plan-work.md` — /plan-work skill definition (8 phases, no status instruction)
+- `.claude/commands/implement-story.md` — /implement-story skill definition (says "In Review", contradicts worker def)
+- `.claude/commands/new-story.md` — Story template (sets initial status to "Draft")
+- `agents/worker.md` — Worker agent definition (step 5: unconditional "Done")
+- `CLAUDE.md` — Project instructions (says "after implementation" but ambiguous)
+- `docs/stories/0.55.story.md` — The affected story (6 implementation tasks, zero completed)
+- `internal/docaudit/parse_story_files.go` — Status parser (recognizes Done, Not Started, Draft, etc.)

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -60,7 +60,9 @@ Your task description defines your scope. Do not expand beyond it, even for "obv
 2. Check ROADMAP.md — if task is out-of-scope, message supervisor before proceeding
 3. Implement the task with tests
 4. Run `make fmt`, `make lint`, `make test`
-5. Update the story file status to `Done (PR #NNN)` — do NOT update ROADMAP.md, epic-list.md, or epics-and-stories.md (project-watchdog handles those per D-162)
+5. Update story file status — do NOT update ROADMAP.md, epic-list.md, or epics-and-stories.md (project-watchdog handles those per D-162):
+   - **Implementation tasks** (`/implement-story`, feature work, bug fixes): Set status to `Done (PR #NNN)` after all acceptance criteria are met in code
+   - **Planning tasks** (`/plan-work`, story creation, docs-only work): Set newly created story status to `Not Started` — NEVER `Done`. A story is only `Done` when its acceptance criteria are implemented, not when the story file is created
 6. Create a PR with a detailed summary
 7. Run `multiclaude agent complete`
 


### PR DESCRIPTION
## Summary

- **Bug:** `/plan-work` workers marked stories `Done (PR #NNN)` after creating story files, even though zero implementation was done. This caused `/implement-story` workers to see "Done" and bail without implementing. Story 0.55 (Heartbeat System) was the trigger — 6 implementation tasks, none completed.
- **Root cause:** Worker definition step 5 unconditionally says "mark story Done" without distinguishing planning PRs from implementation PRs.
- **Fix:** Systemic guardrails across 4 files to prevent recurrence.

## Changes

| File | Change |
|------|--------|
| `.claude/commands/plan-work.md` | Added explicit `<critical>` block: planning workers NEVER set Done, always use Not Started |
| `agents/worker.md` | Step 5 now differentiates by task type: implementation → Done, planning → Not Started |
| `.claude/commands/implement-story.md` | Phase 1 Done-status guard: checks if Done is correct, resets if PR was docs-only |
| `CLAUDE.md` | Clarified Done means ACs met in code, not story file created |
| `_bmad-output/planning-artifacts/plan-work-status-bug-research.md` | Full research document with root cause analysis, flow traces, audit results, and 6 recommendations |

## Research Document

The research doc (`_bmad-output/planning-artifacts/plan-work-status-bug-research.md`) covers:
1. Root cause analysis with competing instruction sources
2. Full flow traces for both `/plan-work` and `/implement-story`
3. Audit of other stories that may be incorrectly marked Done
4. 6 prioritized recommendations (R1-R6)
5. Deferred recommendation: separate Planning PR / Implementation PR fields in story template

## Test plan

- [ ] Spawn a worker with `/plan-work` task — verify new stories get status `Not Started`
- [ ] Run `/implement-story` on a story already marked `Done` from a docs-only PR — verify it detects and resets
- [ ] Run `/implement-story` on a legitimately Done story — verify it halts correctly
- [ ] Verify all persistent agents restart cleanly with updated `worker.md`