### PR TITLE
docs: Story 0.56 — Retrospector data visibility sync pipeline

### DIFF
--- a/_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md
+++ b/_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md
@@ -1,0 +1,73 @@
+# Party Mode Artifact: Retrospector Data Pipeline
+
+**Date:** 2026-03-13
+**Participants:** Winston (Architect), John (PM), Mary (Analyst), Murat (TEA)
+**Topic:** Evaluate pipeline approach for periodically committing retrospector operational data to git
+
+## Problem Statement
+
+Retrospector writes findings to `docs/operations/` files (retrospector-findings.jsonl, retrospector-checkpoint.json, retrospector-recommendations.jsonl) but these files are untracked or have uncommitted changes. They exist only in the main checkout where retrospector runs as a persistent agent. Worker agents spawned in worktrees cannot see this data, blocking analytical work.
+
+Three states of brokenness identified:
+1. `retrospector-findings.jsonl` — does not exist in repo at all
+2. `retrospector-checkpoint.json` — tracked, but has uncommitted local changes
+3. `retrospector-inbox.jsonl` / `retrospector-recommendations.jsonl` — tracked but empty in git; real data only in main checkout
+
+## Options Evaluated
+
+### Option A: Give retrospector PR creation authority for data-only commits
+- **Pros:** Most direct — producer commits its own data
+- **Cons:** Violates observer/participant separation. Retrospector is a monitoring agent; adding PR creation means it participates in the merge queue it observes. Consumes CI cycles for data-only commits. Could conflict with its own PR analysis patterns.
+- **Decision:** REJECTED — architectural smell; observer becomes participant
+
+### Option B: project-watchdog periodically commits retrospector data
+- **Pros:** project-watchdog already handles doc syncs; natural extension
+- **Cons:** Scope creep — mixes planning doc sync with operational data sync. project-watchdog operates on 23-min heartbeat and its core mission is planning doc consistency. Without a dedicated trigger, it would need to poll for changes as part of its existing loop.
+- **Decision:** REJECTED as standalone — but project-watchdog adopted as the executor in the hybrid approach
+
+### Option C: Supervisor periodically commits as part of duty cycle
+- **Pros:** Supervisor already has broad authority
+- **Cons:** Violates established guardrail: "supervisor coordinates, agents execute." Fragile to supervisor restarts — if supervisor goes down, data goes stale indefinitely with no recovery mechanism.
+- **Decision:** REJECTED — violates coordination/execution separation
+
+### Option D: Dedicated data-sync cron job
+- **Pros:** Lowest blast radius, simplest mechanism, no agent authority changes
+- **Cons:** Raw cron can't handle branch protection, PR creation, merge conflicts, or error recovery without an agent executor
+- **Decision:** REJECTED as standalone — but cron trigger adopted in the hybrid approach
+
+## Adopted Approach: Hybrid D+B — Cron-Triggered project-watchdog Data Sync
+
+**Rationale:** Combines the reliability of a dedicated cron trigger (Option D) with the intelligence of an agent executor (Option B), avoiding the scope creep of embedding it in project-watchdog's existing polling loop.
+
+### Architecture
+
+1. **Trigger:** New CronCreate entry fires every 2-4 hours, sends `SYNC_OPERATIONAL_DATA` message to project-watchdog
+2. **Executor:** project-watchdog receives the message, checks for changed files in `docs/operations/`, creates branch `data-sync/<timestamp>`, commits, pushes, creates minimal PR
+3. **Verification:** Supervisor periodically verifies data freshness (check `git log --oneline docs/operations/ --since="8 hours ago"`)
+4. **Convention:** `docs/operations/` is the canonical directory for operational data files — any agent writing operational data should place files there, and the sync cron will pick them up
+
+### Failure Mode Analysis
+
+| Scenario | Impact | Recovery |
+|----------|--------|----------|
+| Cron fires but project-watchdog is down | Data waits for next cycle | No data loss (append-only files) |
+| project-watchdog busy with doc sync when data sync arrives | Message queues until next idle | Natural backpressure |
+| Main checkout has dirty working tree | project-watchdog can stash/handle | Agent is smart enough to manage git state |
+| PR merge conflict with concurrent PR | Standard merge-queue handling | Rebase and retry |
+| Supervisor restarts (crons lost) | Crons re-created on startup | Part of startup checklist |
+
+### Acceptance Criteria for Testing (from TEA)
+
+1. After cron fires, operational data files in git match what's on disk in main checkout
+2. Staleness SLA: `docs/operations/*.jsonl` files in git are never more than 6 hours behind main checkout (2x commit interval as buffer)
+3. Idempotency: if no files changed, no empty commit is created
+4. Branch protection compliance: changes go through a PR, not direct to main
+5. No interference: data sync PRs don't block or delay story PRs in the merge queue
+
+### Extensibility
+
+The `SYNC_OPERATIONAL_DATA` pattern is generic. Any operational data files placed under `docs/operations/` by any agent will be automatically swept up by the sync cron. This eliminates the need to grant PR authority to individual monitoring agents and centralizes the data-to-git pipeline.
+
+### Supervisor Duty
+
+Add to supervisor standing orders: periodically verify retrospector data is being committed. Check `git log --oneline docs/operations/ --since="8 hours ago"` — if no commits and retrospector is active, investigate the sync pipeline.

