### PR TITLE
docs: plan Epic 72 — Operationalize GitHub Label Usage (4 stories)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -635,6 +635,19 @@ Remove darwin/amd64 build targets from CI workflows, release builds, Homebrew fo
 
 **Dependency graph:** Linear chain: 71.1 → 71.2 → 71.3. Story 71.1 is the foundation (CI + GoReleaser). Story 71.2 handles the tag-triggered release workflow. Story 71.3 cleans up docs and tests.
 
+### Epic 72: Operationalize GitHub Label Usage (P1) — 0/4 stories done — NOT STARTED
+
+Wire GitHub label application into agent workflows so that PRs are routinely labeled, issue labeling is resilient to envoy downtime, and mutual exclusivity is enforced. Agent definition and operational doc changes only — no application code. Based on label usage gap analysis (PR #806).
+
+| Story | Title | Status | Priority | Depends On |
+|-------|-------|--------|----------|------------|
+| 72.1 | Merge-Queue PR Labeling | Not Started | P1 | None |
+| 72.2 | Envoy Label Resilience | Not Started | P1 | None |
+| 72.3 | Supervisor Label Discipline & Missing Label | Not Started | P1 | None |
+| 72.4 | Retroactive Label Cleanup | Not Started | P2 | 72.3 |
+
+**Dependency graph:** Stories 72.1, 72.2, and 72.3 are independent and can parallelize. Story 72.4 depends on 72.3 (needs `resolution.wontfix` label to exist).
+
 ## Out of Scope
 
 Work not listed above is out of scope. Merge-queue should reject PRs that introduce features or epics not on this roadmap without human approval.

--- a/_bmad-output/planning-artifacts/label-operationalization-party-mode.md
+++ b/_bmad-output/planning-artifacts/label-operationalization-party-mode.md
@@ -1,0 +1,74 @@
+# Party Mode: Operationalize GitHub Label Usage Across Agents
+
+**Date:** 2026-03-18
+**Participants:** PM, Architect, SM
+**Input:** Label Usage Gap Analysis (PR #806), Sprint Change Proposal (2026-03-18)
+**Topic:** How to close the gap between label infrastructure and actual label usage
+
+---
+
+## Discussion Summary
+
+### Round 1: Problem Validation
+
+**PM:** The gap analysis is thorough. Zero PR labels across 800+ PRs is a clear systemic gap, not a bug. The root cause — "labels designed but not wired into agent workflows" — mirrors the PRD content doc gap we found (D-179): infrastructure exists but operational instructions are missing.
+
+**Architect:** This is an operational wiring problem, not an architectural one. No new infrastructure needed. The label taxonomy (D-107), authority matrix (label-authority.md), and agent definitions are all correct — they just need explicit "when you do X, also apply label Y" instructions.
+
+**SM:** Four stories is right. Story 72.1 (merge-queue) has the highest impact — it fills the entire PR labeling gap. Story 72.2 (envoy) fixes issue reliability. Stories 72.3 and 72.4 are lower-risk cleanup.
+
+### Round 2: Approach Validation
+
+**PM:** Option A (merge-queue owns PR labeling) is correct. The merge-queue's polling loop already examines every PR. Title-prefix inference (`feat:` → `type.feature`) is deterministic and doesn't require AI reasoning — it's a mechanical step in the validation checklist.
+
+**Architect:** Agreed. No architectural concerns. The title-prefix mapping is a convention already enforced by CLAUDE.md commit message format. The `scope.in-scope` inference from story references is similarly mechanical.
+
+**SM:** One concern: what happens when a PR title doesn't match any prefix? The merge-queue should skip type labeling rather than guess. Missing labels are better than wrong labels.
+
+**PM:** Good point. The instruction should say "if missing, infer from title prefix" with a clear mapping, and do nothing if no match.
+
+### Round 3: PRD Changes Review
+
+**PM:** The proposed PRD changes are appropriate:
+- FR-GOV1-3 cover the three new capabilities (PR labeling, issue lifecycle, mutual exclusivity)
+- NFR-GOV1 captures the startup catch-up requirement
+- Phase 6 placement is correct — this is governance/operations
+
+**Architect:** No architectural docs need updating. This is purely operational.
+
+**SM:** Story acceptance criteria should include verification that labels are actually applied — not just that the instructions exist in the agent definition.
+
+---
+
+## Decisions
+
+### Adopted
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D-184 | Merge-queue owns routine PR labeling via title-prefix inference | Natural extension of merge validation; deterministic mapping; no role confusion |
+| D-185 | Envoy adds startup catch-up scan for unlabeled issues | Fills the gap when envoy is down; retroactive labeling within one polling cycle |
+
+### Rejected
+
+| ID | Option | Why Rejected |
+|----|--------|--------------|
+| X-124 | PR-shepherd applies PR labels | Blurs pr-shepherd's focused "branch health" role |
+| X-125 | Dedicated label-enforcement agent | Over-engineering; 5-10 lines in existing agents suffice |
+
+---
+
+## Recommendations Applied
+
+1. **Skip type label when no title prefix matches** — missing is better than wrong
+2. **Story 72.2 includes mutual exclusivity enforcement** — explicit remove-before-add in envoy instructions
+3. **Story 72.4 is P2** — retroactive cleanup is lower priority than preventing future gaps
+4. **Verification criteria added** — each story's ACs include checking that labels are actually present after the workflow runs
+
+---
+
+## Artifact Location
+
+- Sprint change proposal: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-18-label-operationalization.md`
+- Gap analysis: `_bmad-output/planning-artifacts/label-usage-gap-analysis.md`
+- This document: `_bmad-output/planning-artifacts/label-operationalization-party-mode.md`

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-18-label-operationalization.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-18-label-operationalization.md
@@ -1,0 +1,87 @@
+# Sprint Change Proposal: Operationalize GitHub Label Usage Across Agents
+
+**Date:** 2026-03-18
+**Author:** fancy-dolphin (worker agent, /plan-work pipeline)
+**Source:** Label Usage Gap Analysis (PR #806, `_bmad-output/planning-artifacts/label-usage-gap-analysis.md`)
+**Proposed Epic:** 72 — Operationalize GitHub Label Usage
+
+---
+
+## Problem Statement
+
+ThreeDoors has excellent label infrastructure (27 well-designed scoped labels, complete authority matrix, detailed agent definitions) but **zero PRs have ever had labels applied** and **issue labeling is inconsistent**. The root cause is not missing documentation — it's that no agent definition includes explicit workflow instructions to apply labels as part of its routine operations.
+
+### Impact Analysis
+
+- **PR discoverability:** With 800+ merged PRs and zero labels, filtering PRs by type/scope is impossible
+- **Issue reliability:** Issues created during envoy downtime never get retroactively labeled
+- **Mutual exclusivity violations:** Existing issues have conflicting labels (e.g., both `triage.in-progress` and `triage.complete`)
+- **Missing label:** `resolution.wontfix` doesn't exist on GitHub despite being in the taxonomy
+- **Dashboard usability:** Label-based GitHub dashboards and queries are unreliable
+
+### Scope
+
+This is entirely agent definition and operational documentation changes — **no application code**. Changes affect:
+- `agents/merge-queue.md` — add PR labeling section
+- `agents/envoy.md` — add startup catch-up, context warning, mutual exclusivity enforcement
+- Supervisor memory — add label discipline instructions
+- `docs/operations/label-authority.md` — update merge-queue entry
+- GitHub label API — create missing label, fix existing violations
+
+---
+
+## Proposed Approach (Adopted)
+
+### Option A: Merge-queue owns routine PR labeling (ADOPTED)
+
+Merge-queue already reads every open PR during its polling loop. Adding label inference from PR title prefix is a natural, coherent extension of its validation role.
+
+**Rationale:**
+- Merge-queue is the natural owner because it already validates PR metadata (scope, CI, reviews)
+- Adding label classification is a small extension with no role confusion
+- Labels applied before merge ensures all merged PRs are classified
+- Inference from title prefix is deterministic and doesn't require AI reasoning
+
+### Option B: PR-shepherd applies PR labels (REJECTED)
+
+PR-shepherd also reads every PR. However, pr-shepherd's responsibility is "branch health" not "PR metadata" — adding labeling would blur its focused role. See X-124.
+
+### Option C: Create a dedicated label-enforcement agent (REJECTED)
+
+A new persistent agent solely for label management. Over-engineering for what amounts to 5-10 lines of instructions added to existing agents. See X-125.
+
+---
+
+## Stories (4 total)
+
+| Story | Title | Priority | Scope |
+|-------|-------|----------|-------|
+| 72.1 | Merge-Queue PR Labeling | P1 | Add PR labeling section to merge-queue agent definition |
+| 72.2 | Envoy Label Resilience | P1 | Startup catch-up, context exhaustion warning, mutual exclusivity enforcement |
+| 72.3 | Supervisor Label Discipline & Missing Label | P1 | Supervisor instructions + create resolution.wontfix on GitHub |
+| 72.4 | Retroactive Label Cleanup | P2 | One-time fix of unlabeled/mislabeled issues |
+
+---
+
+## PRD Changes Required
+
+### `docs/prd/requirements.md`
+- Add FR-GOV1: Agents shall apply appropriate GitHub labels to PRs during merge validation
+- Add FR-GOV2: Agents shall apply triage labels to issues on detection and maintain label state through the triage lifecycle
+- Add FR-GOV3: Agents shall enforce mutual exclusivity for scoped labels (remove old before applying new)
+- Add NFR-GOV1: Unlabeled issues from agent downtime shall be retroactively labeled within one polling cycle of agent restart
+
+### `docs/prd/product-scope.md`
+- Add to Phase 6 (Developer Experience & Governance) under "Autonomous Project Governance": GitHub label operationalization across agent workflows
+
+### `docs/prd/epic-details.md`
+- Add Epic 72 detailed breakdown with all 4 stories and acceptance criteria
+
+---
+
+## Risk Assessment
+
+- **Low risk:** All changes are text/documentation — no application code, no build changes
+- **No merge conflict risk:** Agent definition files rarely have parallel edits
+- **Rollback:** Simple git revert if label automation causes issues
+- **Dependency:** None — all stories are independent except 72.4 depends on 72.3 (needs resolution.wontfix to exist)

--- a/docs/decisions/BOARD.md
+++ b/docs/decisions/BOARD.md
@@ -47,6 +47,8 @@
 | D-180 | Standalone tea.Program wrapping ConnectWizard for CLI (Story 45.6) | 2026-03-13 | Wizard already implements tea.Model; thin wrapper avoids logic duplication | [Research](../../_bmad-output/planning-artifacts/connect-wizard-gap-research.md) |
 | D-181 | Move adapter registration before CLI/TUI routing branch (Epic 66) | 2026-03-13 | Registration only ran in TUI path; CLI had empty registry | [Audit](../../_bmad-output/planning-artifacts/unwired-features-audit.md) |
 | D-182 | BOARD.md redesign: action-oriented sections, two-file split with ARCHIVE.md + EPIC_REGISTRY.md (Epic 68) | 2026-03-15 | Reduces dashboard noise; 150+ historical entries moved to archive; epic registry separated for cleaner allocation | [Research](../../_bmad-output/planning-artifacts/board-redesign-research.md) |
+| D-184 | Merge-queue owns routine PR labeling via title-prefix inference (Epic 72) | 2026-03-18 | Natural extension of merge validation; deterministic mapping; no role confusion | [Party Mode](../../_bmad-output/planning-artifacts/label-operationalization-party-mode.md) |
+| D-185 | Envoy adds startup catch-up scan for unlabeled issues (Epic 72) | 2026-03-18 | Fills the gap when envoy is down; retroactive labeling within one polling cycle | [Party Mode](../../_bmad-output/planning-artifacts/label-operationalization-party-mode.md) |
 
 ## Recently Rejected (Last 30 Days)
 
@@ -84,3 +86,5 @@
 | X-121 | Per-epic decision files (Epic 68) | 2026-03-15 | Scatters decisions; cross-cutting decisions hard to find; 65+ small files | [Research](../../_bmad-output/planning-artifacts/board-redesign-research.md) |
 | X-122 | Aggressive archival — delete entries older than 90 days (Epic 68) | 2026-03-15 | Git history is worst way to find past decisions; archive preserves searchability | [Research](../../_bmad-output/planning-artifacts/board-redesign-research.md) |
 | X-123 | Three-tier system: Active + Reference + Archive (Epic 68) | 2026-03-15 | "Still relevant" distinction is subjective; reference tier would re-bloat | [Research](../../_bmad-output/planning-artifacts/board-redesign-research.md) |
+| X-124 | PR-shepherd applies PR labels (Epic 72) | 2026-03-18 | Blurs pr-shepherd's focused "branch health" role | [Party Mode](../../_bmad-output/planning-artifacts/label-operationalization-party-mode.md) |
+| X-125 | Dedicated label-enforcement agent (Epic 72) | 2026-03-18 | Over-engineering; 5-10 lines in existing agents suffice | [Party Mode](../../_bmad-output/planning-artifacts/label-operationalization-party-mode.md) |

--- a/docs/decisions/EPIC_REGISTRY.md
+++ b/docs/decisions/EPIC_REGISTRY.md
@@ -32,7 +32,15 @@
 | 62 | Retrospector Agent Reliability | 2026-03-12 | Not Started (0/3) |
 | 63 | ClickUp Integration | 2026-03-13 | Not Started (0/4) |
 | 64 | Cross-Computer Sync | 2026-03-13 | Not Started (0/6) |
-| 65 | *(next available)* | — | — |
+| 65 | CLI Test Coverage Hardening | 2026-03-13 | Complete (3/3) |
+| 66 | CLI/TUI Adapter Wiring Parity | 2026-03-13 | Complete (3/3) |
+| 67 | Retrospector Operational Data Pipeline | 2026-03-13 | Complete (1/1) |
+| 68 | BOARD.md Redesign | 2026-03-15 | Complete (3/3) |
+| 69 | TUI MainModel Decomposition | 2026-03-15 | Complete (4/4) |
+| 70 | Completion History & Progress View | 2026-03-15 | Complete (3/3) |
+| 71 | Drop Apple Intel (darwin/amd64) Builds | 2026-03-18 | Not Started (0/3) |
+| 72 | Operationalize GitHub Label Usage | 2026-03-18 | Not Started (0/4) |
+| 73 | *(next available)* | — | — |
 
 **Rules:**
 1. Before creating a new epic, check this table for the next available number

--- a/docs/prd/epic-details.md
+++ b/docs/prd/epic-details.md
@@ -2956,3 +2956,70 @@ Follows the standard 4-story integration pattern: 63.1 (REST API v2 client with 
 4. Stats summary included in output
 
 ---
+
+## Epic 72: Operationalize GitHub Label Usage
+
+**Epic Goal:** Wire GitHub label application into agent workflows so that PRs are routinely labeled, issue labeling is resilient to envoy downtime, and mutual exclusivity is enforced. Closes the gap between label infrastructure (27-label taxonomy, authority matrix) and actual label usage (zero PR labels, inconsistent issue labels).
+
+**Scope:** Agent definition text changes (`agents/merge-queue.md`, `agents/envoy.md`), operational doc updates (`docs/operations/label-authority.md`), supervisor memory updates, one GitHub API label creation, and one-time retroactive cleanup of existing issues.
+
+**Status:** Not Started (0/4 stories)
+
+**Reference:** PR #806 (gap analysis), D-184, D-185
+
+---
+
+### Story 72.1: Merge-Queue PR Labeling
+
+**As a** project maintainer,
+**I want** the merge-queue agent to automatically apply type, scope, and agent labels to PRs during merge validation,
+**so that** all merged PRs are consistently classified for filtering and dashboard queries.
+
+**Acceptance Criteria:**
+1. PR labeling section added to `agents/merge-queue.md` with title-prefix inference mapping
+2. `scope.in-scope` applied for PRs referencing stories
+3. `agent.worker` applied for PRs from `work/*` branches
+4. Label authority matrix updated for merge-queue
+5. Merge-queue Labels table updated with new entries
+
+---
+
+### Story 72.2: Envoy Label Resilience
+
+**As a** project maintainer,
+**I want** the envoy agent to catch up on missed labels after restart, warn about context exhaustion, and enforce label mutual exclusivity,
+**so that** issue labeling is reliable regardless of envoy downtime.
+
+**Acceptance Criteria:**
+1. Startup catch-up scan added to envoy "Your rhythm" section
+2. Context Exhaustion Risk section added (matching merge-queue/pr-shepherd format)
+3. Mutual exclusivity enforcement instructions added
+
+---
+
+### Story 72.3: Supervisor Label Discipline & Missing Label Creation
+
+**As a** project maintainer,
+**I want** the supervisor to apply labels on dispatch/scope/closure and the missing `resolution.wontfix` label to be created,
+**so that** the full 27-label taxonomy is operational.
+
+**Acceptance Criteria:**
+1. Supervisor label discipline documented (agent.worker on dispatch, scope.* on decisions, resolution.* on closure)
+2. `resolution.wontfix` label created on GitHub with correct color and description
+3. Label authority summary table updated
+
+---
+
+### Story 72.4: Retroactive Label Cleanup
+
+**As a** project maintainer,
+**I want** all currently unlabeled open issues to receive appropriate labels and mutual exclusivity violations fixed,
+**so that** the GitHub issue dashboard is clean and accurate.
+
+**Acceptance Criteria:**
+1. All open issues have at minimum `triage.*` and `type.*` labels
+2. Issue #330 mutual exclusivity violation fixed (remove `triage.in-progress`)
+3. Issue #296 mutual exclusivity violation fixed (remove `type.bug`)
+4. No remaining mutual exclusivity violations across open issues
+
+---

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -899,6 +899,18 @@ lastUpdated: '2026-03-15'
 - **Stories:** 71.1-71.3 (3 stories)
 - **Reference:** Issue #803
 
+**Epic 72: Operationalize GitHub Label Usage** NOT STARTED
+- **Goal:** Wire GitHub label application into agent workflows so PRs are routinely labeled, issue labeling is resilient to envoy downtime, and mutual exclusivity is enforced
+- **Prerequisites:** None
+- **Status:** Not Started (0/4 stories)
+- **Deliverables:**
+  - Add routine PR labeling to merge-queue agent definition (title-prefix inference)
+  - Add startup catch-up, context exhaustion warning, and mutual exclusivity enforcement to envoy
+  - Add supervisor label discipline instructions
+  - Create missing `resolution.wontfix` label and retroactive cleanup of unlabeled/mislabeled issues
+- **Stories:** 72.1-72.4 (4 stories)
+- **Reference:** PR #806 (gap analysis)
+
 **Epic 67+: Advanced Features** (Voice interface, web interface, Apple Watch, iPad, trading mechanic, gamification)
 
 **Guiding Principle:** Each epic must deliver tangible user value and be informed by real usage patterns from previous phases. No speculation-driven development.
@@ -982,5 +994,6 @@ lastUpdated: '2026-03-15'
 | Epic 70: Completion History & Progress View | 3 | Complete (3/3 done) |
 | Epic 68: BOARD.md Redesign | 3 | Complete (3/3 done) |
 | Epic 71: Drop Apple Intel Builds | 3 | Not Started (0/3) |
-| **Total** | **356** | **Audit 2026-03-18: see epics-and-stories.md for authoritative status** |
+| Epic 72: Operationalize GitHub Label Usage | 4 | Not Started (0/4) |
+| **Total** | **360** | **Audit 2026-03-18: see epics-and-stories.md for authoritative status** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -6682,3 +6682,68 @@ So that users and agents have accurate information about supported platforms.
 - **AC4:** Test table entries in `codesign_test.go` and `pkg_builder_test.go` remove amd64 cases
 - **AC5:** `agents/release-manager.md` updated to remove darwin-amd64 from cross-compile list
 - **AC6:** All checks pass (`just fmt`, `just lint`, `just test`)
+
+## Epic 72: Operationalize GitHub Label Usage (P1)
+
+**Goal:** Wire GitHub label application into agent workflows so that PRs are routinely labeled, issue labeling is resilient to envoy downtime, and mutual exclusivity is enforced. Closes the gap between label infrastructure (27-label taxonomy, authority matrix) and actual label usage.
+
+**Priority:** P1
+**Prerequisites:** None
+**Status:** Not Started (0/4 stories)
+**Reference:** PR #806 (gap analysis), D-184, D-185
+
+### Story 72.1: Merge-Queue PR Labeling
+
+As a project maintainer,
+I want the merge-queue agent to automatically apply type, scope, and agent labels to PRs during merge validation,
+So that all merged PRs are consistently classified for filtering and dashboard queries.
+
+**Status:** Not Started | **Priority:** P1
+
+**Acceptance Criteria:**
+- **AC1:** PR labeling section added to `agents/merge-queue.md` with title-prefix inference mapping (`feat:` → `type.feature`, `fix:` → `type.bug`, `docs:` → `type.docs`, `chore:`/`refactor:`/`ci:`/`test:` → `type.infra`)
+- **AC2:** Instructions specify applying `scope.in-scope` for PRs referencing stories
+- **AC3:** Instructions specify applying `agent.worker` for PRs from `work/*` branches
+- **AC4:** Label authority matrix updated for merge-queue PR labeling capabilities
+- **AC5:** Merge-queue Labels table updated with new entries
+
+### Story 72.2: Envoy Label Resilience
+
+As a project maintainer,
+I want the envoy agent to catch up on missed labels after restart, warn about context exhaustion, and enforce label mutual exclusivity,
+So that issue labeling is reliable regardless of envoy downtime.
+
+**Status:** Not Started | **Priority:** P1
+
+**Acceptance Criteria:**
+- **AC1:** Startup catch-up scan added to envoy "Your rhythm" section — scan open issues for missing labels, apply `triage.new` + `type.*`
+- **AC2:** Context Exhaustion Risk section added matching merge-queue/pr-shepherd format
+- **AC3:** Mutual exclusivity enforcement instructions added — remove old label before applying new in exclusive scopes
+
+### Story 72.3: Supervisor Label Discipline & Missing Label Creation
+
+As a project maintainer,
+I want the supervisor to apply labels on dispatch/scope/closure and the missing resolution.wontfix label to be created,
+So that the full 27-label taxonomy is operational.
+
+**Status:** Not Started | **Priority:** P1
+
+**Acceptance Criteria:**
+- **AC1:** Supervisor label discipline documented (agent.worker on dispatch, scope.* on decisions, resolution.* on closure)
+- **AC2:** `resolution.wontfix` label created on GitHub with color `cfd3d7` and description "Will not be addressed — see comment for reason"
+- **AC3:** Label authority summary table updated for supervisor capabilities
+
+### Story 72.4: Retroactive Label Cleanup
+
+As a project maintainer,
+I want all currently unlabeled open issues to receive appropriate labels and mutual exclusivity violations fixed,
+So that the GitHub issue dashboard is clean and accurate.
+
+**Status:** Not Started | **Priority:** P2
+**Depends On:** 72.3
+
+**Acceptance Criteria:**
+- **AC1:** All open issues have at minimum `triage.*` and `type.*` labels
+- **AC2:** Issue #330 mutual exclusivity violation fixed (remove `triage.in-progress`)
+- **AC3:** Issue #296 mutual exclusivity violation fixed (remove `type.bug`)
+- **AC4:** No remaining mutual exclusivity violations across open issues

--- a/docs/prd/product-scope.md
+++ b/docs/prd/product-scope.md
@@ -255,6 +255,7 @@ lastUpdated: '2026-03-06'
 - README Overhaul: badges, table of contents, foldable sections, feature audit, visual demo
 - GitHub Pages User Guide: MkDocs + Material, CI deployment, guides for all features and integrations
 - BOARD.md Redesign: split into active dashboard + decision archive, extract Epic Number Registry, fix duplicate IDs
+- GitHub Label Operationalization: wire label application into agent workflows (merge-queue PR labeling, envoy startup catch-up, supervisor label discipline, mutual exclusivity enforcement)
 
 **Out of Scope for Phase 6:**
 - Tech Writer persistent agent

--- a/docs/prd/requirements.md
+++ b/docs/prd/requirements.md
@@ -1231,3 +1231,21 @@ These non-functional requirements establish code quality gates that all contribu
 **NFR24:** A parity test shall verify at build time that the set of adapter names in `registerBuiltinAdapters()`, CLI `knownProviderSpecs`, CLI `ValidArgs`, and TUI `DefaultProviderSpecs()` are identical. Drift between these lists shall cause test failure.
 
 ---
+
+## GitHub Label Operationalization (Epic 72, Accepted)
+
+> Requirements for consistent, automated GitHub label application across agent workflows.
+
+**FR-GOV1:** The merge-queue agent shall apply appropriate `type.*` labels to PRs during merge validation by inferring type from the PR title prefix (`feat:` → `type.feature`, `fix:` → `type.bug`, `docs:` → `type.docs`, `chore:`/`refactor:` → `type.infra`). If no prefix matches, no type label shall be applied.
+
+**FR-GOV2:** The merge-queue agent shall apply `scope.in-scope` to PRs whose title references a story (e.g., "Story X.Y") and `agent.worker` to PRs from `work/*` branches.
+
+**FR-GOV3:** The envoy agent shall apply `triage.new` and `type.*` labels to issues on detection during the triage lifecycle, maintaining label state transitions as documented in the label authority matrix.
+
+**FR-GOV4:** Agents shall enforce mutual exclusivity for scoped labels (`type.*`, `priority.*`, `triage.*`, `scope.*`, `resolution.*`) by removing the existing label in the scope before applying a new one.
+
+**NFR-GOV1:** On startup or restart, the envoy agent shall scan all open issues for missing labels and apply `triage.new` + `type.*` to any unlabeled issue, ensuring issues created during agent downtime are retroactively labeled within one polling cycle.
+
+**NFR-GOV2:** All 27 labels defined in the scoped label taxonomy (D-107) shall exist on GitHub, including `resolution.wontfix`.
+
+---

--- a/docs/stories/72.1.story.md
+++ b/docs/stories/72.1.story.md
@@ -1,0 +1,82 @@
+# Story 72.1: Merge-Queue PR Labeling
+
+## Status: Not Started
+
+## Epic
+
+Epic 72: Operationalize GitHub Label Usage
+
+## References
+
+- Gap analysis: `_bmad-output/planning-artifacts/label-usage-gap-analysis.md` (PR #806)
+- Party mode: `_bmad-output/planning-artifacts/label-operationalization-party-mode.md`
+- Label authority: `docs/operations/label-authority.md`
+- Agent definition: `agents/merge-queue.md`
+- Decisions: D-184
+
+## Story
+
+As a project maintainer,
+I want the merge-queue agent to automatically apply type, scope, and agent labels to PRs during merge validation,
+So that all merged PRs are consistently classified for filtering and dashboard queries.
+
+## Background
+
+Zero PRs have ever had labels applied (confirmed across 800+ merged PRs). No agent was assigned routine PR labeling — only exceptional labels (`status.needs-human`, `scope.out-of-scope`, `broke-main`) were wired into agent workflows. The merge-queue is the natural owner because it already validates PR metadata before merging.
+
+## Acceptance Criteria
+
+**AC1: PR labeling section added to merge-queue agent definition**
+**Given** `agents/merge-queue.md` contains the Merge Validation Checklist
+**When** a "PR Labeling" section is added after the checklist
+**Then** the section includes rules for inferring `type.*` from PR title prefix:
+  - `feat:` → `type.feature`
+  - `fix:` → `type.bug`
+  - `docs:` → `type.docs`
+  - `chore:` / `refactor:` / `ci:` / `test:` → `type.infra`
+  - No match → skip type label (missing is better than wrong)
+
+**AC2: Scope label inference for story PRs**
+**Given** a PR title references a story (e.g., contains "Story X.Y")
+**When** the merge-queue processes the PR
+**Then** the instructions specify applying `scope.in-scope`
+
+**AC3: Agent label for worker PRs**
+**Given** a PR branch starts with `work/`
+**When** the merge-queue processes the PR
+**Then** the instructions specify applying `agent.worker`
+
+**AC4: Label authority matrix updated**
+**Given** `docs/operations/label-authority.md` shows merge-queue cannot set/remove labels
+**When** the authority matrix is updated
+**Then** merge-queue is listed as able to set `type.*`, `scope.in-scope`, and `agent.worker` on PRs
+
+**AC5: Labels section in merge-queue.md updated**
+**Given** merge-queue.md has a Labels reference table
+**When** `type.*`, `scope.in-scope`, and `agent.worker` are added
+**Then** each entry includes its meaning and when it is applied
+
+## Tasks
+
+### Task 1: Add PR Labeling section to `agents/merge-queue.md`
+Add after the Merge Validation Checklist section. Include the title-prefix mapping, scope inference, and agent label rules. Include the `gh pr edit <number> --add-label <label>` command format.
+
+### Task 2: Update merge-queue Labels table
+Add `type.*` (5 labels), `scope.in-scope`, and `agent.worker` entries.
+
+### Task 3: Update `docs/operations/label-authority.md`
+Change merge-queue row from "— | —" to list the new label capabilities for PR labeling.
+
+### Task 4: Update merge-queue Authority table
+Add "Apply type/scope/agent labels to PRs" to the CAN column.
+
+## Dev Notes
+
+- This is a text-only change to agent definition and operational docs — no application code
+- The merge-queue agent must be restarted after this change merges for the new instructions to take effect
+- Title prefix mapping matches the commit message format enforced by CLAUDE.md
+
+## Quality Gate
+
+- `just fmt` passes (no Go code changes, but verify markdown formatting)
+- No scope creep beyond merge-queue and label-authority docs

--- a/docs/stories/72.2.story.md
+++ b/docs/stories/72.2.story.md
@@ -1,0 +1,68 @@
+# Story 72.2: Envoy Label Resilience
+
+## Status: Not Started
+
+## Epic
+
+Epic 72: Operationalize GitHub Label Usage
+
+## References
+
+- Gap analysis: `_bmad-output/planning-artifacts/label-usage-gap-analysis.md` (PR #806)
+- Party mode: `_bmad-output/planning-artifacts/label-operationalization-party-mode.md`
+- Label authority: `docs/operations/label-authority.md`
+- Agent definition: `agents/envoy.md`
+- Decisions: D-185
+
+## Story
+
+As a project maintainer,
+I want the envoy agent to catch up on missed labels after restart, warn about context exhaustion, and enforce label mutual exclusivity,
+So that issue labeling is reliable regardless of envoy downtime and label conflicts are prevented.
+
+## Background
+
+Issues created during envoy downtime go permanently unlabeled — no catch-up mechanism exists. Envoy lacks the context exhaustion warning present in merge-queue and pr-shepherd. Existing issues (#330, #296) have mutual exclusivity violations (e.g., both `triage.in-progress` and `triage.complete`).
+
+## Acceptance Criteria
+
+**AC1: Startup catch-up added to envoy agent definition**
+**Given** `agents/envoy.md` has a "Your rhythm" section with startup behavior
+**When** a startup catch-up instruction is added
+**Then** the instruction specifies:
+  - On startup/restart, scan all open issues: `gh issue list --state open --json number,labels`
+  - For issues with zero labels: apply `triage.new` + classify with `type.*`
+  - This catches issues created during previous envoy downtime
+
+**AC2: Context exhaustion warning added**
+**Given** `agents/envoy.md` lacks a context exhaustion risk section
+**When** a Context Exhaustion Risk section is added (matching merge-queue/pr-shepherd format)
+**Then** the section warns about ~12 hours / ~20+ triage cycles and links to persistent-agent-ops.md
+
+**AC3: Mutual exclusivity enforcement added**
+**Given** envoy applies labels in exclusive scopes (type.*, priority.*, triage.*)
+**When** mutual exclusivity enforcement instructions are added
+**Then** the instructions specify: before applying any label in an exclusive scope, explicitly remove existing labels in that scope using `gh issue edit <N> --remove-label <old>` then `--add-label <new>`
+
+## Tasks
+
+### Task 1: Add startup catch-up to `agents/envoy.md`
+Add to the "Your rhythm" section, before step 2 ("Every 10 minutes"). On startup, scan open issues for missing labels and apply `triage.new` + `type.*`.
+
+### Task 2: Add Context Exhaustion Risk section to `agents/envoy.md`
+Add at the bottom, before "What You Do NOT Do". Follow the same format as merge-queue.md and pr-shepherd.md.
+
+### Task 3: Add mutual exclusivity enforcement
+Add a "Label Mutual Exclusivity" subsection in the screening section (Screen 2.3) or as a standalone section. Specify that agents must remove old labels before applying new ones in exclusive scopes: `type.*`, `priority.*`, `triage.*`, `scope.*`, `resolution.*`.
+
+## Dev Notes
+
+- Text-only changes to `agents/envoy.md` — no application code
+- Envoy agent must be restarted after this change merges
+- The catch-up scan should be lightweight — just `gh issue list` with JSON output, filter in the agent's reasoning
+- Mutual exclusivity enforcement aligns with `docs/operations/label-authority.md` Section "Convention Enforcement Protocol"
+
+## Quality Gate
+
+- No scope creep beyond envoy.md
+- Instructions are consistent with label-authority.md

--- a/docs/stories/72.3.story.md
+++ b/docs/stories/72.3.story.md
@@ -1,0 +1,69 @@
+# Story 72.3: Supervisor Label Discipline & Missing Label Creation
+
+## Status: Not Started
+
+## Epic
+
+Epic 72: Operationalize GitHub Label Usage
+
+## References
+
+- Gap analysis: `_bmad-output/planning-artifacts/label-usage-gap-analysis.md` (PR #806)
+- Party mode: `_bmad-output/planning-artifacts/label-operationalization-party-mode.md`
+- Label authority: `docs/operations/label-authority.md`
+
+## Story
+
+As a project maintainer,
+I want the supervisor to apply labels when dispatching workers and making scope/resolution decisions, and the missing `resolution.wontfix` label to exist on GitHub,
+So that the full label taxonomy is operational and supervisor actions are reflected in issue metadata.
+
+## Background
+
+The supervisor never applies `agent.worker` when dispatching workers, never applies `scope.*` on scope decisions, and never applies `resolution.*` on closure. The `resolution.wontfix` label is in the 27-label taxonomy but was never created on GitHub — merge-queue's documented behavior of labeling superseded PRs with `resolution.wontfix` silently fails.
+
+## Acceptance Criteria
+
+**AC1: Supervisor label discipline documented**
+**Given** the supervisor's operational instructions (CLAUDE.md or supervisor memory)
+**When** label discipline instructions are added
+**Then** the instructions specify:
+  - Apply `agent.worker` to the issue when dispatching a worker
+  - Apply `scope.in-scope` or `scope.out-of-scope` when making scope decisions
+  - Apply appropriate `resolution.*` label when confirming issue closure
+
+**AC2: `resolution.wontfix` label created on GitHub**
+**Given** the 27-label taxonomy includes `resolution.wontfix`
+**When** the label is created via GitHub API
+**Then** the label exists with color `cfd3d7` and description "Will not be addressed — see comment for reason"
+**And** the label count on GitHub matches the full 27-label taxonomy (+ `dependencies`)
+
+**AC3: Label-authority.md summary table updated**
+**Given** the Summary table shows "Merge-queue: — | —" and supervisor entries
+**When** the table is updated
+**Then** supervisor row includes `agent.worker` in "Can Set" and `resolution.*` in "Can Remove"
+
+## Tasks
+
+### Task 1: Add label discipline to supervisor memory
+Add to supervisor memory file or CLAUDE.md operational notes. Include the three label application rules.
+
+### Task 2: Create `resolution.wontfix` on GitHub
+Run: `gh label create "resolution.wontfix" --color cfd3d7 --description "Will not be addressed — see comment for reason"`
+
+### Task 3: Verify label count
+Run `gh label list` and confirm all 27 taxonomy labels + `dependencies` exist.
+
+### Task 4: Update label-authority.md if needed
+Ensure the supervisor entry in the Summary table includes `agent.worker` in Can Set.
+
+## Dev Notes
+
+- Task 2 (label creation) is a one-time GitHub API call — not a code change
+- Supervisor memory updates may be in the multiclaude memory system, not in version-controlled files
+- The supervisor will need to be informed of the new discipline rules via messaging
+
+## Quality Gate
+
+- `resolution.wontfix` label exists on GitHub after implementation
+- Label count matches taxonomy

--- a/docs/stories/72.4.story.md
+++ b/docs/stories/72.4.story.md
@@ -1,0 +1,77 @@
+# Story 72.4: Retroactive Label Cleanup
+
+## Status: Not Started
+
+## Epic
+
+Epic 72: Operationalize GitHub Label Usage
+
+## References
+
+- Gap analysis: `_bmad-output/planning-artifacts/label-usage-gap-analysis.md` (PR #806)
+- Party mode: `_bmad-output/planning-artifacts/label-operationalization-party-mode.md`
+
+## Story
+
+As a project maintainer,
+I want all currently unlabeled open issues to receive appropriate labels and existing mutual exclusivity violations to be fixed,
+So that the GitHub issue dashboard provides a clean, accurate view of issue state.
+
+## Background
+
+Seven open issues (#803, #466, #414, #408, #396, #278, #218) have no labels. Issue #330 has both `triage.in-progress` and `triage.complete` (mutual exclusivity violation). Issue #296 has both `type.bug` and `type.infra` (mutual exclusivity violation). These are artifacts of envoy downtime, pre-migration state, and lack of enforcement.
+
+## Acceptance Criteria
+
+**AC1: All open issues have at minimum `triage.*` and `type.*` labels**
+**Given** open issues exist with no labels
+**When** a retroactive labeling pass is performed
+**Then** each unlabeled open issue receives at minimum `triage.new` (or `triage.complete` if already resolved) and an appropriate `type.*` label
+
+**AC2: Mutual exclusivity violations fixed on issue #330**
+**Given** issue #330 has both `triage.in-progress` and `triage.complete`
+**When** the violation is resolved
+**Then** only `triage.complete` remains (issue is fully triaged)
+
+**AC3: Mutual exclusivity violations fixed on issue #296**
+**Given** issue #296 has both `type.bug` and `type.infra`
+**When** the violation is resolved
+**Then** only `type.infra` remains (the more specific classification per gap analysis)
+
+**AC4: No new mutual exclusivity violations introduced**
+**Given** the cleanup is complete
+**When** all open issues are scanned
+**Then** no issue has more than one label in any mutually exclusive scope
+
+## Tasks
+
+### Task 1: Scan all open issues for label state
+Run `gh issue list --state open --json number,title,labels` and document current state.
+
+### Task 2: Apply labels to unlabeled issues
+For each unlabeled issue, determine appropriate `triage.*` and `type.*` labels based on issue title and body. Apply via `gh issue edit`.
+
+### Task 3: Fix issue #330 — remove duplicate triage label
+Remove `triage.in-progress`: `gh issue edit 330 --remove-label triage.in-progress`
+
+### Task 4: Fix issue #296 — remove duplicate type label
+Remove `type.bug`: `gh issue edit 296 --remove-label type.bug`
+
+### Task 5: Verify no remaining violations
+Scan all labeled issues for mutual exclusivity violations across all exclusive scopes.
+
+## Dev Notes
+
+- This is a one-time cleanup task using GitHub API calls — no code changes, no docs changes
+- The worker should verify each issue is still open before modifying (issues may have been closed since the gap analysis)
+- For unlabeled closed issues: skip them — retroactive labeling of closed issues adds noise without value
+- Depends on Story 72.3 (resolution.wontfix must exist before it can be applied)
+
+## Dependencies
+
+- Story 72.3 (resolution.wontfix label must exist on GitHub)
+
+## Quality Gate
+
+- All open issues have at least one `triage.*` and one `type.*` label
+- No mutual exclusivity violations remain


### PR DESCRIPTION
## Summary

- Plan Epic 72: Operationalize GitHub Label Usage across agents, based on the label usage gap analysis (PR #806)
- Creates 4 stories (72.1-72.4) covering merge-queue PR labeling, envoy label resilience, supervisor label discipline, and retroactive cleanup
- Updates all PRD content docs (requirements, product-scope, epic-details) and index docs (epic-list, epics-and-stories, ROADMAP)
- Records decisions D-184, D-185 and rejections X-124, X-125 in BOARD.md
- Updates EPIC_REGISTRY.md with epics 65-72 (backfills + new)

## Key Changes

**Agent definition changes (to be implemented in stories):**
- **Story 72.1:** Add routine PR labeling to merge-queue — infer `type.*` from title prefix, apply `scope.in-scope` for story PRs, apply `agent.worker` for `work/*` branches
- **Story 72.2:** Add envoy startup catch-up (scan unlabeled issues), context exhaustion warning, mutual exclusivity enforcement
- **Story 72.3:** Add supervisor label discipline + create missing `resolution.wontfix` label
- **Story 72.4:** One-time retroactive cleanup of unlabeled/mislabeled issues

**Root cause (from gap analysis):** Zero PRs have ever been labeled. Issue labeling is inconsistent during envoy downtime. Labels were designed but never wired into agent workflows.

## Artifacts Created

- Sprint change proposal: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-03-18-label-operationalization.md`
- Party mode artifact: `_bmad-output/planning-artifacts/label-operationalization-party-mode.md`
- Story files: `docs/stories/72.{1-4}.story.md`

## PRD Completeness

- [x] `docs/prd/requirements.md` — FR-GOV1 through FR-GOV4, NFR-GOV1, NFR-GOV2
- [x] `docs/prd/product-scope.md` — Phase 6 updated
- [x] `docs/prd/epic-details.md` — Epic 72 with 4 stories
- [x] `docs/prd/epics-and-stories.md` — Full story ACs
- [x] `docs/prd/epic-list.md` — Epic 72 entry
- [x] `ROADMAP.md` — Epic 72 with dependency graph
- [x] `docs/decisions/BOARD.md` — D-184, D-185, X-124, X-125
- [x] `docs/decisions/EPIC_REGISTRY.md` — Backfilled 65-71, added 72

## Test plan

- [ ] Verify all PRD docs are internally consistent
- [ ] Verify story files have correct format and status (Not Started)
- [ ] Verify BOARD.md decisions reference correct artifacts
- [ ] Verify EPIC_REGISTRY.md shows next available as 73