### PR TITLE
docs: make agent reply mechanisms explicit with multiclaude message send

### DIFF
--- a/agents/arch-watchdog.md
+++ b/agents/arch-watchdog.md
@@ -65,7 +65,11 @@ gh pr diff <number> --name-only
    - Design decisions documented in story files
 4. If divergence detected:
    - **Minor:** Update architecture docs directly (within authority)
-   - **Major:** Open GitHub issue with details, message project-watchdog and supervisor
+   - **Major:** Open GitHub issue with details, then notify via messaging:
+     ```bash
+     multiclaude message send project-watchdog "Architecture drift detected in internal/foo/, see issue #NNN. Correlation: PR-NNN"
+     multiclaude message send supervisor "Architecture drift detected in internal/foo/, see issue #NNN. Correlation: PR-NNN"
+     ```
 5. **Add PR number to processed list** after all operations complete
 
 ### Analyzing PR Contents
@@ -87,7 +91,7 @@ When you receive a message containing "HEARTBEAT":
 
 1. **Run your full Polling Loop** (see "Polling Loop" section above — check recently merged PRs for architecture alignment)
 2. **Ack the HEARTBEAT message** via `multiclaude message ack <id>`
-3. **Report any findings** through normal channels (message supervisor and project-watchdog for architecture drift, update docs for minor changes)
+3. **Report any findings via messaging** — use `multiclaude message send supervisor` and `multiclaude message send project-watchdog` for architecture drift; update docs directly for minor changes
 
 HEARTBEAT messages are lightweight triggers — they tell you "now is a good time to check everything." You determine what work to do based on what you find.
 
@@ -162,20 +166,20 @@ This ensures no architecture drift accumulates during downtime while avoiding du
 
 ## Message Handling
 
-**From project-watchdog:**
+**From project-watchdog** (received via `multiclaude message list`):
 - "PRD section X changed after PR #NNN, verify architecture alignment. Correlation: PR-NNN" -> Review relevant architecture docs against the PRD change
 - "Story X.Y flagged for tech note refresh" -> Check if architecture section needs update
 
-**To project-watchdog:**
+**To project-watchdog** (send via `multiclaude message send project-watchdog`):
 - "Architecture docs updated after PR #NNN, stories may need tech note refresh. Correlation: PR-NNN"
 - "Architecture drift detected in internal/foo/, see issue #NNN. Correlation: PR-NNN"
 
-**To supervisor:**
+**To supervisor** (send via `multiclaude message send supervisor`):
 - "New undocumented pattern in internal/foo/ introduced by PR #NNN"
 - "Architecture decision X violated by PR #NNN — details: ..."
 - "Significant architectural debt accumulating in package X"
 
-All messages include the correlation PR number when applicable.
+All messages include the correlation PR number when applicable. **Always use `multiclaude message send <recipient>` — never just print to tmux.**
 
 ## Communication
 

--- a/agents/envoy.md
+++ b/agents/envoy.md
@@ -20,7 +20,7 @@ When you receive a message containing "HEARTBEAT":
 
 1. **Run your full polling rhythm** (see "Your rhythm" list above — check for new issues, poll for updates, cross-reference merged PRs against open issues)
 2. **Ack the HEARTBEAT message** via `multiclaude message ack <id>`
-3. **Report any findings** through normal channels (message supervisor for triage results, comment on issues, etc.)
+3. **Report any findings via messaging** — use `multiclaude message send supervisor` for triage results and escalations; use `gh issue comment` for issue updates
 
 HEARTBEAT messages are lightweight triggers — they tell you "now is a good time to check everything." You determine what work to do based on what you find.
 
@@ -36,7 +36,7 @@ Fast, mechanical checks using pattern matching and lookups. Run all four gates b
 - Empty body or body < 10 characters
 - Known advertising patterns (URLs to unrelated products, cryptocurrency spam)
 - Gibberish (no recognizable English words in title)
-- **Action:** Close the issue + notify supervisor immediately
+- **Action:** Close the issue + notify supervisor immediately via `multiclaude message send supervisor "Screened out issue #<number>: spam"`
 
 **Gate 1.2 — Duplicate Detection:**
 - Exact or near-exact title match against open issues in the tracker
@@ -56,7 +56,7 @@ Fast, mechanical checks using pattern matching and lookups. Run all four gates b
 - Check SOUL.md exclusion patterns (see `docs/envoy-operations.md` alignment reference)
 - **Action:** If decided against → polite decline citing the decision. If in-progress → link to existing work.
 
-**Layer 1 exit:** If any gate resolves the issue (spam closed, duplicate flagged, already-fixed linked, previously-decided cited), stop processing and notify supervisor of the screen-out. Otherwise, proceed to Layer 2.
+**Layer 1 exit:** If any gate resolves the issue (spam closed, duplicate flagged, already-fixed linked, previously-decided cited), stop processing and notify supervisor of the screen-out via `multiclaude message send supervisor "Screened out issue #<number>: [reason]"`. Otherwise, proceed to Layer 2.
 
 ### Layer 2: Lightweight AI Screening
 
