### PR TITLE
docs: governance sync — Story 71.3 Done (Epic 71 2/3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -623,7 +623,7 @@ Split BOARD.md into a focused active dashboard (<120 lines) and a complete decis
 
 **Dependency graph:** Linear chain: 68.1 → 68.2 → 68.3.
 
-### Epic 71: Drop Apple Intel (darwin/amd64) Builds (P1) — 1/3 stories done — IN PROGRESS
+### Epic 71: Drop Apple Intel (darwin/amd64) Builds (P1) — 2/3 stories done — IN PROGRESS
 
 Remove darwin/amd64 build targets from CI workflows, release builds, Homebrew formula, and installer/packaging to save CI runner minutes and focus on Apple Silicon (darwin/arm64). Reference: Issue #803.
 
@@ -631,7 +631,7 @@ Remove darwin/amd64 build targets from CI workflows, release builds, Homebrew fo
 |-------|-------|--------|----------|------------|
 | 71.1 | Remove darwin/amd64 from CI Build and Alpha Release Pipeline | Done (PR #810) | P1 | None |
 | 71.2 | Remove darwin/amd64 from Stable Release Workflow | Not Started | P1 | 71.1 |
-| 71.3 | Update Docs, Tests, and Agent Definitions for Intel Removal | Not Started | P1 | 71.1, 71.2 |
+| 71.3 | Update Docs, Tests, and Agent Definitions for Intel Removal | Done (PR #817) | P1 | 71.1, 71.2 |
 
 **Dependency graph:** Linear chain: 71.1 → 71.2 → 71.3. Story 71.1 is the foundation (CI + GoReleaser). Story 71.2 handles the tag-triggered release workflow. Story 71.3 cleans up docs and tests.
 

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -891,7 +891,7 @@ lastUpdated: '2026-03-15'
 **Epic 71: Drop Apple Intel (darwin/amd64) Builds** IN PROGRESS
 - **Goal:** Remove darwin/amd64 build targets from CI workflows, release builds, Homebrew formula, and all installer/packaging to save CI runner minutes and focus on Apple Silicon
 - **Prerequisites:** None
-- **Status:** In Progress (1/3 stories done)
+- **Status:** In Progress (2/3 stories done)
 - **Deliverables:**
   - Remove darwin/amd64 from GoReleaser config, justfile, CI workflow builds/signing/notarization
   - Remove darwin/amd64 from stable release workflow signing and packaging
@@ -993,7 +993,7 @@ lastUpdated: '2026-03-15'
 | Epic 69: TUI MainModel Decomposition | 4 | Complete (4/4 done) |
 | Epic 70: Completion History & Progress View | 3 | Complete (3/3 done) |
 | Epic 68: BOARD.md Redesign | 3 | Complete (3/3 done) |
-| Epic 71: Drop Apple Intel Builds | 3 | In Progress (1/3 done) |
+| Epic 71: Drop Apple Intel Builds | 3 | In Progress (2/3 done) |
 | Epic 72: Operationalize GitHub Label Usage | 4 | Complete (4/4 done) |
 | **Total** | **360** | **Audit 2026-03-18: see epics-and-stories.md for authoritative status** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -6632,7 +6632,7 @@ So that the board guide, sweep process, and agent behaviors are consistent with 
 
 **Priority:** P1
 **Prerequisites:** None
-**Status:** In Progress (1/3 stories done)
+**Status:** In Progress (2/3 stories done)
 **Reference:** Issue #803
 
 ### Story 71.1: Remove darwin/amd64 from CI Build and Alpha Release Pipeline
@@ -6672,7 +6672,7 @@ As a project maintainer,
 I want documentation, tests, and agent definitions to reflect that darwin/amd64 is no longer built,
 So that users and agents have accurate information about supported platforms.
 
-**Status:** Not Started | **Priority:** P1
+**Status:** Done (PR #817) | **Priority:** P1
 **Depends On:** 71.1, 71.2
 
 **Acceptance Criteria:**


### PR DESCRIPTION
## Summary
- Story 71.3 (Update Docs, Tests, Agent Definitions for Intel Removal) → Done (PR #817)
- Epic 71 progress: 1/3 → 2/3 IN PROGRESS
- Updated ROADMAP.md, epics-and-stories.md, epic-list.md

## Note
PR #815 (Story 71.2) still open — once merged, Epic 71 will be COMPLETE (3/3).