### PR TITLE
docs: update harvest checklist to point at nodes (rof2 sweep)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,8 +331,11 @@ Read charter.md before any substantive work. It contains:
 3. Write an Exploration Brief in _kos/probes/
 4. Do the probe work
 5. Write a finding in _kos/findings/
-6. Harvest: update affected nodes, move files if confidence changed
-7. Update charter.md if bedrock changed
+6. Harvest: update affected NODES (`_kos/nodes/{bedrock,frontier,graveyard}/*.yaml`),
+   move files if confidence changed. Charter is renderer output (per orc F22,
+   `kos charter render`); do NOT hand-edit charter prose outside
+   `<!-- backdrop -->` blocks. Subrepo charter renderer extension tracked
+   in aae-orc-gezz.
 
 Cross-repo questions belong in the orchestrator's _kos/, not here.
 
@@ -352,6 +355,12 @@ Always accompany with a commit message explaining the evidence.
 ### Harvest Verification
 Before starting the next cycle, verify:
 - [ ] Finding written and committed
-- [ ] Charter updated if bedrock changed
+- [ ] Bedrock/frontier/graveyard NODES updated if state changed —
+      edit `_kos/nodes/{bedrock,frontier,graveyard}/*.yaml`, NOT charter
+      prose. Charter is renderer output (per orc F22,
+      `brief-charter-as-projection-renderer.md`, `kos charter render`).
+      Subrepo extension tracked in aae-orc-gezz; until it ships, treat
+      charter sections outside `<!-- backdrop -->` blocks as read-only
+      and edit the underlying nodes.
 - [ ] Frontier questions updated (closed, opened, or revised)
 - [ ] Exploration briefs marked complete or carried forward


### PR DESCRIPTION
## Summary

Updates `CLAUDE.md` Session Protocol and Harvest Verification to point at `_kos/nodes/{bedrock,frontier,graveyard}/*.yaml` instead of instructing hand-edits to charter prose. Mirrors the orc CLAUDE.md update from the `aae-orc-rof2` fleet sweep.

Charter is renderer output (per orc F22 `brief-charter-as-projection-renderer.md`, `kos charter render`). Subrepo charter renderer extension tracked in `aae-orc-gezz`.

This is a CODEOWNERS-protected file (`CLAUDE.md`), so submitted via PR per ThreeDoors' protected-files policy.

## Fleet context

Same-day commits across the rest of the fleet (all default branches):
- forestage develop 2873007 · kos main 9f03bc6 · flyloft main 89aed11
- marvel main 2b11b43 · switchboard develop 23e7e58 · spectacle main ac9d3e4
- tmux-cmc main ba1ace5 · curtain main 64084cd · BetterDials main 555f236

sidestep deferred (concurrent feature work in flight).

## Test plan
- [ ] No code changes — pure docs update
- [ ] Verify wording matches orc CLAUDE.md `Harvest Verification` and `Session Protocol` sections
- [ ] CI green

Refs: aae-orc-rof2