@@ -96,10 +96,10 @@ The envoy's core reasoning step. Read the issue, understand intent, classify, an
 **Screen 2.4 — Scope Assessment:**
 - Check ROADMAP.md for related epics/stories
 - Determine if the issue fits an existing epic, needs a new story, or is out of scope
-- In-scope → relay to supervisor with full triage context
-- Out-of-scope → escalate to supervisor for scope decision
+- In-scope → relay to supervisor via `multiclaude message send supervisor "New issue #<number> passed screening: [summary]. Awaiting triage decision."`
+- Out-of-scope → escalate to supervisor via `multiclaude message send supervisor "Issue #<number> appears out of scope: [details]. Awaiting scope decision."`
 
-**Layer 2 exit:** Issue is either declined (misaligned), resolved (question answered), or relayed to supervisor with triage summary. Only issues requiring multi-agent deliberation proceed to Layer 3.
+**Layer 2 exit:** Issue is either declined (misaligned), resolved (question answered), or relayed to supervisor via `multiclaude message send supervisor`. Only issues requiring multi-agent deliberation proceed to Layer 3.
 
 ### Layer 3: BMAD Deliberation Recommendation
 
@@ -131,7 +131,7 @@ When you spot recently merged PRs:
 1. Review all open issues — did a merge incidentally resolve something?
 2. If yes: comment on the issue explaining what was fixed and how, then close it
 3. If partially addressed: comment noting progress and what remains open
-4. If uncertain: message supervisor for guidance before closing
+4. If uncertain: message supervisor via `multiclaude message send supervisor "Uncertain if PR #<number> resolves issue #<number>: [details]"` before closing
 
 ## Communication Style
 

--- a/agents/merge-queue.md
+++ b/agents/merge-queue.md
@@ -14,13 +14,19 @@ Unchecked merges introduce scope creep, broken builds, and regressions. Without 
 
 You cannot merge PRs that modify `.github/workflows/` files — your token lacks the `workflow` scope. These PRs must be flagged for manual merge by the project owner. Attempting to merge them will fail silently or produce confusing errors.
 
-**Action:** When a PR touches workflow files, label it `status.needs-human` and message the supervisor explaining the OAuth limitation.
+**Action:** When a PR touches workflow files, label it `status.needs-human` and notify via messaging:
+```bash
+multiclaude message send supervisor "PR #<number> touches .github/workflows/ — cannot merge due to OAuth workflow scope limitation. Labeled status.needs-human."
+```
 
 ### Scope Rejection Protocol
 
 Every PR must align with ROADMAP.md. A PR with green CI but out-of-scope changes is **not mergeable**. Scope violations that slip through create tech debt, confuse planning docs, and erode the roadmap as a decision tool.
 
-**Action:** When scope is questionable, label `scope.out-of-scope`, comment on the PR with the specific ROADMAP.md section that doesn't cover the work, and message the supervisor.
+**Action:** When scope is questionable, label `scope.out-of-scope`, comment on the PR with the specific ROADMAP.md section that doesn't cover the work, and notify via messaging:
+```bash
+multiclaude message send supervisor "PR #<number> flagged scope.out-of-scope: [reason]. See PR comment for details."
+```
 
 ### CI Churn Prevention
 
@@ -92,7 +98,10 @@ After every PR merge, you MUST check whether the push-to-main CI run succeeds. T
 
 **On entering emergency mode:**
 1. Halt all pending merges immediately — do NOT merge any PR until main is green
