### PR TITLE
docs: create story files for Epic 30 stories 30.2–30.4

### DIFF
--- a/docs/stories/30.2.story.md
+++ b/docs/stories/30.2.story.md
@@ -1,0 +1,59 @@
+# Story 30.2: Read-Only Linear Provider with Field Mapping
+
+## Status: Not Started
+
+**Epic:** 30 — Linear Integration
+**Priority:** P2
+**Story Points:** 3
+**Depends On:** Story 30.1
+**FRs:** FR116, FR118
+
+## Description
+
+As a ThreeDoors user, I want my Linear issues to appear as properly mapped ThreeDoors tasks with correct status, effort, tags, and due dates, so that I can manage my engineering work through the Three Doors interface.
+
+## Acceptance Criteria
+
+1. **AC1:** `LinearProvider` implements `core.TaskProvider` with `LoadTasks()` returning all issues from configured teams, mapped to ThreeDoors `Task` structs
+2. **AC2:** Field mapping:
+   - `issue.title` → `Task.Text`
+   - `issue.description` → `Task.Context` (Markdown preserved)
+   - `issue.labels[].name` → `Task.Tags`
+   - `issue.dueDate` → `Task.DueDate`
+   - `issue.identifier` (e.g., "TEAM-123") → `Task.ID` prefix for source identification
+3. **AC3:** Status mapping (via `issue.state.type`):
+   - `triage` → `todo`
+   - `backlog` → `todo`
+   - `unstarted` → `todo`
+   - `started` → `in-progress`
+   - `completed` → `complete`
+   - `cancelled` → `archived`
+4. **AC4:** Effort mapping:
+   - Linear priority (1=urgent → Effort 4, 2=high → Effort 3, 3=medium → Effort 2, 4=low → Effort 1)
+   - When priority is 0 (no priority), use `estimate` as secondary signal (if present)
+5. **AC5:** `SaveTask()` and `DeleteTask()` return `core.ErrReadOnly` — this is a read-only provider in this story
+6. **AC6:** `Watch()` returns a channel that polls for issue changes at `poll_interval` intervals
+7. **AC7:** Local cache with configurable TTL (default 5m) at `~/.threedoors/linear-cache.yaml` to reduce API calls
+8. **AC8:** Source badge: `[LN]` for TUI display
+9. **AC9:** Issues filtered by `assignee` config when specified (default: all team members)
+
+## Technical Notes
+
+- Query `workflowStates` for each team to build the status mapping table dynamically (state names vary per team, but `state.type` is consistent)
+- Cache invalidation: full reload on poll, partial updates if Linear supports `updatedAfter` filter
+- `Task.SourceProvider` set to `"linear"` for write routing
+- Register provider in adapter registry (`internal/adapters/registry.go`)
+
+## Tasks
+
+- [ ] Implement `LinearProvider` struct with `LoadTasks()`, `SaveTask()`, `DeleteTask()`, `MarkComplete()`
+- [ ] Implement status mapping from `state.type` enum
+- [ ] Implement priority inversion mapping (Linear 1-4 → ThreeDoors 4-1)
+- [ ] Implement estimate-as-effort fallback when priority is 0
+- [ ] Implement assignee filtering
+- [ ] Implement `Watch()` polling with configurable interval
+- [ ] Implement local YAML cache with TTL
+- [ ] Register provider in adapter registry (`internal/adapters/registry.go`)
+- [ ] Write unit tests for field mapping (table-driven)
+- [ ] Write unit tests for status mapping (all 6 state types)
+- [ ] Write unit tests for effort mapping (priority + estimate combinations)

