### PR TITLE
docs: governance sync — Story 69.2 Done, Epic 69 now 3/4

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -586,14 +586,14 @@ Task data synchronization across multiple computers. Architecturally distinct fr
 
 Single story under Epic 5 (macOS Distribution). CI generates signed, notarized .pkg installer uploaded to GitHub Releases alongside binaries. Reopens Epic 5 from COMPLETE to 1/2.
 
-### Epic 69: TUI MainModel Decomposition (P1) — 2/4 stories done
+### Epic 69: TUI MainModel Decomposition (P1) — 3/4 stories done
 
 Refactor `internal/tui/main_model.go` (2991 lines) into focused files. Extract view transition/navigation logic, source/sync view controllers, planning/task management view controllers, and auxiliary view controllers into separate files.
 
 | Story | Title | Status | Priority | Depends On |
 |-------|-------|--------|----------|------------|
 | 69.1 | Extract View Transition & Navigation Logic | Done (PR #767) | P1 | None |
-| 69.2 | Extract Source/Sync View Controllers | Not Started | P1 | 69.1 |
+| 69.2 | Extract Source/Sync View Controllers | Done (PR #786) | P1 | 69.1 |
 | 69.3 | Extract Planning & Task Management View Controllers | Done (PR #779) | P1 | 69.1 |
 | 69.4 | Extract Auxiliary View Controllers & Command Dispatch | Not Started | P1 | 69.2, 69.3 |
 

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -852,7 +852,7 @@
 
 **Epic 69: TUI MainModel Decomposition** (P1)
 - **Goal:** Refactor `internal/tui/main_model.go` (2991 lines) into focused files for improved maintainability
-- **Status:** In Progress (2/4 done — PRs #767, #779)
+- **Status:** In Progress (3/4 done — PRs #767, #779, #786)
 - **Deliverables:**
   - View transition & navigation logic extracted
   - Source/sync view controllers extracted
@@ -961,7 +961,7 @@
 | Epic 65: CLI Test Coverage Hardening | 3 | Complete (3/3 done) |
 | Epic 66: CLI/TUI Adapter Wiring Parity | 3 | Complete (3/3 done) |
 | Epic 67: Retrospector Operational Data Pipeline | 1 | Complete (1/1 done) |
-| Epic 69: TUI MainModel Decomposition | 4 | In Progress (2/4 done) |
+| Epic 69: TUI MainModel Decomposition | 4 | In Progress (3/4 done) |
 | Epic 70: Completion History & Progress View | 3 | Complete (3/3 done) |
 | Epic 68: BOARD.md Redesign | 3 | Not Started |
 | **Total** | **353** | **Audit 2026-03-15: see epics-and-stories.md for authoritative status** |

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -6518,7 +6518,7 @@ So that worker agents in isolated worktrees can access current operational data 
 
 **Priority:** P1
 **Prerequisites:** None
-**Status:** 2/4 stories done
+**Status:** 3/4 stories done
 
 ### Story 69.1: Extract View Transition & Navigation Logic
 
@@ -6534,7 +6534,7 @@ As a developer,
 I want source and sync view controller logic extracted from main_model.go,
 So that provider connection and sync flows are maintainable independently.
 
-**Status:** Not Started | **Priority:** P1
+**Status:** Done (PR #786) | **Priority:** P1
 **Depends On:** 69.1
 
 ### Story 69.3: Extract Planning & Task Management View Controllers


### PR DESCRIPTION
## Summary

- **Story 69.2** (Extract Source/Sync View Controllers) → Done (PR #786)
- **Epic 69** progress: 3/4 stories done (only 69.4 remains)

## Test plan

- [ ] Verify Story 69.2 status updated in all three planning docs
- [ ] Verify Epic 69 progress count is 3/4