### PR TITLE
docs: Epic 67 — Retrospector Operational Data Pipeline

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,6 +475,14 @@ Fix three infrastructure reliability issues preventing the retrospector agent (S
 
 **Dependency graph:** All three stories are fully independent and can be implemented in parallel.
 
+### Epic 67: Retrospector Operational Data Pipeline (P1) — 0/1 stories — NOT STARTED
+
+Automate periodic sync of retrospector operational data (`docs/operations/`) to git via cron-triggered project-watchdog pipeline. Workers in isolated worktrees currently cannot see retrospector data. The project-watchdog handler already exists (Epic 62); this epic adds the cron trigger and supervisor verification.
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 67.1 | Cron-Triggered Operational Data Sync Pipeline | Not Started | P1 | Epic 62 (done) |
+
 ### Epic 61: GitHub Pages User Guide (P2) — 4/4 stories done — COMPLETE
 
 Publish ThreeDoors documentation as a professional GitHub Pages site using MkDocs + Material for MkDocs, making the user guide discoverable via search engines and accessible without cloning the repo.

--- a/docs/prd/epic-details.md
+++ b/docs/prd/epic-details.md
@@ -2598,6 +2598,46 @@ Follows the standard 4-story integration pattern: 63.1 (REST API v2 client with 
 1. Tests for task, sources, connect, extract, interactive commands
 2. Final coverage ≥70%
 
+## Epic 67: Retrospector Operational Data Pipeline
+
+**Epic Goal:** Automate periodic sync of retrospector operational data (`docs/operations/`) to git via a cron-triggered project-watchdog pipeline, so worker agents in isolated worktrees have access to current operational data.
+
+**Scope:** CronCreate setup for `SYNC_OPERATIONAL_DATA` trigger, supervisor standing orders for cron creation and staleness verification. The project-watchdog handler already exists (added during Epic 62 reliability work).
+
+**Status:** Not Started (0/1 done)
+
+**Prerequisites:** Epic 62 (Retrospector Agent Reliability) — COMPLETE
+
+**Triggered by:** Party mode research: `_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md`
+
+**NFRs covered:** NFR-ODP1 through NFR-ODP5
+
+---
+
+### Story 67.1: Cron-Triggered Operational Data Sync Pipeline
+
+**As a** multiclaude operator,
+**I want** retrospector operational data to be automatically committed to git every 3 hours,
+**so that** worker agents in isolated worktrees can access current operational data and the data is durable in version control.
+
+**Acceptance Criteria:**
+1. Supervisor startup checklist includes a `CronCreate("0 */3 * * *", "multiclaude message send project-watchdog SYNC_OPERATIONAL_DATA")` entry
+2. project-watchdog receives `SYNC_OPERATIONAL_DATA` messages and creates data-sync PRs when `docs/operations/` has changes (handler already exists — verify it works)
+3. If no files changed, no commit or PR is created (idempotency)
+4. Supervisor has a standing order to periodically verify data freshness: `git log --oneline docs/operations/ --since="8 hours ago"` — investigate if no commits and retrospector is active
+5. All changes go through PR workflow (branch protection compliance)
+6. Data sync PRs use the standard `data-sync/<timestamp>` branch naming convention
+
+**Technical Notes:**
+- project-watchdog definition already contains the `SYNC_OPERATIONAL_DATA Response Protocol` (lines 80-121 of `agents/project-watchdog.md`)
+- This story primarily involves supervisor configuration (cron setup, standing orders) and verification
+- Cron interval: every 3 hours (party mode recommended 2-4 hours; 3 hours balances freshness vs. PR noise)
+- Staleness SLA: 6 hours (2x commit interval)
+
+**Estimated Time:** 30-45 minutes
+
+---
+
 ## Epic 66: CLI/TUI Adapter Wiring Parity (PROVISIONAL)
 
 **Epic Goal:** Fix three gaps where implemented adapter code is not properly connected to CLI and TUI entry points, ensuring all registered adapters are accessible through both the CLI and TUI connect flows with proper flag validation.

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -839,7 +839,18 @@
 - **Stories:** 65.1-65.3 (3 stories)
 - **Research:** `_bmad-output/planning-artifacts/state-of-testing-report.md`
 
-**Epic 66+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
+**Epic 67: Retrospector Operational Data Pipeline** (P1)
+- **Goal:** Automate periodic sync of retrospector operational data (`docs/operations/`) to git via cron-triggered project-watchdog pipeline, so worker agents in isolated worktrees have access to current operational data
+- **Prerequisites:** Epic 62 (Retrospector Agent Reliability) — COMPLETE
+- **Status:** Not Started (0/1 done)
+- **Deliverables:**
+  - CronCreate entry for `SYNC_OPERATIONAL_DATA` in supervisor startup checklist
+  - Supervisor standing order for staleness verification
+  - Verification of existing project-watchdog handler
+- **Stories:** 67.1 (1 story)
+- **Research:** `_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md`
+
+**Epic 67+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
 
@@ -917,5 +928,6 @@
 | Epic 64: Cross-Computer Sync | 6 | Complete (6/6 done) |
 | Epic 65: CLI Test Coverage Hardening | 3 | Complete (3/3 done) |
 | Epic 66: CLI/TUI Adapter Wiring Parity | 3 | Complete (3/3 done) |
-| **Total** | **342** | **Audit 2026-03-13: see epics-and-stories.md for authoritative status** |
+| Epic 67: Retrospector Operational Data Pipeline | 1 | Not Started (0/1 done) |
+| **Total** | **343** | **Audit 2026-03-13: see epics-and-stories.md for authoritative status** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 0-15, 3.5, 17-32, 34-51, 53-66 are COMPLETE. Epic 5 reopened (2/2, Story 5.3 done). Epic 16 is ICEBOX. 753+ merged PRs total. Last audit: 2026-03-13.
+**Implementation Status:** Epics 0-15, 3.5, 17-32, 34-51, 53-66 are COMPLETE. Epic 5 reopened (2/2, Story 5.3 done). Epic 16 is ICEBOX. Epic 67 (0/1) NOT STARTED. 753+ merged PRs total. Last audit: 2026-03-13.
 
 ## Requirements Inventory
 
@@ -6421,3 +6421,28 @@ So that I get clear error messages instead of silently incomplete configurations
 - **AC3:** Parity test verifies adapter registry, CLI specs, CLI args, and TUI specs are in sync
 - **AC4:** Connect command help text lists all supported providers
 - **AC5:** `ValidArgs` matches `knownProviderSpecs` keys exactly
+
+## Epic 67: Retrospector Operational Data Pipeline (P1)
+
+**Goal:** Automate periodic sync of retrospector operational data (`docs/operations/`) to git via cron-triggered project-watchdog pipeline, so worker agents in isolated worktrees have access to current operational data.
+
+**Priority:** P1
+**Prerequisites:** Epic 62 (Retrospector Agent Reliability) — COMPLETE
+**NFRs:** NFR-ODP1 through NFR-ODP5
+**Triggered by:** Party mode research: `_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md`
+
+### Story 67.1: Cron-Triggered Operational Data Sync Pipeline
+
+As a multiclaude operator,
+I want retrospector operational data to be automatically committed to git every 3 hours,
+So that worker agents in isolated worktrees can access current operational data and the data is durable in version control.
+
+**Status:** Not Started | **Priority:** P1
+
+**Acceptance Criteria:**
+- **AC1:** Supervisor startup checklist includes `CronCreate("0 */3 * * *", "multiclaude message send project-watchdog SYNC_OPERATIONAL_DATA")` entry
+- **AC2:** project-watchdog receives `SYNC_OPERATIONAL_DATA` and creates data-sync PRs when `docs/operations/` has changes (handler already exists — verify it works)
+- **AC3:** If no files changed, no commit or PR is created (idempotency)
+- **AC4:** Supervisor has standing order to verify data freshness: `git log --oneline docs/operations/ --since="8 hours ago"` — investigate if no commits and retrospector is active
+- **AC5:** All changes go through PR workflow (branch protection compliance)
+- **AC6:** Data sync PRs use `data-sync/<timestamp>` branch naming convention

--- a/docs/prd/product-scope.md
+++ b/docs/prd/product-scope.md
@@ -258,7 +258,7 @@
 
 ---
 
-## Phase 6+: Autonomous Project Governance (Epics 37-38, 51-53, 58, 62)
+## Phase 6+: Autonomous Project Governance (Epics 37-38, 51-53, 58, 62, 67)
 
 **In Scope:**
 - Persistent BMAD Agent Infrastructure: project-watchdog, arch-watchdog agent definitions, SM/QA cron jobs, agent communication architecture (Epic 37)
@@ -268,6 +268,7 @@
 - Remote Collaboration: SSH access, tmux management, MCP bridge design, security hardening (Epic 53)
 - Supervisor Shift Handover: transcript monitoring, rolling state snapshot, 5-step handover protocol, emergency handover, history logging (Epic 58)
 - Retrospector Agent Reliability: file-based inbox, recommendation queue, checkpoint persistence (Epic 62)
+- Retrospector Operational Data Pipeline: cron-triggered project-watchdog sync of `docs/operations/` to git (Epic 67)
 
 **Out of Scope for this Phase:**
 - Tech Writer persistent agent

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -1136,6 +1136,22 @@ These non-functional requirements establish code quality gates that all contribu
 
 **NFR-TC3:** All subcommands (config, mood, health, stats, plan, version, task, sources, connect, extract) shall have dedicated test coverage
 
+## Retrospector Operational Data Pipeline (Epic 67, Accepted)
+
+> Requirements for automated sync of retrospector operational data to git.
+
+**NFR-ODP1:** The system shall periodically commit retrospector operational data files (`docs/operations/*.jsonl`, `docs/operations/*.json`) to git via a cron-triggered agent pipeline, ensuring worker agents in isolated worktrees have access to current operational data
+
+**NFR-ODP2:** Operational data files in git shall be no more than 6 hours behind the main checkout (2x the commit interval as buffer for the staleness SLA)
+
+**NFR-ODP3:** The data sync pipeline shall be idempotent — if no operational data files have changed since the last sync, no commit or PR shall be created
+
+**NFR-ODP4:** Operational data commits shall go through branch protection (PR workflow), not direct pushes to main
+
+**NFR-ODP5:** Data sync PRs shall not interfere with or delay story PRs in the merge queue
+
+---
+
 ## CLI/TUI Adapter Wiring Parity Requirements
 
 > Requirements for ensuring all registered adapters are accessible through both CLI and TUI entry points.

--- a/docs/stories/67.1.story.md
+++ b/docs/stories/67.1.story.md
@@ -1,0 +1,85 @@
+# Story 67.1: Cron-Triggered Operational Data Sync Pipeline
+
+## Status: Not Started
+
+## Epic
+
+Epic 67: Retrospector Operational Data Pipeline
+
+## References
+
+- Party mode artifact: `_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md`
+- project-watchdog definition: `agents/project-watchdog.md` (SYNC_OPERATIONAL_DATA handler, lines 80-121)
+- Related: Epic 62 (Retrospector Agent Reliability) — COMPLETE
+
+## Story
+
+As a multiclaude operator,
+I want retrospector operational data to be automatically committed to git every 3 hours,
+So that worker agents in isolated worktrees can access current operational data and the data is durable in version control.
+
+## Background
+
+Retrospector writes findings to `docs/operations/` files (retrospector-findings.jsonl, retrospector-checkpoint.json, retrospector-recommendations.jsonl) but these files are untracked or have uncommitted changes. They exist only in the main checkout where retrospector runs as a persistent agent. Worker agents spawned in worktrees cannot see this data.
+
+Party mode research (2026-03-13) evaluated four approaches and adopted a hybrid: cron-triggered project-watchdog data sync. The project-watchdog handler was added during Epic 62 reliability work. This story completes the pipeline by setting up the cron trigger and supervisor verification standing orders.
+
+## Acceptance Criteria
+
+**Given** the supervisor starts up (fresh session)
+**When** it runs its startup checklist
+**Then** it creates a CronCreate entry: `CronCreate("0 */3 * * *", "multiclaude message send project-watchdog SYNC_OPERATIONAL_DATA")`
+**And** the cron fires every 3 hours, sending `SYNC_OPERATIONAL_DATA` to project-watchdog
+
+**Given** project-watchdog receives a `SYNC_OPERATIONAL_DATA` message
+**When** `docs/operations/` has uncommitted changes or untracked data files
+**Then** project-watchdog creates a `data-sync/<timestamp>` branch, commits the changes, pushes, and creates a PR
+**And** reports the PR number to the supervisor
+
+**Given** project-watchdog receives a `SYNC_OPERATIONAL_DATA` message
+**When** no files in `docs/operations/` have changed since the last sync
+**Then** no commit, branch, or PR is created (idempotency)
+
+**Given** the supervisor is running its periodic checks
+**When** it verifies operational data freshness
+**Then** it runs `git log --oneline docs/operations/ --since="8 hours ago"`
+**And** if no commits exist and retrospector is active, it investigates the sync pipeline
+
+**Given** a data sync PR is created
+**When** it enters the merge queue
+**Then** it does not interfere with or delay story PRs
+
+## Technical Notes
+
+- The project-watchdog `SYNC_OPERATIONAL_DATA Response Protocol` already exists in `agents/project-watchdog.md` (lines 80-121)
+- Primary work: update supervisor MEMORY.md startup checklist to include the CronCreate entry
+- Secondary work: add a supervisor standing order for staleness verification
+- Cron interval: every 3 hours (party mode recommended 2-4h; 3h balances freshness vs. PR noise)
+- Staleness SLA: 6 hours (2x commit interval as buffer)
+- CronCreate jobs auto-expire after 3 days and are lost on restart — the startup checklist ensures recreation
+
+## Tasks
+
+### Task 1: Update supervisor startup checklist
+Add the CronCreate entry for SYNC_OPERATIONAL_DATA to the supervisor's MEMORY.md startup checklist, alongside the existing HEARTBEAT crons.
+
+### Task 2: Add supervisor standing order for staleness verification
+Add a standing order to the supervisor's standing orders section: periodically verify `docs/operations/` data freshness using `git log --oneline docs/operations/ --since="8 hours ago"`.
+
+### Task 3: Verify project-watchdog handler
+Confirm the SYNC_OPERATIONAL_DATA handler in `agents/project-watchdog.md` is complete and correct. No changes expected — verification only.
+
+### Task 4: Validation
+- Verify cron entry syntax is correct
+- Verify standing order is clear and actionable
+- Run `make fmt` (no-op for .md but good hygiene)
+
+## Quality Gate
+
+AC-Q1 (formatting), AC-Q5 (scope)
+
+## Decisions
+
+- D-ODP1: Adopted hybrid cron + project-watchdog approach over giving retrospector PR authority (observer/participant separation), supervisor direct commits (coordination/execution separation), or standalone cron (needs agent intelligence for branch protection)
+- D-ODP2: 3-hour cron interval chosen from 2-4h range — balances data freshness against merge queue noise
+- D-ODP3: Staleness SLA of 6 hours (2x commit interval) — generous buffer accounts for project-watchdog being busy or restarting


### PR DESCRIPTION
## Summary

- Adds Epic 67: Retrospector Operational Data Pipeline — cron-triggered project-watchdog sync of `docs/operations/` data to git
- Creates Story 67.1 with acceptance criteria for cron setup, staleness verification, and handler validation
- Updates all PRD content docs: requirements.md (NFR-ODP1-5), product-scope.md, epic-details.md
- Updates all planning docs: epic-list.md, epics-and-stories.md, ROADMAP.md
- Story status: `Not Started` (this is a /plan-work PR — planning only, no implementation)

**Key insight:** The project-watchdog `SYNC_OPERATIONAL_DATA` handler already exists (added during Epic 62 reliability work, lines 80-121 of `agents/project-watchdog.md`). Story 67.1 covers the remaining work: supervisor cron setup and staleness verification standing orders.

**Party mode artifact:** `_bmad-output/planning-artifacts/retrospector-data-pipeline-party-mode.md`
**Epic number allocated by:** project-watchdog (via supervisor, Epic 67)

## Test plan

- [ ] Verify no merge conflicts in planning docs
- [ ] Verify story file exists at `docs/stories/67.1.story.md` with status `Not Started`
- [ ] Verify epic-list.md story count table is consistent
- [ ] Verify ROADMAP.md includes Epic 67 entry
- [ ] Verify NFR-ODP1-5 requirements are in requirements.md