### PR TITLE
Remove CronCreate heartbeats from startup checklist

### DIFF
--- a/docs/stories/73.2.story.md
+++ b/docs/stories/73.2.story.md
@@ -1,6 +1,6 @@
 # Story 73.2: Remove CronCreate Heartbeats from Startup Checklist
 
-## Status: In Progress
+## Status: Deployed — Under Observation
 
 ## Epic
 


### PR DESCRIPTION
## Summary

- Removed 6 CronCreate heartbeat crons from supervisor MEMORY.md startup checklist (Story 73.2 / Q-C-011)
- Daemon wake loop (~2 min cycle) already handles agent nudging — heartbeat crons were redundant and caused double-injection
- SYNC_OPERATIONAL_DATA cron retained (serves different purpose: data freshness)
- Updated feedback memory to reflect heartbeat crons are gone
- Added post-merge validation tasks: shutdown/restart test, multi-day observational testing, retrospector monitoring

## What Changed

| File | Change |
|------|--------|
| `docs/stories/73.2.story.md` | Added Tasks 4-6 (post-merge validation), status → Deployed — Under Observation |
| Supervisor MEMORY.md (outside repo) | Removed 6 heartbeat CronCreate lines, added daemon wake note |
| `feedback_never_delete_crons.md` (outside repo) | Updated to reflect only SYNC_OPERATIONAL_DATA cron remains |

## What NOT Changed

- HEARTBEAT handling in agent definitions (agents still respond to heartbeats from daemon)
- SYNC_OPERATIONAL_DATA cron (retained as-is)
- Daemon wake loop (it's the replacement, already running)

## Test Plan

- [ ] PR merges cleanly
- [ ] After merge: full supervisor + agent restart (Task 4)
- [ ] Multi-day observation: agents responsive with daemon wake only (Task 5)
- [ ] Retrospector monitoring agent responsiveness (Task 6)
- [ ] Story marked Done only after multi-day observation confirms no regression