### PR TITLE
fix: update Dockerfile.test to Go 1.26 (#770)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,7 +2,7 @@
 # Story 18.4: Builds a test runner image with Go toolchain and linting tools.
 # Source code is mounted at runtime via docker-compose, not copied into the image.
 
-FROM golang:1.25-bookworm
+FROM golang:1.26-bookworm
 
 # Pin tool versions to match CI (.github/workflows/ci.yml)
 ARG GOFUMPT_VERSION=v0.7.0


### PR DESCRIPTION
## Summary

- Updates `Dockerfile.test` base image from `golang:1.25-bookworm` to `golang:1.26-bookworm`
- `go.mod` was bumped to Go 1.26.1 in PR #761, but the Dockerfile wasn't updated, causing Docker E2E tests to fail on `go mod download` (Go 1.25 can't satisfy the 1.26.1 toolchain requirement)
- CI workflows already use `go-version-file: 'go.mod'` so they're unaffected — only `Dockerfile.test` was stale

Fixes #770

## Test plan

- [x] `just test` passes locally
- [x] `just fmt` — no changes
- [x] `just lint` — 0 issues
- [ ] CI Docker E2E job passes on this PR