### PR TITLE
fix: CODEOWNERS security — replace @skippy with @arcaven

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,28 +1,28 @@
 # CODEOWNERS — ThreeDoors Golden Repo
 # Gate files that control project direction, AI behavior, and infrastructure.
-# Files WITH entries here require @skippy approval to merge.
+# Files WITH entries here require @arcaven approval to merge.
 # Files WITHOUT entries can merge with CI-only gates (0 required approvals).
 #
 # Syntax: later rules override earlier ones for the same path.
 # Reference: https://docs.github.com/articles/about-code-owners
 
 # Project philosophy
-SOUL.md                         @skippy
+SOUL.md                         @arcaven
 
 # Agent instructions and rules
-CLAUDE.md                       @skippy
-/.claude/                       @skippy
+CLAUDE.md                       @arcaven
+/.claude/                       @arcaven
 
 # Scope control — planning docs
-ROADMAP.md                      @skippy
-/docs/prd/epic-list.md          @skippy
-/docs/prd/epics-and-stories.md  @skippy
+ROADMAP.md                      @arcaven
+/docs/prd/epic-list.md          @arcaven
+/docs/prd/epics-and-stories.md  @arcaven
 
 # Architectural decisions
-/docs/decisions/BOARD.md        @skippy
+/docs/decisions/BOARD.md        @arcaven
 
 # CI/CD and infrastructure (includes this file)
-/.github/                       @skippy
+/.github/                       @arcaven
 
 # Agent behavior definitions
-/agents/                        @skippy
+/agents/                        @arcaven


### PR DESCRIPTION
## Summary

- Replaces all `@skippy` references in `.github/CODEOWNERS` with `@arcaven`
- **Security fix**: `@skippy` is the GitHub identity AI agents push as, meaning agents could satisfy their own CODEOWNERS review requirements — defeating the governance gate entirely
- `@arcaven` is the actual human project owner who should approve governance changes

## Story

Story 74.1 (follow-up security fix)

## Test plan

- [ ] Verify CODEOWNERS parses correctly: `gh api repos/arcavenae/ThreeDoors/codeowners/errors`
- [ ] Verify PRs touching protected files now require @arcaven approval (not @skippy)
- [ ] Confirm merge-queue cannot self-approve PRs touching governance files

## Note

This PR touches `.github/CODEOWNERS` which is itself a protected file — requires human (@arcaven) approval to merge. PR #842 (BOARD.md removal from CODEOWNERS) is separate and can merge independently.