### PR TITLE
fix: resolve pre-existing ShellCheck warnings in test scripts

### DIFF
--- a/scripts/handover-history.sh
+++ b/scripts/handover-history.sh
@@ -186,6 +186,7 @@ cmd_record() {
     local anomalies_json="[]"
     if [[ -n "$ANOMALIES" ]]; then
         # Convert comma-separated list to JSON array
+        # shellcheck disable=SC2001 # Pattern uses backreference (&) which parameter expansion can't do
         anomalies_json="[$(echo "$ANOMALIES" | sed 's/[^,]*/"&"/g')]"
     fi
 

--- a/scripts/quota-status.sh
+++ b/scripts/quota-status.sh
@@ -31,13 +31,20 @@ PROJECT_DIR=""
 OUTPUT_JSON=false
 USE_COLOR=true
 
-# --- Colors ---
+# --- Colors (used in embedded Python script below) ---
+# shellcheck disable=SC2034
 RED='\033[0;31m'
+# shellcheck disable=SC2034
 ORANGE='\033[0;91m'
+# shellcheck disable=SC2034
 YELLOW='\033[0;33m'
+# shellcheck disable=SC2034
 GREEN='\033[0;32m'
+# shellcheck disable=SC2034
 BOLD='\033[1m'
+# shellcheck disable=SC2034
 DIM='\033[2m'
+# shellcheck disable=SC2034
 RESET='\033[0m'
 
 # --- Argument parsing ---
@@ -75,12 +82,19 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$USE_COLOR" == "false" ]]; then
+    # shellcheck disable=SC2034
     RED=''
+    # shellcheck disable=SC2034
     ORANGE=''
+    # shellcheck disable=SC2034
     YELLOW=''
+    # shellcheck disable=SC2034
     GREEN=''
+    # shellcheck disable=SC2034
     BOLD=''
+    # shellcheck disable=SC2034
     DIM=''
+    # shellcheck disable=SC2034
     RESET=''
 fi
 
@@ -339,8 +353,6 @@ print(json.dumps(data, indent=2))
 fi
 
 # --- Formatted output ---
-TOTAL_TOKENS=$(python3 -c "import json; d=json.loads('$TOKEN_DATA'.replace(\"'\", \"\")); print(d['total_tokens'])" 2>/dev/null || echo "0")
-
 # Use python for all formatting to avoid shell quoting issues with JSON
 python3 << FMTEOF
 import json

--- a/scripts/rollcall.sh
+++ b/scripts/rollcall.sh
@@ -34,7 +34,6 @@ if [[ -z "$REPO" ]]; then
     fi
 fi
 
-SESSION="mc-${REPO}"
 USER_NAME=$(whoami)
 JSONL_DIR="$HOME/.claude/projects/-Users-${USER_NAME}--multiclaude-repos-${REPO}"
 
@@ -42,12 +41,11 @@ JSONL_DIR="$HOME/.claude/projects/-Users-${USER_NAME}--multiclaude-repos-${REPO}
 if [[ -t 1 ]]; then
     RED='\033[0;31m'
     GREEN='\033[0;32m'
-    YELLOW='\033[0;33m'
     BOLD='\033[1m'
     DIM='\033[2m'
     NC='\033[0m'
 else
-    RED='' GREEN='' YELLOW='' BOLD='' DIM='' NC=''
+    RED='' GREEN='' BOLD='' DIM='' NC=''
 fi
 
 # Header

--- a/scripts/shift-clock.sh
+++ b/scripts/shift-clock.sh
@@ -254,7 +254,6 @@ check_natural_seam() {
     local idle_threshold=$((now_epoch - SEAM_IDLE_SECONDS))
 
     # Check for recent multiclaude work commands (tool_use with "multiclaude work" in the content)
-    local recent_work_commands=0
     local last_tool_timestamp
     last_tool_timestamp="$(grep '"tool_use"' "$transcript" | tail -1 | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}' || echo "")"
 

--- a/scripts/sm-sprint-health.sh
+++ b/scripts/sm-sprint-health.sh
@@ -62,7 +62,7 @@ add_to_report ""
 # --- 1. Check for stale PRs (>STALE_HOURS without activity) ---
 add_to_report "## Open PRs"
 
-STALE_CUTOFF="$(date -u -v-${STALE_HOURS}H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "${STALE_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
+STALE_CUTOFF="$(date -u -v-"${STALE_HOURS}"H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "${STALE_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
 
 OPEN_PRS="$(gh pr list --repo "$REPO" --state open --json number,title,updatedAt,author --limit 50 2>/dev/null || echo "[]")"
 PR_COUNT="$(echo "$OPEN_PRS" | jq 'length')"

--- a/scripts/test-cron-scripts.sh
+++ b/scripts/test-cron-scripts.sh
@@ -96,7 +96,9 @@ fi
 
 # Test 9: Update flag creates baseline file
 echo "Test: --update creates baseline file"
-cd "$REPO_ROOT" && BASELINE_FILE="$TMPDIR_TEST/new-baseline.json" "$SCRIPT_DIR/qa-coverage-audit.sh" --update >/dev/null 2>&1 || true
+if cd "$REPO_ROOT"; then
+    BASELINE_FILE="$TMPDIR_TEST/new-baseline.json" "$SCRIPT_DIR/qa-coverage-audit.sh" --update >/dev/null 2>&1 || true
+fi
 if [[ -f "$TMPDIR_TEST/new-baseline.json" ]]; then
     pass "--update creates baseline file"
     # Verify it's valid JSON

--- a/scripts/test-quota-monitor.sh
+++ b/scripts/test-quota-monitor.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$SCRIPT_DIR/quota-monitor.sh"
-QUOTA_SCRIPT="$SCRIPT_DIR/quota-status.sh"
 TESTDATA_DIR="$SCRIPT_DIR/testdata/quota-monitor"
 PASS=0
 FAIL=0

--- a/scripts/test-shift-snapshot.sh
+++ b/scripts/test-shift-snapshot.sh
@@ -163,7 +163,7 @@ create_mock_bins
 # Test 4: Snapshot generation with mocked commands
 echo "Test: generates valid snapshot with mocked commands"
 HANDOVER_TEST_DIR="$TMPDIR_BASE/handover"
-OUTPUT="$(PATH="$MOCK_BIN_DIR:$PATH" "$SCRIPT" --repo TestRepo --handover-dir "$HANDOVER_TEST_DIR" 2>&1)"
+PATH="$MOCK_BIN_DIR:$PATH" "$SCRIPT" --repo TestRepo --handover-dir "$HANDOVER_TEST_DIR" >/dev/null 2>&1
 if [[ -f "$HANDOVER_TEST_DIR/shift-state.yaml" ]]; then
     pass "snapshot file created"
 else

--- a/scripts/test-verify-mcp-bridge.sh
+++ b/scripts/test-verify-mcp-bridge.sh
@@ -87,6 +87,7 @@ MOCK
     echo "$binary"
 }
 
+# shellcheck disable=SC2317,SC2329 # Functions are called below; ShellCheck is confused by exit in heredocs
 run_test() {
     local name="$1"
     local expected_exit="${2:-0}"
@@ -109,6 +110,7 @@ run_test() {
     echo "$output"
 }
 
+# shellcheck disable=SC2317,SC2329
 run_test_grep() {
     local name="$1"
     local pattern="$2"

--- a/scripts/validate-alpha-formula.sh
+++ b/scripts/validate-alpha-formula.sh
@@ -20,7 +20,8 @@ FORMULA=$(sed -n '/cat > threedoors-a.rb <<FORMULA/,/^[[:space:]]*FORMULA$/p' "$
   | sed '/^[[:space:]]*FORMULA$/d' \
   | sed 's/^          //')
 
-# Substitute shell variable interpolations with valid placeholders
+# Substitute Ruby template interpolations (literal ${...}) with valid placeholders
+# shellcheck disable=SC2016 # Single quotes intentional — these are literal template tokens, not shell vars
 FORMULA=$(echo "$FORMULA" \
   | sed 's/${VERSION}/0.1.0-alpha.20260101.abcdef0/g' \
   | sed 's/${BASE_URL}/https:\/\/github.com\/arcavenae\/ThreeDoors\/releases\/download\/alpha-20260101-abcdef0/g' \


### PR DESCRIPTION
## Summary

- Fixes all ShellCheck warnings across `scripts/*.sh` and `scripts/hooks/*.sh` (10 files, 0 warnings remaining)
- SC2015: Replaced `A && B || C` anti-pattern with proper `if/then` in `test-cron-scripts.sh`
- SC2317/SC2329: Added disable directives for false-positive "unreachable function" warnings in `test-verify-mcp-bridge.sh` (ShellCheck confused by `exit` inside heredocs)
- SC2034: Removed truly unused variables (`QUOTA_SCRIPT`, `OUTPUT`, `SESSION`, `YELLOW`, `recent_work_commands`, `TOTAL_TOKENS`); added disable for color vars used in embedded Python
- SC2086: Added missing double-quotes around variable in `sm-sprint-health.sh`
- SC2001/SC2016: Added disable directives for intentional patterns (sed backreference, literal template tokens)

All warnings are pre-existing — none were introduced by PR #892.

## Test plan

- [ ] `shellcheck scripts/*.sh scripts/hooks/*.sh` passes with exit code 0
- [ ] `just test` passes (no behavioral changes from removing unused vars)
- [ ] CI ShellCheck job passes

## Provenance
- **Autonomy Level:** L3 (AI-autonomous)
- **Review:** CI validation