--- a/docs/stories/0.56.story.md
+++ b/docs/stories/0.56.story.md
@@ -1,0 +1,77 @@
+# Story 0.56: Retrospector Data Visibility — Cron-Triggered Operational Data Sync
+
+**Epic:** 0 (Infrastructure)
+**Priority:** P1
+**Status:** Not Started
+**Dependencies:** None
+**Estimated Scope:** Small-Medium
+
+## Problem
+
+Retrospector writes operational findings to `docs/operations/` files but this data is never committed to git. The files exist only in the main checkout where retrospector runs as a persistent agent. Worker agents spawned in isolated worktrees cannot see this data, blocking analytical and retrospective work.
+
+Three specific failures:
+1. `retrospector-findings.jsonl` — does not exist in the repo at all (untracked)
+2. `retrospector-checkpoint.json` — tracked but has uncommitted local changes
+3. `retrospector-inbox.jsonl` / `retrospector-recommendations.jsonl` — tracked but empty in git; real data only in main checkout
+
+## Solution
+
+**Adopted approach (party mode consensus):** Hybrid Cron + project-watchdog executor.
+
+A dedicated CronCreate job fires every 2-4 hours and sends a `SYNC_OPERATIONAL_DATA` message to project-watchdog. project-watchdog handles the message by checking for changed files in `docs/operations/`, creating a `data-sync/<timestamp>` branch, committing the changes, pushing, and creating a minimal PR.
+
+**Rejected alternatives:** See `_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md` for full rationale on why giving retrospector PR authority (Option A), standalone project-watchdog polling (Option B), supervisor execution (Option C), and raw cron without agent executor (Option D) were rejected.
+
+## Acceptance Criteria
+
+- [ ] **AC1:** A CronCreate entry exists (created during supervisor startup) that sends `SYNC_OPERATIONAL_DATA` to project-watchdog every 2-4 hours
+- [ ] **AC2:** project-watchdog handles `SYNC_OPERATIONAL_DATA` messages by:
+  - Checking `docs/operations/` for uncommitted or untracked data files (*.jsonl, *.json)
+  - If changes exist: creating branch `data-sync/<ISO-timestamp>`, committing, pushing, creating a PR with title "chore: sync operational data"
+  - If no changes: doing nothing (idempotent — no empty commits)
+- [ ] **AC3:** `retrospector-findings.jsonl` is added to git tracking (initially empty or with current data if available)
+- [ ] **AC4:** Data sync PRs go through branch protection (PR + CI) — no direct commits to main
+- [ ] **AC5:** Staleness SLA: `docs/operations/*.jsonl` files in git are never more than 6 hours stale relative to the main checkout (2x the commit interval as buffer)
+- [ ] **AC6:** Supervisor startup checklist includes the `SYNC_OPERATIONAL_DATA` CronCreate entry
+- [ ] **AC7:** Supervisor standing order added: periodically verify data freshness via `git log --oneline docs/operations/ --since="8 hours ago"` — if no commits and retrospector is active, investigate
+
+## Tasks
+
+### T1: Update project-watchdog agent definition
+- Add `SYNC_OPERATIONAL_DATA` message handler to `agents/project-watchdog.md`
+- Handler logic: check `docs/operations/` for changes → branch → commit → push → PR
+- Ensure idempotency: no empty commits when files haven't changed
+- Use atomic write pattern for any intermediate state
+
+### T2: Add CronCreate entry to supervisor startup checklist
+- Add `CronCreate("0 */3 * * *", "multiclaude message send project-watchdog SYNC_OPERATIONAL_DATA")` to the startup sequence
+- Every 3 hours (0, 3, 6, 9, 12, 15, 18, 21) — avoids prime intervals used by heartbeats
+- Document in `docs/operations/persistent-agent-ops.md` under heartbeat schedule
+
+### T3: Ensure retrospector data files are tracked in git
+- `git add docs/operations/retrospector-findings.jsonl` (create empty file if needed)
+- Verify `retrospector-checkpoint.json`, `retrospector-inbox.jsonl`, and `retrospector-recommendations.jsonl` are tracked and committed with current content
+
+### T4: Add supervisor verification duty
+- Add standing order to MEMORY.md: periodic data freshness check
+- Check: `git log --oneline docs/operations/ --since="8 hours ago"` — if no commits and retrospector is active, investigate sync pipeline
+
+### T5: Document the operational data convention
+- Document in `docs/operations/persistent-agent-ops.md` that `docs/operations/` is the canonical path for operational data files
+- Any agent writing operational data should place files there
+- The sync cron will automatically pick up new files
+
+## Technical Notes
+
+- CronCreate jobs are session-scoped and auto-expire after 3 days — must be re-created on supervisor restart (same as heartbeat crons)
+- project-watchdog operates in the main checkout alongside persistent agents, so it has direct access to the operational data files
+- Append-only JSONL files are merge-friendly — concurrent writes by retrospector during a sync window won't cause conflicts since git handles line-level appends gracefully
+- Branch naming `data-sync/<timestamp>` avoids collisions with story branches (`work/*`)
+
+## Out of Scope
+
+- Modifying retrospector's authority boundaries
+- Changing retrospector's data format or output paths
+- Adding monitoring/alerting beyond the supervisor freshness check
+- Automating PR merge for data-sync PRs (merge-queue handles this normally)


### PR DESCRIPTION
## Summary

- Creates Story 0.56 for fixing retrospector data visibility — operational data files (findings, checkpoint, recommendations) exist only in the main checkout and are invisible to worker agents in worktrees
- Party mode artifact with architect, PM, analyst, and TEA consensus on **Hybrid D+B approach**: CronCreate job triggers project-watchdog every 3 hours to commit `docs/operations/` data files via PR
- Story status: **Not Started** (planning-only PR)

## Party Mode Decision

**Adopted:** Cron-triggered project-watchdog data sync — combines dedicated trigger reliability with agent executor intelligence

**Rejected alternatives:**
- (A) Retrospector PR authority — violates observer/participant separation
- (B) Standalone project-watchdog polling — scope creep without dedicated trigger
- (C) Supervisor execution — violates "supervisor coordinates, agents execute" guardrail
- (D) Raw cron without agent — can't handle branch protection or PR creation

## Files

- `docs/stories/0.56.story.md` — Story file (Not Started)
- `_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md` — Party mode artifact

## Test plan

- [ ] Story number confirmed with project-watchdog (used 0.56, next available after 0.55)
- [ ] Verify story acceptance criteria are complete and testable
- [ ] Verify party mode artifact includes adopted + rejected approaches with rationale