-2. Message the supervisor with the failing run URL, commit SHA, and which PR was most recently merged
+2. Notify supervisor via messaging:
+   ```bash
+   multiclaude message send supervisor "EMERGENCY: Main CI red after merging PR #<number>. Run URL: <url>. Commit: <sha>. Halting all merges."
+   ```
 3. Label the most recently merged PR with `broke-main`:
    ```bash
    gh label create broke-main --color D73A4A --description "This PR broke the main branch CI" --force
@@ -104,7 +113,10 @@ After every PR merge, you MUST check whether the push-to-main CI run succeeds. T
 
 **On exiting emergency mode:**
 1. Verify main CI is green: `gh run list --branch main --limit 1 --json conclusion` shows `success`
-2. Message the supervisor that main is green again
+2. Notify supervisor via messaging:
+   ```bash
+   multiclaude message send supervisor "Emergency resolved: Main CI green again. Resuming normal merge operations."
+   ```
 3. Resume normal merge operations
 
 ### PRs Needing Humans
@@ -165,7 +177,7 @@ When you receive a message containing "HEARTBEAT":
 
 1. **Run your full Polling Loop** (see above)
 2. **Ack the HEARTBEAT message** via `multiclaude message ack <id>`
-3. **Report any findings** through normal channels (message supervisor for escalations, merge ready PRs, etc.)
+3. **Report any findings via messaging** — use `multiclaude message send supervisor` for escalations, merge readiness, and emergency mode status
 
 HEARTBEAT messages are lightweight triggers — they tell you "now is a good time to check everything." You determine what work to do based on what you find.
 

--- a/agents/pr-shepherd.md
+++ b/agents/pr-shepherd.md
@@ -51,7 +51,10 @@ Proactive rebasing causes O(n^2) CI runs when multiple PRs are open. Only rebase
 - You never merge; merge-queue never rebases
 
 ### With Supervisor
-- Escalate design-level conflicts, blocked PRs, scope disputes
+- Escalate design-level conflicts, blocked PRs, scope disputes via messaging:
+  ```bash
+  multiclaude message send supervisor "PR #<number> has design-level conflict: [details]. Needs guidance."
+  ```
 - Receive rebase requests and priority guidance
 
 ### With Workers
@@ -136,7 +139,7 @@ When you receive a message containing "HEARTBEAT":
 
 1. **Run your full Polling Loop** (see above)
 2. **Ack the HEARTBEAT message** via `multiclaude message ack <id>`
-3. **Report any findings** through normal channels (message supervisor for escalations, spawn workers for fixes, etc.)
+3. **Report any findings via messaging** — use `multiclaude message send supervisor` for escalations and status updates; use `multiclaude work` to spawn fix workers
 
 HEARTBEAT messages are lightweight triggers — they tell you "now is a good time to check everything." You determine what work to do based on what you find.
 

--- a/agents/project-watchdog.md
+++ b/agents/project-watchdog.md
@@ -20,7 +20,10 @@ Planning docs that lag behind reality cause cascading problems: workers implemen
 
 1. Agent sends you a message: `"Requesting epic number for: [description]"`
 2. You check ROADMAP.md, `docs/prd/epics-and-stories.md`, and `docs/prd/epic-list.md` for the next available number
-3. You reply with the allocated number: `"Allocated Epic NN for [description]"`
+3. You reply **via messaging** with the allocated number:
+   ```bash
+   multiclaude message send <requester> "Allocated Epic NN for [description]"
+   ```
 4. Only THEN may the requesting agent use that number
 5. Story numbers within an epic follow the same protocol
 
@@ -49,17 +52,29 @@ Before updating any epic-level data, read ROADMAP.md and confirm the epic number
 ## Interaction Protocols
 
 ### With Supervisor
-- Report story completions: `"Story X.Y status updated to Done (PR #NNN)"`
-- Escalate PRD drift, dependency violations, scope questions
+- Report story completions via messaging:
+  ```bash
+  multiclaude message send supervisor "Story X.Y status updated to Done (PR #NNN)"
+  ```
+- Escalate PRD drift, dependency violations, scope questions via messaging:
+  ```bash
+  multiclaude message send supervisor "PRD drift detected: [details]. Escalating for scope decision."
+  ```
 - Receive scope guidance and priority decisions
 
 ### With Arch Watchdog
-- Send: `"PRD section X changed after PR #NNN, verify architecture alignment"`
+- Send architecture alignment requests via messaging:
+  ```bash
+  multiclaude message send arch-watchdog "PRD section X changed after PR #NNN, verify architecture alignment"
+  ```
 - Receive: `"Architecture updated, stories may need tech note refresh"`
 - Cross-reference architecture changes against PRD
 
 ### With All Agents (Number Allocation)
-- Receive number requests, check for conflicts, allocate, reply
+- Receive number requests, check for conflicts, allocate, reply **via messaging**:
+  ```bash
+  multiclaude message send <requester> "Allocated Epic NN for [description]"
+  ```
 - Supervisor must also request numbers — no exceptions
 
 ## SYNC_OPERATIONAL_DATA Response Protocol
@@ -97,7 +112,10 @@ When you receive a message containing "SYNC_OPERATIONAL_DATA":
       git checkout main
       ```
 4. **Ack the message** via `multiclaude message ack <id>`
-5. **Report to supervisor** if a PR was created: `"Data sync PR #NNN created"`
+5. **Report to supervisor via messaging** if a PR was created:
+   ```bash
+   multiclaude message send supervisor "Data sync PR #NNN created"
+   ```
 
 **Idempotency:** If a `data-sync/*` branch already exists with identical content, skip creating a duplicate. Check with `git diff --stat HEAD` after staging — if empty, abort.
 
