### PR TITLE
docs: plan Epic 68 — BOARD.md Redesign

### DIFF
--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -869,6 +869,19 @@
   - History CLI command (`threedoors history`)
 - **Stories:** 70.1, 70.2, 70.3 (3 stories)
 
+**Epic 68: BOARD.md Redesign** (P2)
+- **Goal:** Split BOARD.md into a focused active dashboard (<120 lines) and a complete decision archive, extract Epic Number Registry to its own file, fix duplicate IDs, and update all supporting docs and agent definitions
+- **Prerequisites:** None
+- **Status:** Not Started
+- **Deliverables:**
+  - ARCHIVE.md with complete historical record (181+ decided, 118+ rejected entries)
+  - EPIC_REGISTRY.md extracted as standalone coordination mutex file
+  - Restructured BOARD.md with action-oriented sections (Needs Decision, Under Investigation, Recently Decided/Rejected)
+  - Duplicate ID deconfliction across decided and rejected entries
+  - Updated README.md, SWEEP.md, and 5 agent definitions for new structure
+- **Stories:** 68.1-68.3 (3 stories)
+- **Research:** See `_bmad-output/planning-artifacts/board-redesign-research.md` (PR #762)
+
 **Epic 67+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
@@ -950,5 +963,6 @@
 | Epic 67: Retrospector Operational Data Pipeline | 1 | Complete (1/1 done) |
 | Epic 69: TUI MainModel Decomposition | 4 | In Progress (2/4 done) |
 | Epic 70: Completion History & Progress View | 3 | Complete (3/3 done) |
-| **Total** | **350** | **Audit 2026-03-15: see epics-and-stories.md for authoritative status** |
+| Epic 68: BOARD.md Redesign | 3 | Not Started |
+| **Total** | **353** | **Audit 2026-03-15: see epics-and-stories.md for authoritative status** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 0-15, 3.5, 17-32, 34-51, 53-67 are COMPLETE. Epic 5 reopened (2/2, Story 5.3 done). Epic 16 is ICEBOX. Epics 69, 70 planned (Not Started). 764+ merged PRs total. Last audit: 2026-03-15.
+**Implementation Status:** Epics 0-15, 3.5, 17-32, 34-51, 53-67 are COMPLETE. Epic 5 reopened (2/2, Story 5.3 done). Epic 16 is ICEBOX. Epics 68, 69, 70 planned (Not Started). 764+ merged PRs total. Last audit: 2026-03-15.
 
 ## Requirements Inventory
 
@@ -6564,3 +6564,38 @@ So that I can view my completion history from the terminal without launching the
 
 **Status:** Done (PR #777) | **Priority:** P1
 **Depends On:** 70.1
+
+## Epic 68: BOARD.md Redesign (P2)
+
+**Goal:** Split BOARD.md into a focused active dashboard (<120 lines) and a complete decision archive, extract Epic Number Registry to its own file, fix duplicate IDs, and update all supporting docs and agent definitions.
+
+**Priority:** P2
+**Prerequisites:** None
+**Status:** Not Started (0/3 stories done)
+**Research:** `_bmad-output/planning-artifacts/board-redesign-research.md` (PR #762)
+
+### Story 68.1: Create Decision Archive and Extract Epic Registry
+
+As a project contributor,
+I want historical decisions moved to a separate archive file and the Epic Number Registry extracted to its own file,
+So that BOARD.md remains a focused active dashboard and the registry is independently maintainable.
+
+**Status:** Not Started | **Priority:** P2
+
+### Story 68.2: Restructure Active BOARD.md
+
+As a project decision-maker,
+I want BOARD.md restructured with action-oriented sections showing only items needing attention,
+So that I can scan the board in seconds and see what needs my input without wading through historical entries.
+
+**Status:** Not Started | **Priority:** P2
+**Depends On:** 68.1
+
+### Story 68.3: Update Supporting Documentation for Board Redesign
+
+As a project contributor or agent,
+I want all documentation and agent definitions updated to reflect the new BOARD.md structure,
+So that the board guide, sweep process, and agent behaviors are consistent with the two-file split.
+
+**Status:** Not Started | **Priority:** P2
+**Depends On:** 68.1, 68.2

--- a/docs/stories/68.1.story.md
+++ b/docs/stories/68.1.story.md
@@ -1,0 +1,64 @@
+# Story 68.1: Create Decision Archive and Extract Epic Registry
+
+## Status: Not Started
+
+## Epic
+
+Epic 68: BOARD.md Redesign
+
+## References
+
+- Research artifact: `_bmad-output/planning-artifacts/board-redesign-research.md` (PR #762)
+- Current BOARD.md: `docs/decisions/BOARD.md` (411 lines)
+- Current README.md: `docs/decisions/README.md`
+
+## Story
+
+As a project contributor,
+I want historical decisions moved to a separate archive file and the Epic Number Registry extracted to its own file,
+So that BOARD.md remains a focused active dashboard and the registry is independently maintainable.
+
+## Background
+
+BOARD.md has grown to 411 lines with 181 decided entries, 118 rejected entries, and an Epic Number Registry that serves a completely different purpose (agent coordination mutex). The research at PR #762 recommends a two-file split: active BOARD.md + ARCHIVE.md, plus extracting the registry.
+
+## Acceptance Criteria
+
+- [ ] `docs/decisions/ARCHIVE.md` exists containing:
+  - All Decided entries (D-001 through D-181+) in chronological order
+  - All Rejected entries (both current sections merged into one) in chronological order
+  - Resolved Open Questions (Q-001 through Q-004)
+  - Completed Research entries (R-001)
+  - Superseded entries (if any exist)
+  - Header with cross-reference link back to `BOARD.md`
+- [ ] `docs/decisions/EPIC_REGISTRY.md` exists containing:
+  - The Epic Number Registry extracted from BOARD.md
+  - Brief header explaining its purpose as the coordination mutex for epic number allocation
+- [ ] Duplicate IDs are fixed during migration:
+  - Two D-059s: second instance renumbered (D-059b or next available)
+  - Two D-074s: second instance renumbered
+  - Two D-112-117 sets: second set renumbered
+  - Two D-128s: second instance renumbered
+  - Two D-137s: second instance renumbered
+  - Two D-153-156 sets: second set renumbered
+  - Duplicate IDs in X-050-X-072 range: second instances renumbered
+- [ ] Two separate Rejected sections merged into single section in ARCHIVE.md
+- [ ] No content is lost — all entries from current BOARD.md appear in either the new BOARD.md or ARCHIVE.md
+- [ ] Story file status updated to Done with PR number
+
+## Tasks
+
+- [ ] Read full current BOARD.md to catalog all entries and identify exact duplicate IDs
+- [ ] Create `docs/decisions/ARCHIVE.md` with proper structure (All Decided, All Rejected, Resolved Questions, Completed Research, Superseded)
+- [ ] Fix all duplicate IDs during the migration — renumber second instances
+- [ ] Merge the two Rejected sections into one unified section
+- [ ] Create `docs/decisions/EPIC_REGISTRY.md` with the registry content
+- [ ] Remove archived entries and registry from BOARD.md (leaving stubs/cross-references)
+- [ ] Verify no entries were lost (count check: decided + rejected + questions + research + superseded)
+- [ ] Run `just fmt` and `just lint`
+
+## Technical Notes
+
+- This story creates the archive and registry files but does NOT restructure BOARD.md's active sections — that's Story 68.2
+- The BOARD.md changes in this story are subtractive only (removing content moved to archive/registry)
+- Duplicate ID fix strategy: append 'b' suffix to the second instance (e.g., D-059b) to preserve existing references while ensuring uniqueness

--- a/docs/stories/68.2.story.md
+++ b/docs/stories/68.2.story.md
@@ -1,0 +1,64 @@
+# Story 68.2: Restructure Active BOARD.md
+
+## Status: Not Started
+
+## Epic
+
+Epic 68: BOARD.md Redesign
+
+## Dependencies
+
+- Story 68.1 (archive and registry must exist before restructuring the active board)
+
+## References
+
+- Research artifact: `_bmad-output/planning-artifacts/board-redesign-research.md` (PR #762)
+- Design: "Proposed Redesign" section of research artifact
+
+## Story
+
+As a project decision-maker,
+I want BOARD.md restructured with action-oriented sections showing only items needing attention,
+So that I can scan the board in seconds and see what needs my input without wading through historical entries.
+
+## Background
+
+After Story 68.1 moves historical entries to the archive, BOARD.md still has the old section structure (Open Questions, Active Research, Pending Recommendations, Decided, Rejected). The research recommends replacing these with action-oriented sections: "Needs Decision", "Under Investigation", "Recently Decided (30 days)", "Recently Rejected (30 days)".
+
+## Acceptance Criteria
+
+- [ ] BOARD.md has new section structure:
+  - **Needs Decision (Human Input Required)** — replaces Open Questions + Pending Recommendations for unresolved items
+  - **Under Investigation** — replaces Active Research for active items
+  - **Recently Decided (Last 30 Days)** — decided entries from the last 30 days (approx. D-160+ based on dates)
+  - **Recently Rejected (Last 30 Days)** — rejected entries from the last 30 days
+- [ ] Header includes cross-reference: "Full history: [ARCHIVE.md](ARCHIVE.md)"
+- [ ] Current active items correctly placed:
+  - P-001 (Justfile migration, awaiting sign-off) → Needs Decision
+  - P-007 (PRD cleanup, awaiting story creation) → Needs Decision
+  - R-002 (PRD audit, open) → Under Investigation
+  - All resolved Q-001–Q-004 → removed (already in archive from 68.1)
+  - All resolved R-001 → removed (already in archive from 68.1)
+  - All "Done" P-entries (P-002–P-006) → removed (already in archive from 68.1)
+- [ ] Recently Decided section contains only entries from the last ~30 days (March 2026)
+- [ ] Recently Rejected section contains only entries from the last ~30 days
+- [ ] Target BOARD.md size: < 120 lines of active content
+- [ ] Story file status updated to Done with PR number
+
+## Tasks
+
+- [ ] Identify which Decided entries fall within the last 30 days (using dates from entries)
+- [ ] Identify which Rejected entries fall within the last 30 days
+- [ ] Restructure BOARD.md header and description
+- [ ] Create "Needs Decision" section with P-001, P-007
+- [ ] Create "Under Investigation" section with R-002
+- [ ] Create "Recently Decided" section with last-30-day entries
+- [ ] Create "Recently Rejected" section with last-30-day entries
+- [ ] Verify all items are accounted for (active board + archive = complete set)
+- [ ] Run `just fmt` and `just lint`
+
+## Technical Notes
+
+- The 30-day window is a guideline, not a hard cutoff. Use entry dates to determine roughly which entries are "recent" (March 2026). When in doubt, include rather than exclude.
+- Items in "Needs Decision" should preserve their original P-NNN or Q-NNN IDs for traceability
+- The Superseded section can remain in BOARD.md if there are active superseded items, otherwise move to archive only

--- a/docs/stories/68.3.story.md
+++ b/docs/stories/68.3.story.md
@@ -1,0 +1,70 @@
+# Story 68.3: Update Supporting Documentation for Board Redesign
+
+## Status: Not Started
+
+## Epic
+
+Epic 68: BOARD.md Redesign
+
+## Dependencies
+
+- Story 68.1 (archive and registry files must exist)
+- Story 68.2 (active BOARD.md must have new structure)
+
+## References
+
+- Research artifact: `_bmad-output/planning-artifacts/board-redesign-research.md` (PR #762)
+- Decisions README: `docs/decisions/README.md`
+- Sweep process: `docs/decisions/SWEEP.md`
+- Agent definitions referencing BOARD.md sections: `agents/retrospector.md`, `agents/project-watchdog.md`, `agents/envoy.md`, `agents/supervisor.md`, `agents/research-supervisor.md`
+
+## Story
+
+As a project contributor or agent,
+I want all documentation and agent definitions updated to reflect the new BOARD.md structure,
+So that the board guide, sweep process, and agent behaviors are consistent with the two-file split.
+
+## Background
+
+The BOARD.md redesign (Stories 68.1-68.2) changes the board's section structure and introduces two new files (ARCHIVE.md, EPIC_REGISTRY.md). Several documents reference BOARD.md by section name or describe its structure. These must be updated for consistency.
+
+## Acceptance Criteria
+
+- [ ] `docs/decisions/README.md` updated:
+  - Board Structure section reflects new sections (Needs Decision, Under Investigation, Recently Decided, Recently Rejected)
+  - Lifecycle flow updated to include archive aging
+  - References to ARCHIVE.md and EPIC_REGISTRY.md added
+  - Column Definitions table updated for new section names
+  - ID Scheme section notes that EPIC_REGISTRY.md is now separate
+- [ ] `docs/decisions/SWEEP.md` updated:
+  - 30-day aging added as a sweep responsibility (move entries older than 30 days from Recently Decided/Rejected to archive)
+  - Staleness markers (`[STALE]`) documented for "Needs Decision" and "Under Investigation" items exceeding thresholds
+  - Scan targets updated to reference new section names
+  - Report format updated to include aging actions
+- [ ] Agent definitions updated for new section names:
+  - `agents/project-watchdog.md`: "Pending Recommendations" → "Needs Decision" in BOARD.md update instructions
+  - `agents/retrospector.md`: References to "Pending Recommendations" and "BOARD.md table format" updated
+  - `agents/envoy.md`: "Decided section" and "Pending Recommendations" references updated
+  - `agents/supervisor.md`: BOARD.md reference updated
+  - `agents/research-supervisor.md`: BOARD.md reference updated
+- [ ] BOARD.md redesign decisions recorded on the new BOARD.md (in Recently Decided or Needs Decision as appropriate)
+- [ ] Story file status updated to Done with PR number
+
+## Tasks
+
+- [ ] Update `docs/decisions/README.md` with new structure, lifecycle, and file references
+- [ ] Update `docs/decisions/SWEEP.md` with archive aging responsibility and staleness markers
+- [ ] Update `agents/project-watchdog.md` section references
+- [ ] Update `agents/retrospector.md` section references
+- [ ] Update `agents/envoy.md` section references
+- [ ] Update `agents/supervisor.md` section references
+- [ ] Update `agents/research-supervisor.md` section references
+- [ ] Add board redesign decisions to BOARD.md (D-entries for the adopted approach)
+- [ ] Run `just fmt` and `just lint`
+
+## Technical Notes
+
+- CLAUDE.md references to BOARD.md are generic ("check BOARD.md", "add entry to BOARD.md") and do NOT need changes — the file still exists at the same path
+- Agent definition changes should be minimal — just updating section name references, not restructuring agent behavior
+- The redesign decisions to record on BOARD.md should reference the research artifact and this epic's stories
+- After agent definition changes merge, persistent agents (retrospector, project-watchdog, envoy) will need restarts to pick up new definitions — note this in the PR description


### PR DESCRIPTION
## Summary

- Creates 3 stories for Epic 68 (BOARD.md Redesign), based on merged research at PR #762
- Updates `epic-list.md` and `epics-and-stories.md` with Epic 68 entries
- Epic number 68 allocated by project-watchdog via supervisor

### Stories Created

| Story | Title | Status |
|-------|-------|--------|
| 68.1 | Create Decision Archive and Extract Epic Registry | Not Started |
| 68.2 | Restructure Active BOARD.md | Not Started |
| 68.3 | Update Supporting Documentation for Board Redesign | Not Started |

### Story Dependency Chain
68.1 → 68.2 → 68.3 (sequential — each builds on the previous)

### Research Source
`_bmad-output/planning-artifacts/board-redesign-research.md` (PR #762)

## Test plan

- [x] Story files exist at `docs/stories/68.{1,2,3}.story.md`
- [x] All stories have status `Not Started`
- [x] Epic 68 added to `epic-list.md` story count summary
- [x] Epic 68 added to `epics-and-stories.md` with all 3 stories
- [x] No code changes — docs-only PR