### PR TITLE
docs: update source-tree.md — sync package drift

### DIFF
--- a/docs/architecture/source-tree.md
+++ b/docs/architecture/source-tree.md
@@ -308,11 +308,14 @@ ThreeDoors/
 │   │       ├── markdown.go         # Markdown task parser
 │   │       └── daily_notes.go      # Daily note integration
 │   │
-│   ├── sync/                         # Sync Engine (Phase 3, Epic 11)
-│   │   ├── engine.go                # SyncEngine orchestrator
-│   │   ├── queue.go                 # OfflineQueue (JSONL)
-│   │   ├── conflict.go             # ConflictResolver
-│   │   └── log.go                   # SyncLog (rotating)
+│   ├── sync/                         # Sync Engine (Phase 3, Epic 11/64)
+│   │   ├── transport.go             # SyncTransport interface, SyncOp, Changeset
+│   │   ├── git_transport.go         # GitSyncTransport — Git-based SyncTransport impl
+│   │   ├── git_executor.go          # GitExecutor interface, ExecGitExecutor
+│   │   ├── connection.go            # GitSyncConnection — Connection Manager adapter
+│   │   ├── offline.go               # OfflineManager — offline queue & reconciliation (Epic 64)
+│   │   ├── debounce.go              # Debouncer — coalesces rapid sync events
+│   │   └── errors.go                # Sentinel errors (ErrGitNotFound, ErrRebaseConflict, etc.)
 │   │
 │   ├── intelligence/                 # Intelligence Layer (Phase 3-4)
 │   │   ├── agent_service.go         # AgentService — auto-discovery + fallback chain (Epic 57)


### PR DESCRIPTION
## Summary

- Updated `internal/sync/` section in source-tree.md to reflect actual package contents
- Removed stale entries: `engine.go`, `queue.go`, `conflict.go`, `log.go` (none exist)
- Added actual files: `transport.go`, `git_transport.go`, `git_executor.go`, `connection.go`, `offline.go` (new in PR #743), `debounce.go`, `errors.go`
- Updated epic reference from "Epic 11" to "Epic 11/64" to reflect cross-computer sync work

## Trigger

Architecture drift detected during review of PR #743 (Story 64.5 — Offline Queue & Reconciliation).

## Test plan

- [x] Documentation-only change — no code affected