### PR TITLE
docs: governance sync — Epic 71 COMPLETE (3/3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -623,14 +623,14 @@ Split BOARD.md into a focused active dashboard (<120 lines) and a complete decis
 
 **Dependency graph:** Linear chain: 68.1 → 68.2 → 68.3.
 
-### Epic 71: Drop Apple Intel (darwin/amd64) Builds (P1) — 2/3 stories done — IN PROGRESS
+### Epic 71: Drop Apple Intel (darwin/amd64) Builds (P1) — 3/3 stories done — COMPLETE
 
 Remove darwin/amd64 build targets from CI workflows, release builds, Homebrew formula, and installer/packaging to save CI runner minutes and focus on Apple Silicon (darwin/arm64). Reference: Issue #803.
 
 | Story | Title | Status | Priority | Depends On |
 |-------|-------|--------|----------|------------|
 | 71.1 | Remove darwin/amd64 from CI Build and Alpha Release Pipeline | Done (PR #810) | P1 | None |
-| 71.2 | Remove darwin/amd64 from Stable Release Workflow | Not Started | P1 | 71.1 |
+| 71.2 | Remove darwin/amd64 from Stable Release Workflow | Done (PR #815) | P1 | 71.1 |
 | 71.3 | Update Docs, Tests, and Agent Definitions for Intel Removal | Done (PR #817) | P1 | 71.1, 71.2 |
 
 **Dependency graph:** Linear chain: 71.1 → 71.2 → 71.3. Story 71.1 is the foundation (CI + GoReleaser). Story 71.2 handles the tag-triggered release workflow. Story 71.3 cleans up docs and tests.

--- a/docs/prd/epic-list.md
+++ b/docs/prd/epic-list.md
@@ -888,10 +888,10 @@ lastUpdated: '2026-03-15'
 - **Stories:** 68.1-68.3 (3 stories)
 - **Research:** See `_bmad-output/planning-artifacts/board-redesign-research.md` (PR #762)
 
-**Epic 71: Drop Apple Intel (darwin/amd64) Builds** IN PROGRESS
+**Epic 71: Drop Apple Intel (darwin/amd64) Builds** COMPLETE
 - **Goal:** Remove darwin/amd64 build targets from CI workflows, release builds, Homebrew formula, and all installer/packaging to save CI runner minutes and focus on Apple Silicon
 - **Prerequisites:** None
-- **Status:** In Progress (2/3 stories done)
+- **Status:** Complete (3/3 stories done)
 - **Deliverables:**
   - Remove darwin/amd64 from GoReleaser config, justfile, CI workflow builds/signing/notarization
   - Remove darwin/amd64 from stable release workflow signing and packaging
@@ -993,7 +993,7 @@ lastUpdated: '2026-03-15'
 | Epic 69: TUI MainModel Decomposition | 4 | Complete (4/4 done) |
 | Epic 70: Completion History & Progress View | 3 | Complete (3/3 done) |
 | Epic 68: BOARD.md Redesign | 3 | Complete (3/3 done) |
-| Epic 71: Drop Apple Intel Builds | 3 | In Progress (2/3 done) |
+| Epic 71: Drop Apple Intel Builds | 3 | Complete (3/3 done) |
 | Epic 72: Operationalize GitHub Label Usage | 4 | Complete (4/4 done) |
 | **Total** | **360** | **Audit 2026-03-18: see epics-and-stories.md for authoritative status** |
 ---

--- a/docs/prd/epics-and-stories.md
+++ b/docs/prd/epics-and-stories.md
@@ -14,7 +14,7 @@ regeneratedFrom: "PRD v2.0 + Architecture v2.0 (post-party-mode-recommendations)
 
 This document provides the complete epic and story breakdown for ThreeDoors, decomposing the requirements from the PRD v2.0, UX Design, and Architecture v2.0 into implementable stories. This is a regeneration reflecting the 9 party mode recommendations integrated into the PRD and architecture.
 
-**Implementation Status:** Epics 0-15, 3.5, 17-32, 34-51, 53-70 are COMPLETE. Epic 5 reopened (2/2, Story 5.3 done). Epic 16 is ICEBOX. Epic 68 COMPLETE (3/3 done). Epic 71 IN PROGRESS (1/3 done). Epic 72 COMPLETE (4/4 done). 810+ merged PRs total. Last audit: 2026-03-19.
+**Implementation Status:** Epics 0-15, 3.5, 17-32, 34-51, 53-70 are COMPLETE. Epic 5 reopened (2/2, Story 5.3 done). Epic 16 is ICEBOX. Epic 68 COMPLETE (3/3 done). Epic 71 COMPLETE (3/3 done). Epic 72 COMPLETE (4/4 done). 810+ merged PRs total. Last audit: 2026-03-19.
 
 ## Requirements Inventory
 
@@ -6657,7 +6657,7 @@ As a project maintainer,
 I want to remove darwin/amd64 from the stable release signing and packaging pipeline,
 So that tagged releases no longer produce Intel Mac artifacts and macOS runner time is halved.
 
-**Status:** Not Started | **Priority:** P1
+**Status:** Done (PR #815) | **Priority:** P1
 **Depends On:** 71.1
 
 **Acceptance Criteria:**


### PR DESCRIPTION
## Summary

- Mark Story 71.2 as Done (PR #815) in all three planning docs
- Update Epic 71 header to COMPLETE (3/3) across ROADMAP.md, epics-and-stories.md, and epic-list.md

## Files Changed

- `ROADMAP.md` — Story 71.2 status + epic header
- `docs/prd/epics-and-stories.md` — Story 71.2 status + implementation status line
- `docs/prd/epic-list.md` — Epic 71 status in summary and table

## Governance

PR #815 (Story 71.2) was the last remaining story in Epic 71. Stories 71.1 (PR #810) and 71.3 (PR #817) were already marked Done in prior governance sync PR #820.