--- a/docs/stories/30.3.story.md
+++ b/docs/stories/30.3.story.md
@@ -1,0 +1,49 @@
+# Story 30.3: Bidirectional Sync & WAL Integration
+
+## Status: Not Started
+
+**Epic:** 30 — Linear Integration
+**Priority:** P2
+**Story Points:** 3
+**Depends On:** Story 30.2
+**FRs:** FR119
+
+## Description
+
+As a ThreeDoors user, when I complete a task that originated from Linear, I want the corresponding Linear issue to be transitioned to "Done" automatically, so that my work status stays synchronized across both systems.
+
+## Acceptance Criteria
+
+1. **AC1:** `MarkComplete(taskID)` sends a GraphQL mutation to transition the issue to the team's `completed` workflow state
+2. **AC2:** The mutation discovers the correct "completed" state ID dynamically by querying `workflowStates` for the issue's team and finding the state with `type: "completed"`
+3. **AC3:** Write operations are wrapped in `WALProvider` for offline queuing — if the API is unreachable, the mutation is queued and retried
+4. **AC4:** `SaveTask()` supports updating the issue `title` and `description` via GraphQL mutation (but not status — status changes go through `MarkComplete`)
+5. **AC5:** Failed mutations are logged with the task ID and error for sync observability
+6. **AC6:** `DeleteTask()` remains `ErrReadOnly` — Linear issue deletion is destructive and not supported
+7. **AC7:** Sync status is reported via `HealthCheck()` including last successful sync time and pending WAL entries
+
+## Technical Notes
+
+- GraphQL mutation for state transition:
+  ```graphql
+  mutation IssueUpdate($id: String!, $stateId: String!) {
+    issueUpdate(id: $id, input: { stateId: $stateId }) {
+      success
+      issue { id state { name type } }
+    }
+  }
+  ```
+- Must query `workflowStates(filter: { team: { id: { eq: $teamId } } })` to discover the correct completed state ID
+- Cache the team→completedStateId mapping with TTL to avoid re-querying on every completion
+
+## Tasks
+
+- [ ] Implement `MarkComplete()` with GraphQL mutation for state transition
+- [ ] Implement dynamic completed-state discovery per team
+- [ ] Cache team→completedStateId mapping with TTL
+- [ ] Integrate WALProvider wrapper for offline queuing
+- [ ] Implement `SaveTask()` for title/description updates
+- [ ] Add sync status reporting to `HealthCheck()`
+- [ ] Write unit tests for mutation construction
+- [ ] Write unit tests for WAL integration (queue, replay, dequeue)
+- [ ] Write integration test with mocked GraphQL server for full sync flow

--- a/docs/stories/30.4.story.md
+++ b/docs/stories/30.4.story.md
@@ -1,0 +1,45 @@
+# Story 30.4: Contract Tests & Integration Testing
+
+## Status: Not Started
+
+**Epic:** 30 — Linear Integration
+**Priority:** P2
+**Story Points:** 2
+**Depends On:** Story 30.2
+**FRs:** FR116 (validation)
+
+## Description
+
+As a ThreeDoors developer, I want comprehensive contract and integration tests for the Linear adapter, so that I can verify compliance with the TaskProvider interface and catch regressions in field mapping and sync behavior.
+
+## Acceptance Criteria
+
+1. **AC1:** `LinearProvider` passes the full `adapters.RunContractTests` suite using a mocked `GraphQLClient` interface
+2. **AC2:** Contract tests validate all `TaskProvider` methods: `LoadTasks`, `SaveTask`, `DeleteTask`, `MarkComplete`, `Watch`, `HealthCheck`
+3. **AC3:** Field mapping tests cover all Linear field types with table-driven test cases:
+   - All 6 `state.type` values → correct ThreeDoors status
+   - All 5 priority values (0-4) → correct Effort
+   - Estimate fallback when priority is 0
+   - Label arrays → Tags
+   - Due date parsing → DueDate
+4. **AC4:** Integration test with `httptest.NewServer` serving canned GraphQL responses validates end-to-end query/response flow
+5. **AC5:** Error handling tests: auth failure (401), rate limit (429 with Retry-After), network timeout, malformed response
+6. **AC6:** Pagination test: mock server returns paginated results, verify all pages fetched
+7. **AC7:** All tests pass with `go test -race ./internal/adapters/linear/...`
+
+## Technical Notes
+
+- Use the `GraphQLClient` interface from Story 30.1 for mocking — no external dependencies in tests
+- Canned responses should match actual Linear API response shapes
+- Contract test suite is in `internal/adapters/contract.go`
+
+## Tasks
+
+- [ ] Create `internal/adapters/linear/linear_test.go` with contract test runner
+- [ ] Create mock `GraphQLClient` implementation with canned responses
+- [ ] Write table-driven field mapping tests (status, priority, effort, labels, dates)
+- [ ] Write pagination test with multi-page mock responses
+- [ ] Write error handling tests (401, 429, timeout, malformed)
+- [ ] Write `httptest.NewServer` integration test for full query/response flow
+- [ ] Verify `go test -race` passes
+- [ ] Run `adapters.RunContractTests` with LinearProvider


### PR DESCRIPTION
## Summary

- Creates missing story files for Epic 30 (Linear Integration) stories 30.2, 30.3, and 30.4
- Story 30.1 already exists and is Done (PR #446); these three remaining stories had titles in `epics-and-stories.md` but no actual `.story.md` files
- Content sourced from `_bmad-output/planning-artifacts/epic-30-linear-integration.md` and the sprint change proposal

### Stories created:
- **30.2** — Read-Only Linear Provider with Field Mapping (3 SP, depends on 30.1)
- **30.3** — Bidirectional Sync & WAL Integration (3 SP, depends on 30.2)
- **30.4** — Contract Tests & Integration Testing (2 SP, depends on 30.2)

All stories set to **Not Started** — these are planning artifacts only.

## Test plan

- [ ] Verify story files exist at `docs/stories/30.{2,3,4}.story.md`
- [ ] Verify all stories have status `Not Started`
- [ ] Verify acceptance criteria match the epic planning artifact
- [ ] No code changes — docs only