@@ -107,7 +125,7 @@ When you receive a message containing "HEARTBEAT":
 
 1. **Run your full Polling Loop** (see Operational Notes below — check recently merged PRs, update story status, check ROADMAP.md progress, consume retrospector recommendation queue)
 2. **Ack the HEARTBEAT message** via `multiclaude message ack <id>`
-3. **Report any findings** through normal channels (message supervisor for story completions, epic progress, PRD drift, etc.)
+3. **Report any findings via messaging** — use `multiclaude message send supervisor` for story completions, epic progress, PRD drift, etc.
 
 HEARTBEAT messages are lightweight triggers — they tell you "now is a good time to check everything." You determine what work to do based on what you find.
 

--- a/agents/release-manager.md
+++ b/agents/release-manager.md
@@ -107,3 +107,22 @@ gh run view <RUN_ID> --repo arcaven/homebrew-tap --log
 - Release failure that can't be fixed by a patch release
 - Tap CI failures caused by another project's formula
 - Major/minor version tagging decisions
+
+## Communication
+
+**All messages MUST use the messaging system — not tmux output.**
+
+```bash
+# Report release status to supervisor
+multiclaude message send supervisor "Release v1.0.1 tagged. GoReleaser workflow triggered. Monitoring tap CI."
+
+# Escalate failures
+multiclaude message send supervisor "Release v1.0.0 failed at brew audit step. Root cause: [details]. Planning patch release."
+
+# Report completion
+multiclaude message send supervisor "Release v1.0.1 complete. Both ThreeDoors and tap CI green."
+
+# Check your messages
+multiclaude message list
+multiclaude message ack <id>
+```

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -9,7 +9,10 @@ You are a code review agent. Help code get merged safely.
 1. Get the diff: `gh pr diff <number>`
 2. Check ROADMAP.md first (out-of-scope = blocking)
 3. Post comments via `gh pr comment`
-4. Message merge-queue with summary
+4. Report to merge-queue via messaging:
+   ```bash
+   multiclaude message send merge-queue "Review complete for PR #<number>. [N] blocking, [M] suggestions. [Safe to merge / Needs fixes: ...]"
+   ```
 5. Run `multiclaude agent complete`
 
 ## Comment Format

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -57,7 +57,7 @@ Your task description defines your scope. Do not expand beyond it, even for "obv
 
 ### Workflow
 1. Read the task description and any referenced story file
-2. Check ROADMAP.md — if task is out-of-scope, message supervisor before proceeding
+2. Check ROADMAP.md — if task is out-of-scope, notify supervisor via `multiclaude message send supervisor "Task out of scope per ROADMAP.md: [details]. Awaiting guidance."` before proceeding
 3. Implement the task with tests
 4. Run `make fmt`, `make lint`, `make test`
 5. Update story file status — do NOT update ROADMAP.md, epic-list.md, or epics-and-stories.md (project-watchdog handles those per D-162):


### PR DESCRIPTION
## Summary

- **Root cause:** project-watchdog's epic-allocation flow (lines 21-23) said "reply" without specifying `multiclaude message send`, causing the agent to print the reply to its tmux pane instead of routing it through the messaging system
- **Scope:** Audited ALL 11 agent definitions (`agents/*.md`) for ambiguous reply/respond/report/notify/escalate instructions
- **Fix:** Made every reply mechanism explicit with the exact `multiclaude message send <recipient> "message"` command

## Files changed (8 of 11 agents — 3 were already correct)

| Agent | Issues Fixed |
|-------|-------------|
| **project-watchdog.md** | Epic allocation reply, interaction protocols, SYNC_OPERATIONAL_DATA report, HEARTBEAT report |
| **arch-watchdog.md** | Message Handling section (content without commands), divergence notification, HEARTBEAT report |
| **envoy.md** | Layer 1 screen-out notifications, Layer 2 relay/escalate, cross-check uncertainty, HEARTBEAT report |
| **merge-queue.md** | OAuth limitation notification, scope rejection notification, emergency mode entry/exit, HEARTBEAT report |
| **pr-shepherd.md** | Supervisor escalation in interaction protocols, HEARTBEAT report |
| **release-manager.md** | Added entire Communication section (was completely missing) |
| **reviewer.md** | Process step 4 "Message merge-queue" made explicit |
| **worker.md** | Out-of-scope notification to supervisor |

**Agents already correct (no changes needed):**
- `research-supervisor.md` — thorough explicit commands throughout
- `retrospector.md` — explicit `multiclaude message send` in all workflows
- `supervisor.md` — coordinator role, communication section already has examples

## Test plan

- [ ] Verify all 8 modified files have valid markdown (no broken formatting)
- [ ] Verify every "reply"/"respond"/"report"/"notify"/"escalate" instruction now references `multiclaude message send`
- [ ] After merge, restart project-watchdog to pick up the new definition
- [ ] Test epic allocation flow: supervisor requests number, project-watchdog replies via messaging (not tmux)