### PR TITLE
docs: governance sync — Epic 69 COMPLETE

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -586,7 +586,7 @@ Task data synchronization across multiple computers. Architecturally distinct fr
 
 Single story under Epic 5 (macOS Distribution). CI generates signed, notarized .pkg installer uploaded to GitHub Releases alongside binaries. Reopens Epic 5 from COMPLETE to 1/2.
 
-### Epic 69: TUI MainModel Decomposition (P1) — 3/4 stories done
+### Epic 69: TUI MainModel Decomposition (P1) — 4/4 stories done — COMPLETE
 
 Refactor `internal/tui/main_model.go` (2991 lines) into focused files. Extract view transition/navigation logic, source/sync view controllers, planning/task management view controllers, and auxiliary view controllers into separate files.
 
@@ -595,7 +595,7 @@ Refactor `internal/tui/main_model.go` (2991 lines) into focused files. Extract v
 | 69.1 | Extract View Transition & Navigation Logic | Done (PR #767) | P1 | None |
 | 69.2 | Extract Source/Sync View Controllers | Done (PR #786) | P1 | 69.1 |
 | 69.3 | Extract Planning & Task Management View Controllers | Done (PR #779) | P1 | 69.1 |
-| 69.4 | Extract Auxiliary View Controllers & Command Dispatch | Not Started | P1 | 69.2, 69.3 |
+| 69.4 | Extract Auxiliary View Controllers & Command Dispatch | Done (PR #789) | P1 | 69.2, 69.3 |
 
 **Dependency graph:** 69.1 first, then 69.2 & 69.3 can parallelize, then 69.4 last.
 

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -852,7 +852,7 @@
 
 **Epic 69: TUI MainModel Decomposition** (P1)
 - **Goal:** Refactor `internal/tui/main_model.go` (2991 lines) into focused files for improved maintainability
-- **Status:** In Progress (3/4 done — PRs #767, #779, #786)
+- **Status:** COMPLETE (4/4 done — PRs #767, #779, #786, #789)
 - **Deliverables:**
   - View transition & navigation logic extracted
   - Source/sync view controllers extracted
@@ -961,7 +961,7 @@
 | Epic 65: CLI Test Coverage Hardening | 3 | Complete (3/3 done) |
 | Epic 66: CLI/TUI Adapter Wiring Parity | 3 | Complete (3/3 done) |
 | Epic 67: Retrospector Operational Data Pipeline | 1 | Complete (1/1 done) |
-| Epic 69: TUI MainModel Decomposition | 4 | In Progress (3/4 done) |
+| Epic 69: TUI MainModel Decomposition | 4 | Complete (4/4 done) |
 | Epic 70: Completion History & Progress View | 3 | Complete (3/3 done) |
 | Epic 68: BOARD.md Redesign | 3 | Not Started |
 | **Total** | **353** | **Audit 2026-03-15: see epics-and-stories.md for authoritative status** |

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -6518,7 +6518,7 @@ So that worker agents in isolated worktrees can access current operational data 
 
 **Priority:** P1
 **Prerequisites:** None
-**Status:** 3/4 stories done
+**Status:** COMPLETE (4/4 stories done)
 
 ### Story 69.1: Extract View Transition & Navigation Logic
 
@@ -6552,7 +6552,7 @@ As a developer,
 I want auxiliary view controllers and command dispatch logic extracted from main_model.go,
 So that the decomposition is complete and main_model.go is a thin orchestrator.
 
-**Status:** Not Started | **Priority:** P1
+**Status:** Done (PR #789) | **Priority:** P1
 **Depends On:** 69.2, 69.3
 
 ## Epic 70: Completion History & Progress View (P1)


### PR DESCRIPTION
## Summary

- **Epic 69** (TUI MainModel Decomposition): **COMPLETE** (4/4 stories done)
  - Story 69.4 (Extract Auxiliary View Controllers & Command Dispatch) → Done (PR #789)
- Updated all three planning docs

## Test plan

- [ ] Verify Epic 69 marked COMPLETE in ROADMAP, epic-list, epics-and-stories
- [ ] Verify Story 69.4 status updated